### PR TITLE
MVP: dashboard apply

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,12 @@
+# Copy to .envrc and fill in real values, then run `direnv allow`.
+# .envrc is gitignored — never commit real credentials.
+
+# Personal API key with dashboard:write and insight:write scopes.
+# Create one at <host>/settings/user-api-keys.
+export POSTHOG_PERSONAL_API_KEY=phx_replace_me
+
+# Numeric project ID to sync into. Use a dev project for testing.
+export POSTHOG_PROJECT_ID=000000
+
+# Defaults to https://us.posthog.com. Override for EU or self-hosted.
+# export POSTHOG_HOST=https://eu.posthog.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Direnv — local credentials, never committed
+.envrc
+.direnv/
+
+# Dotenv variants
+.env
+.env.local
+.env.*.local
+
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Build output
+dist/
+*.tsbuildinfo
+
+# Editor / OS
+.DS_Store
+.vscode/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist/
 .DS_Store
 .vscode/
 .idea/
+
+# Claude Code per-project state
+.claude/

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,3 +51,15 @@ docs/
 ## Current status
 
 Pre-MVP. The MVP scope is **dashboard synchronization via `npx posthog-definitions apply`** — see [`implementation/mvp-roadmap.md`](implementation/mvp-roadmap.md).
+
+## Local development
+
+This repo uses [direnv](https://direnv.net/) to load PostHog credentials for testing `apply` against a dev project:
+
+```
+cp .envrc.example .envrc
+# edit .envrc with a dev-project personal API key + project id
+direnv allow
+```
+
+`.envrc` is gitignored. The CLI reads `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID`, and optionally `POSTHOG_HOST` from the environment — direnv just keeps them out of your shell history and out of git.

--- a/docs/implementation/mvp-roadmap.md
+++ b/docs/implementation/mvp-roadmap.md
@@ -15,14 +15,13 @@
 | Feature flags, actions, cohorts | Different data models. Each is a separate sprint. |
 | Query types beyond `trends` and `hogql` | Each is a typed wrapper, additive. Trends covers ~70% of demo cases. |
 | Drift detection on UI edits | Strictly post-MVP; needs a UX decision. |
-| Code generation for callers (typed flag keys) | Only relevant once flags ship. |
-| Preview environments per branch | Requires server-side support for cheap project creation. |
+| Automated test suite | MVP verifies by running `apply` against a dev project. Backfill tests once the loop is shipping. |
 
 ## Sequenced plan
 
 The order matters: each step unblocks the next. The order is also designed so that the riskiest unknowns are verified earliest.
 
-### Day 1 — De-risk
+### De-risk
 
 Read-only investigation. No code yet.
 
@@ -30,47 +29,44 @@ Read-only investigation. No code yet.
 2. **Verify nested tile write.** Confirm `DashboardSerializer.create` accepts the `tiles: [{ insight: {...} }]` shape and creates the insight inline, or whether we need a two-step (insight first, then dashboard).
 3. **Verify tag-based search.** Confirm we can query dashboards/insights by tag prefix. If not, fall back to fetching all and filtering client-side.
 
-Output: a short note in [`risks.md`](risks.md) marking each item ✅/❌ with the API responses.
+These can also be verified inline during implementation by running `apply` against a dev project — the first real run is the test.
 
-### Day 2-3 — Skeleton
+### Skeleton
 
 4. **Repo scaffold**: `package.json`, `tsconfig.json`, `src/`, `bin/posthog-definitions`. Single package with both SDK and CLI exports.
 5. **SDK types**: copy/derive `Dashboard`, `Insight`, `Tile`, `Layout` from this docs spec. Add `dashboard`, `insight`, `text` factory functions (bare nouns, no `define*` prefix). Pure, no I/O.
-6. **API client**: generate typed client from PostHog's OpenAPI spec. Pin to the endpoints we use (dashboards, insights). No hand-rolled fetch.
+6. **API client**: hand-rolled minimal typed wrapper over the dashboards + insights endpoints. Swap for a generated client post-MVP if useful.
 
-### Day 4-5 — Core loop
+### Core loop
 
 7. **Loader**: glob `posthog/**/*.ts`, import via `tsx` (programmatic), collect default exports, tag each with `path`.
 8. **Validator**: required fields, unique keys per kind, layout bounds, tile non-emptiness.
 9. **Differ**: pair desired vs current by tag. Emit ops: `{ kind: "create" | "update" | "unchanged"; resource: ...; payload?: ... }`.
-10. **Executor**: serial HTTP calls in order (insights first, dashboards second), stop on first error.
+10. **Executor**: serial HTTP calls in order (insights first, dashboards second), stop on first error. Re-check `iac:*` tag immediately before every write (safety guard).
 11. **`apply` command wiring**: load → validate → diff → execute → report.
 
-### Day 6 — Polish
+### Polish
 
 12. **`--dry-run`**: short-circuit before any mutation, print the planned ops.
 13. **`--verbose`**: log each call.
 14. **Exit codes per spec**.
-15. **Smoke tests against staging**:
-    - **a. Coexistence test (mandatory).** Pre-populate the staging project with 3 hand-built dashboards and 3 hand-built insights (no `iac:*` tags). Run `apply` with one IaC-managed dashboard. Verify: the 3 hand-built dashboards and 3 hand-built insights are byte-identical before and after (compare via API GETs). This is the [safety invariant](apply.md#safety-invariant--this-is-the-rule-everything-else-serves) check. If this fails, the build does not ship.
-    - **b. Idempotence test.** Run `apply` twice with no source changes. Second run reports `0 created, 0 updated, N unchanged`.
-    - **c. Mutation test.** Edit the source file. Re-run. Verify exactly one resource updated; everything else untouched.
-    - **d. Tag-strip test.** Manually remove the `iac:dashboards:<key>` tag from a managed dashboard in the UI. Re-run `apply`. Verify the CLI refuses to write to that resource (executor-layer guard) and exits non-zero.
 
-### Day 7 — Documentation and release
+### Verification
 
-16. Update `docs/interface/getting-started.md` with real installation instructions.
-17. Tag `v0.1.0`. Publish to npm under `@posthog/definitions` (private at first).
-18. Announce in a small group; gather feedback before public release.
+Manual: run `apply` against a dev project with `.envrc`-loaded credentials. Confirm idempotence (second run = all unchanged), mutation (edit a field, re-run = one update), and the safety invariant (a hand-built dashboard alongside is untouched). Backfill automated tests after the first ship.
 
-**Total estimate: 5-7 working days for one engineer**, assuming the Day 1 investigation comes back clean. Add 2-3 days of slack if any Day 1 item turns up red.
+### Documentation and release
+
+15. Update `docs/interface/getting-started.md` with real installation instructions.
+16. Tag `v0.1.0`. Publish to npm under `@posthog/definitions` (private at first).
+17. Announce in a small group; gather feedback before public release.
 
 ## Order-of-magnitude cost
 
 Most expensive parts in descending order:
 
-1. **API client correctness** — the OpenAPI spec covers a lot of surface and not every endpoint is well-typed. Plan for some hand-editing.
-2. **`tsx` programmatic loader** — loading user TS code at runtime has rough edges (path aliases, `node_modules` resolution). Budget time.
+1. **API client correctness** — even hand-rolled, the dashboards endpoint has a lot of shape. Plan for some iteration against a real project.
+2. **`tsx` programmatic loader** — loading user TS code at runtime has rough edges (path aliases, `node_modules` resolution).
 3. **Differ correctness on `tiles`** — the trickiest data structure to compare. Order matters? Insight identity matters? Hash-based skip is the safety net.
 4. **Everything else** — SDK types, CLI scaffold, executor — straightforward.
 
@@ -79,6 +75,5 @@ Most expensive parts in descending order:
 - A new user can install, write `posthog/dashboards/foo.ts`, run `apply`, and see the dashboard in PostHog.
 - Re-running with no changes prints `0 created, 0 updated, 1 unchanged`.
 - Editing the file changes `1 unchanged` to `1 updated`.
-- CI can run `apply --dry-run` against a real project and exit 0.
-- **Day 6 smoke test 15a (coexistence) passes**: hand-built dashboards/insights in the same project are byte-identical before and after `apply`.
+- A hand-built dashboard in the same project is byte-identical before and after `apply` (safety invariant — verified manually against a dev project).
 - Docs in this repo match the shipped behavior.

--- a/docs/implementation/risks.md
+++ b/docs/implementation/risks.md
@@ -1,6 +1,6 @@
 # Risks and open questions
 
-Block on these before committing to the MVP timeline. Each is a quick investigation, not a build task.
+Block on these before committing to the MVP. Each is a quick investigation, not a build task.
 
 ## R1 — Tags round-trip through dashboard/insight writes
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,16 @@
+# Example dashboards
+
+Used to smoke-test the `apply` loop against a dev PostHog project.
+
+From the repo root, after setting up `.envrc`:
+
+```
+pnpm dev apply --dir examples/posthog --dry-run
+pnpm dev apply --dir examples/posthog
+```
+
+The growth dashboard defines two `trends` insights (`weekly-signups`,
+`weekly-active`) and a text tile, all tagged `iac:dashboards:growth` /
+`iac:insights:<key>` on the server. Re-running `apply` should report
+everything as `unchanged`; edit a name or query and the next run should
+report exactly one `update`.

--- a/examples/posthog/dashboards/growth.ts
+++ b/examples/posthog/dashboards/growth.ts
@@ -1,0 +1,35 @@
+import { dashboard, insight, text, trends } from "../../../src/index.js";
+
+const signups = insight({
+  key: "weekly-signups",
+  name: "Weekly signups",
+  description: "Count of `user signed up` events per ISO week.",
+  query: trends({
+    series: [{ event: "user signed up", math: "total" }],
+    interval: "week",
+    dateRange: { date_from: "-90d" },
+  }),
+});
+
+const activeUsers = insight({
+  key: "weekly-active",
+  name: "Weekly active users",
+  query: trends({
+    series: [{ event: "$pageview", math: "weekly_active" }],
+    interval: "week",
+    dateRange: { date_from: "-90d" },
+  }),
+});
+
+export default dashboard({
+  key: "growth",
+  name: "Growth (iac)",
+  description: "Smoke-test dashboard managed by posthog-definitions.",
+  pinned: false,
+  tags: ["growth"],
+  tiles: [
+    { insight: signups, layout: { x: 0, y: 0, w: 6, h: 4 } },
+    { insight: activeUsers, layout: { x: 6, y: 0, w: 6, h: 4 } },
+    text({ body: "Managed by posthog-definitions. Edit the source file, then run `apply`.", layout: { x: 0, y: 4, w: 12, h: 1 } }),
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -1,13 +1,44 @@
 {
-  "name": "posthog-definitions",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "name": "@posthog/definitions",
+  "version": "0.0.0",
+  "description": "Infrastructure-as-code for PostHog dashboards and insights.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "packageManager": "pnpm@10.28.2"
+  "bin": {
+    "posthog-definitions": "./dist/cli/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json && chmod +x dist/cli/index.js",
+    "dev": "tsx src/cli/index.ts",
+    "apply": "tsx src/cli/index.ts apply",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "tinyglobby": "^0.2.10",
+    "tsx": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=18.17"
+  },
+  "packageManager": "pnpm@10.28.2",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PostHog/posthog-definitions.git"
+  }
 }

--- a/src/apply/diff.ts
+++ b/src/apply/diff.ts
@@ -1,0 +1,132 @@
+import type { Dashboard, Insight } from "../sdk/types.js";
+import type { ServerDashboard } from "../client/dashboards.js";
+import type { ServerInsight } from "../client/insights.js";
+import { specHash } from "./hash.js";
+import {
+  dashboardKeyFromTags,
+  dashboardPayload,
+  extractHash,
+  insightKeyFromTags,
+  insightPayload,
+} from "./serialize.js";
+
+export type InsightOp =
+  | { kind: "create"; key: string; spec: Insight; hash: string }
+  | { kind: "update"; key: string; spec: Insight; hash: string; serverId: number }
+  | { kind: "unchanged"; key: string; spec: Insight; serverId: number };
+
+export type DashboardOp =
+  | { kind: "create"; key: string; spec: Dashboard; hash: string }
+  | { kind: "update"; key: string; spec: Dashboard; hash: string; serverId: number }
+  | { kind: "unchanged"; key: string; spec: Dashboard; serverId: number };
+
+export type DiffResult = {
+  insightOps: InsightOp[];
+  dashboardOps: DashboardOp[];
+  orphanInsights: ServerInsight[];
+  orphanDashboards: ServerDashboard[];
+};
+
+export function diff(
+  desired: { dashboards: Dashboard[]; insights: Insight[] },
+  current: { dashboards: ServerDashboard[]; insights: ServerInsight[] },
+): DiffResult {
+  const insightOps: InsightOp[] = [];
+  const dashboardOps: DashboardOp[] = [];
+
+  const currentInsightByKey = new Map<string, ServerInsight>();
+  for (const ci of current.insights) {
+    const key = insightKeyFromTags(ci.tags);
+    if (key) currentInsightByKey.set(key, ci);
+  }
+
+  for (const spec of desired.insights) {
+    const hash = specHash(insightPayload(spec, ""));
+    const server = currentInsightByKey.get(spec.key);
+    if (!server) {
+      insightOps.push({ kind: "create", key: spec.key, spec, hash });
+    } else if (extractHash(server.tags) === hash) {
+      insightOps.push({ kind: "unchanged", key: spec.key, spec, serverId: server.id });
+    } else {
+      insightOps.push({ kind: "update", key: spec.key, spec, hash, serverId: server.id });
+    }
+  }
+
+  const desiredInsightKeys = new Set(desired.insights.map((i) => i.key));
+  const orphanInsights = current.insights.filter((ci) => {
+    const key = insightKeyFromTags(ci.tags);
+    return key !== undefined && !desiredInsightKeys.has(key);
+  });
+
+  const currentDashboardByKey = new Map<string, ServerDashboard>();
+  for (const cd of current.dashboards) {
+    const key = dashboardKeyFromTags(cd.tags);
+    if (key) currentDashboardByKey.set(key, cd);
+  }
+
+  for (const spec of desired.dashboards) {
+    const hash = specHash(dashboardSpecForHash(spec));
+    const server = currentDashboardByKey.get(spec.key);
+    if (!server) {
+      dashboardOps.push({ kind: "create", key: spec.key, spec, hash });
+    } else if (extractHash(server.tags) === hash) {
+      dashboardOps.push({ kind: "unchanged", key: spec.key, spec, serverId: server.id });
+    } else {
+      dashboardOps.push({ kind: "update", key: spec.key, spec, hash, serverId: server.id });
+    }
+  }
+
+  const desiredDashboardKeys = new Set(desired.dashboards.map((d) => d.key));
+  const orphanDashboards = current.dashboards.filter((cd) => {
+    const key = dashboardKeyFromTags(cd.tags);
+    return key !== undefined && !desiredDashboardKeys.has(key);
+  });
+
+  return { insightOps, dashboardOps, orphanInsights, orphanDashboards };
+}
+
+function dashboardSpecForHash(spec: Dashboard): unknown {
+  return {
+    key: spec.key,
+    name: spec.name,
+    description: spec.description ?? null,
+    pinned: spec.pinned ?? false,
+    restriction: spec.restriction,
+    tags: spec.tags ?? [],
+    tiles: spec.tiles.map((tile) => {
+      if ("insight" in tile) {
+        return {
+          kind: "insight",
+          insightKey: tile.insight.key,
+          layout: tile.layout,
+          color: tile.color,
+          filtersOverride: tile.filtersOverride,
+        };
+      }
+      return tile;
+    }),
+  };
+}
+
+export function dashboardPayloadHash(spec: Dashboard): string {
+  return specHash(dashboardSpecForHash(spec));
+}
+
+export function insightPayloadHash(spec: Insight): string {
+  return specHash(insightPayload(spec, ""));
+}
+
+export function buildDashboardCreatePayload(
+  spec: Dashboard,
+  hash: string,
+  insightIdByKey: Map<string, number>,
+): ReturnType<typeof dashboardPayload> {
+  return dashboardPayload(spec, hash, insightIdByKey);
+}
+
+export function buildInsightCreatePayload(
+  spec: Insight,
+  hash: string,
+): ReturnType<typeof insightPayload> {
+  return insightPayload(spec, hash);
+}

--- a/src/apply/execute.ts
+++ b/src/apply/execute.ts
@@ -1,0 +1,140 @@
+import type { ClientConfig } from "../client/config.js";
+import {
+  createDashboard,
+  getDashboard,
+  type ServerDashboard,
+  updateDashboard,
+} from "../client/dashboards.js";
+import {
+  createInsight,
+  getInsight,
+  type ServerInsight,
+  updateInsight,
+} from "../client/insights.js";
+import type { DashboardOp, DiffResult, InsightOp } from "./diff.js";
+import {
+  dashboardPayload,
+  dashboardTag,
+  insightPayload,
+  insightTag,
+} from "./serialize.js";
+
+export class SafetyViolationError extends Error {
+  constructor(kind: "dashboard" | "insight", id: number, key: string) {
+    super(
+      `Refusing to write to ${kind} ${id} (key="${key}"): its tags no longer include the managed iac:* identity tag. This usually means the tag was removed in the UI between fetch and write. Aborting.`,
+    );
+    this.name = "SafetyViolationError";
+  }
+}
+
+export type ExecuteOptions = {
+  verbose?: boolean;
+};
+
+export type ExecuteSummary = {
+  insightsCreated: number;
+  insightsUpdated: number;
+  insightsUnchanged: number;
+  dashboardsCreated: number;
+  dashboardsUpdated: number;
+  dashboardsUnchanged: number;
+};
+
+export async function execute(
+  config: ClientConfig,
+  diffResult: DiffResult,
+  options: ExecuteOptions = {},
+): Promise<ExecuteSummary> {
+  const summary: ExecuteSummary = {
+    insightsCreated: 0,
+    insightsUpdated: 0,
+    insightsUnchanged: 0,
+    dashboardsCreated: 0,
+    dashboardsUpdated: 0,
+    dashboardsUnchanged: 0,
+  };
+
+  const insightIdByKey = new Map<string, number>();
+
+  for (const op of diffResult.insightOps) {
+    const id = await runInsightOp(config, op, options);
+    insightIdByKey.set(op.key, id);
+    if (op.kind === "create") summary.insightsCreated++;
+    else if (op.kind === "update") summary.insightsUpdated++;
+    else summary.insightsUnchanged++;
+  }
+
+  for (const op of diffResult.dashboardOps) {
+    await runDashboardOp(config, op, insightIdByKey, options);
+    if (op.kind === "create") summary.dashboardsCreated++;
+    else if (op.kind === "update") summary.dashboardsUpdated++;
+    else summary.dashboardsUnchanged++;
+  }
+
+  return summary;
+}
+
+async function runInsightOp(
+  config: ClientConfig,
+  op: InsightOp,
+  options: ExecuteOptions,
+): Promise<number> {
+  if (op.kind === "unchanged") return op.serverId;
+
+  const payload = insightPayload(op.spec, op.hash);
+
+  if (op.kind === "create") {
+    const created = await createInsight(config, payload, options);
+    return created.id;
+  }
+
+  await assertManagedInsight(config, op.serverId, op.key, options);
+  const updated = await updateInsight(config, op.serverId, payload, options);
+  return updated.id;
+}
+
+async function runDashboardOp(
+  config: ClientConfig,
+  op: DashboardOp,
+  insightIdByKey: Map<string, number>,
+  options: ExecuteOptions,
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+
+  const payload = dashboardPayload(op.spec, op.hash, insightIdByKey);
+
+  if (op.kind === "create") {
+    await createDashboard(config, payload, options);
+    return;
+  }
+
+  await assertManagedDashboard(config, op.serverId, op.key, options);
+  await updateDashboard(config, op.serverId, payload, options);
+}
+
+async function assertManagedInsight(
+  config: ClientConfig,
+  id: number,
+  key: string,
+  options: ExecuteOptions,
+): Promise<void> {
+  const current: ServerInsight = await getInsight(config, id, options);
+  const expected = insightTag(key);
+  if (!current.tags?.includes(expected)) {
+    throw new SafetyViolationError("insight", id, key);
+  }
+}
+
+async function assertManagedDashboard(
+  config: ClientConfig,
+  id: number,
+  key: string,
+  options: ExecuteOptions,
+): Promise<void> {
+  const current: ServerDashboard = await getDashboard(config, id, options);
+  const expected = dashboardTag(key);
+  if (!current.tags?.includes(expected)) {
+    throw new SafetyViolationError("dashboard", id, key);
+  }
+}

--- a/src/apply/hash.ts
+++ b/src/apply/hash.ts
@@ -1,0 +1,17 @@
+import { createHash } from "node:crypto";
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of entries) result[k] = canonicalize(v);
+  return result;
+}
+
+export function specHash(value: unknown): string {
+  const canonical = JSON.stringify(canonicalize(value));
+  return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+}

--- a/src/apply/load.ts
+++ b/src/apply/load.ts
@@ -1,0 +1,102 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { glob } from "tinyglobby";
+import { tsImport } from "tsx/esm/api";
+import type { Dashboard, Insight, Tile } from "../sdk/types.js";
+import { isInsightTile } from "../sdk/types.js";
+
+export type LoadedSpec = {
+  path: string;
+  spec: Dashboard | Insight;
+};
+
+export type DesiredState = {
+  dashboards: Array<{ path: string; spec: Dashboard }>;
+  insights: Array<{ path: string; spec: Insight }>;
+};
+
+export class LoadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LoadError";
+  }
+}
+
+function looksLikeDashboard(value: unknown): value is Dashboard {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.key === "string" && typeof v.name === "string" && Array.isArray(v.tiles);
+}
+
+function looksLikeInsight(value: unknown): value is Insight {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.key === "string" &&
+    typeof v.name === "string" &&
+    !!v.query &&
+    typeof v.query === "object" &&
+    !Array.isArray((value as { tiles?: unknown }).tiles)
+  );
+}
+
+export async function loadDefinitions(dir: string): Promise<DesiredState> {
+  const absDir = path.resolve(dir);
+  const files = await glob("**/*.ts", { cwd: absDir, absolute: true });
+
+  const dashboards: Array<{ path: string; spec: Dashboard }> = [];
+  const insights: Array<{ path: string; spec: Insight }> = [];
+
+  for (const file of files.sort()) {
+    const module = await tsImport(pathToFileURL(file).href, import.meta.url);
+    const exported = (module as { default?: unknown }).default;
+    if (exported === undefined) {
+      continue;
+    }
+    if (looksLikeDashboard(exported)) {
+      dashboards.push({ path: file, spec: exported });
+    } else if (looksLikeInsight(exported)) {
+      insights.push({ path: file, spec: exported });
+    } else {
+      throw new LoadError(
+        `${file}: default export is not a Dashboard or Insight. Got: ${JSON.stringify(exported).slice(0, 200)}`,
+      );
+    }
+  }
+
+  for (const { spec } of dashboards) {
+    for (const tile of spec.tiles) {
+      collectInlineInsight(tile, insights);
+    }
+  }
+
+  return dedupeInsights(dashboards, insights);
+}
+
+function collectInlineInsight(
+  tile: Tile,
+  insights: Array<{ path: string; spec: Insight }>,
+): void {
+  if (!isInsightTile(tile)) return;
+  const insight = tile.insight;
+  if (!insights.some((i) => i.spec === insight || i.spec.key === insight.key)) {
+    insights.push({ path: "<inline>", spec: insight });
+  }
+}
+
+function dedupeInsights(
+  dashboards: Array<{ path: string; spec: Dashboard }>,
+  insights: Array<{ path: string; spec: Insight }>,
+): DesiredState {
+  const byKey = new Map<string, { path: string; spec: Insight }>();
+  for (const entry of insights) {
+    const existing = byKey.get(entry.spec.key);
+    if (existing && existing.spec !== entry.spec) {
+      throw new LoadError(
+        `Insight key "${entry.spec.key}" is defined in multiple places (${existing.path} and ${entry.path}). Keys must be unique.`,
+      );
+    }
+    byKey.set(entry.spec.key, entry);
+  }
+  return { dashboards, insights: [...byKey.values()] };
+}

--- a/src/apply/serialize.ts
+++ b/src/apply/serialize.ts
@@ -1,0 +1,156 @@
+import type {
+  ButtonTile,
+  Dashboard,
+  Insight,
+  InsightTile,
+  Layout,
+  Query,
+  TextTile,
+  Tile,
+} from "../sdk/types.js";
+import { isButtonTile, isInsightTile, isTextTile } from "../sdk/types.js";
+
+const RESTRICTION_TO_LEVEL: Record<NonNullable<Dashboard["restriction"]>, number> = {
+  everyone: 21,
+  collaborators: 37,
+};
+
+export function insightTag(key: string): string {
+  return `iac:insights:${key}`;
+}
+
+export function dashboardTag(key: string): string {
+  return `iac:dashboards:${key}`;
+}
+
+export function hashTag(hex: string): string {
+  return `iac:hash:${hex}`;
+}
+
+export function isManagedTag(tag: string): boolean {
+  return tag.startsWith("iac:");
+}
+
+export function extractHash(tags: string[] | undefined): string | undefined {
+  return tags?.find((t) => t.startsWith("iac:hash:"))?.slice("iac:hash:".length);
+}
+
+export function dashboardKeyFromTags(tags: string[] | undefined): string | undefined {
+  const tag = tags?.find((t) => t.startsWith("iac:dashboards:"));
+  return tag?.slice("iac:dashboards:".length);
+}
+
+export function insightKeyFromTags(tags: string[] | undefined): string | undefined {
+  const tag = tags?.find((t) => t.startsWith("iac:insights:"));
+  return tag?.slice("iac:insights:".length);
+}
+
+function wrapQuery(query: Query): unknown {
+  if (query.kind === "TrendsQuery") {
+    return { kind: "InsightVizNode", source: query };
+  }
+  return { kind: "DataTableNode", source: query };
+}
+
+function mergeTags(userTags: string[] | undefined, managedTags: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const tag of managedTags) {
+    if (!seen.has(tag)) {
+      seen.add(tag);
+      result.push(tag);
+    }
+  }
+  for (const tag of userTags ?? []) {
+    if (isManagedTag(tag)) continue;
+    if (!seen.has(tag)) {
+      seen.add(tag);
+      result.push(tag);
+    }
+  }
+  return result;
+}
+
+export function insightPayload(
+  spec: Insight,
+  hash: string,
+): { name: string; description: string | null; query: unknown; tags: string[] } {
+  return {
+    name: spec.name,
+    description: spec.description ?? null,
+    query: wrapQuery(spec.query),
+    tags: mergeTags(spec.tags, [insightTag(spec.key), hashTag(hash)]),
+  };
+}
+
+function layoutsFor(layout: Layout): Record<string, Layout> {
+  return { sm: layout, lg: layout };
+}
+
+function serializeTile(tile: Tile, insightIdByKey: Map<string, number>): unknown {
+  if (isInsightTile(tile)) {
+    return serializeInsightTile(tile, insightIdByKey);
+  }
+  if (isTextTile(tile)) {
+    return serializeTextTile(tile);
+  }
+  if (isButtonTile(tile)) {
+    return serializeButtonTile(tile);
+  }
+  throw new Error(`Unknown tile shape: ${JSON.stringify(tile)}`);
+}
+
+function serializeInsightTile(tile: InsightTile, insightIdByKey: Map<string, number>): unknown {
+  const id = insightIdByKey.get(tile.insight.key);
+  if (id === undefined) {
+    throw new Error(
+      `Insight "${tile.insight.key}" was not created before its dashboard tile. This is a bug in the executor ordering.`,
+    );
+  }
+  return {
+    insight: { id },
+    layouts: layoutsFor(tile.layout),
+    ...(tile.color !== undefined && { color: tile.color }),
+    ...(tile.filtersOverride !== undefined && { filters_hash: null, filters: tile.filtersOverride }),
+  };
+}
+
+function serializeTextTile(tile: TextTile): unknown {
+  return {
+    text: { body: tile.body },
+    layouts: layoutsFor(tile.layout),
+  };
+}
+
+function serializeButtonTile(tile: ButtonTile): unknown {
+  return {
+    text: {
+      body: `[${tile.text}](${tile.url})`,
+    },
+    layouts: layoutsFor(tile.layout),
+  };
+}
+
+export function dashboardPayload(
+  spec: Dashboard,
+  hash: string,
+  insightIdByKey: Map<string, number>,
+): {
+  name: string;
+  description: string | null;
+  pinned: boolean;
+  tags: string[];
+  restriction_level?: number;
+  tiles: unknown[];
+} {
+  return {
+    name: spec.name,
+    description: spec.description ?? null,
+    pinned: spec.pinned ?? false,
+    tags: mergeTags(spec.tags, [dashboardTag(spec.key), hashTag(hash)]),
+    ...(spec.restriction !== undefined && {
+      restriction_level: RESTRICTION_TO_LEVEL[spec.restriction],
+    }),
+    tiles: spec.tiles.map((tile) => serializeTile(tile, insightIdByKey)),
+  };
+}

--- a/src/apply/validate.ts
+++ b/src/apply/validate.ts
@@ -1,0 +1,93 @@
+import type { DesiredState } from "./load.js";
+import { isButtonTile, isInsightTile, isTextTile } from "../sdk/types.js";
+import type { Layout, Tile } from "../sdk/types.js";
+
+export class ValidationError extends Error {
+  constructor(public readonly issues: string[]) {
+    super(`Validation failed:\n - ${issues.join("\n - ")}`);
+    this.name = "ValidationError";
+  }
+}
+
+const GRID_WIDTH = 12;
+
+export function validate(state: DesiredState): void {
+  const issues: string[] = [];
+
+  const dashboardKeys = new Map<string, string>();
+  for (const { path, spec } of state.dashboards) {
+    if (!spec.key) issues.push(`${path}: dashboard.key is required`);
+    if (!spec.name) issues.push(`${path}: dashboard.name is required`);
+    if (!spec.tiles || spec.tiles.length === 0) {
+      issues.push(`${path}: dashboard "${spec.key}" must have at least one tile`);
+    } else {
+      spec.tiles.forEach((tile, index) => validateTile(issues, path, spec.key, index, tile));
+    }
+
+    const existingPath = dashboardKeys.get(spec.key);
+    if (existingPath) {
+      issues.push(`Duplicate dashboard key "${spec.key}" in ${existingPath} and ${path}`);
+    } else {
+      dashboardKeys.set(spec.key, path);
+    }
+  }
+
+  const insightKeys = new Set<string>();
+  for (const { path, spec } of state.insights) {
+    if (!spec.key) issues.push(`${path}: insight.key is required`);
+    if (!spec.name) issues.push(`${path}: insight.name is required`);
+    if (!spec.query) issues.push(`${path}: insight "${spec.key}" is missing query`);
+    if (insightKeys.has(spec.key)) {
+      issues.push(`Duplicate insight key "${spec.key}"`);
+    }
+    insightKeys.add(spec.key);
+  }
+
+  const knownInsightKeys = new Set(state.insights.map((i) => i.spec.key));
+  for (const { path, spec } of state.dashboards) {
+    for (const tile of spec.tiles) {
+      if (isInsightTile(tile) && !knownInsightKeys.has(tile.insight.key)) {
+        issues.push(
+          `${path}: dashboard "${spec.key}" references unknown insight "${tile.insight.key}"`,
+        );
+      }
+    }
+  }
+
+  if (issues.length > 0) throw new ValidationError(issues);
+}
+
+function validateTile(
+  issues: string[],
+  path: string,
+  dashboardKey: string,
+  index: number,
+  tile: Tile,
+): void {
+  const where = `${path}: dashboard "${dashboardKey}" tile[${index}]`;
+  if (isInsightTile(tile)) {
+    if (!tile.insight) issues.push(`${where}: missing insight`);
+    validateLayout(issues, where, tile.layout);
+  } else if (isTextTile(tile)) {
+    if (!tile.body) issues.push(`${where}: text tile body is empty`);
+    validateLayout(issues, where, tile.layout);
+  } else if (isButtonTile(tile)) {
+    if (!tile.url) issues.push(`${where}: button tile url is empty`);
+    if (!tile.text) issues.push(`${where}: button tile text is empty`);
+    validateLayout(issues, where, tile.layout);
+  } else {
+    issues.push(`${where}: unknown tile shape`);
+  }
+}
+
+function validateLayout(issues: string[], where: string, layout: Layout | undefined): void {
+  if (!layout) {
+    issues.push(`${where}: layout is required`);
+    return;
+  }
+  if (layout.x < 0 || layout.y < 0) issues.push(`${where}: layout x/y must be >= 0`);
+  if (layout.w <= 0 || layout.h <= 0) issues.push(`${where}: layout w/h must be > 0`);
+  if (layout.x + layout.w > GRID_WIDTH) {
+    issues.push(`${where}: layout overflows the ${GRID_WIDTH}-column grid (x=${layout.x}, w=${layout.w})`);
+  }
+}

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -1,0 +1,139 @@
+import { listManagedDashboards } from "../client/dashboards.js";
+import { listManagedInsights } from "../client/insights.js";
+import { ConfigError, loadConfig } from "../client/config.js";
+import { ApiError } from "../client/http.js";
+import { diff, type DiffResult } from "../apply/diff.js";
+import { execute, SafetyViolationError } from "../apply/execute.js";
+import { LoadError, loadDefinitions } from "../apply/load.js";
+import { ValidationError, validate } from "../apply/validate.js";
+import type { ApplyArgs } from "./args.js";
+
+export async function runApply(args: ApplyArgs): Promise<number> {
+  const overrides: { host?: string; projectId?: string } = {};
+  if (args.host !== undefined) overrides.host = args.host;
+  if (args.project !== undefined) overrides.projectId = args.project;
+
+  let config;
+  try {
+    config = loadConfig(overrides);
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      console.error(`error: ${err.message}`);
+      return 3;
+    }
+    throw err;
+  }
+
+  let desired;
+  try {
+    desired = await loadDefinitions(args.dir);
+  } catch (err) {
+    if (err instanceof LoadError) {
+      console.error(`error: ${err.message}`);
+      return 1;
+    }
+    throw err;
+  }
+
+  try {
+    validate(desired);
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      console.error(`error: ${err.message}`);
+      return 1;
+    }
+    throw err;
+  }
+
+  console.error(
+    `Loaded ${desired.dashboards.length} dashboard(s) and ${desired.insights.length} insight(s) from ${args.dir}/`,
+  );
+
+  if (args.dryRun && desired.dashboards.length === 0 && desired.insights.length === 0) {
+    console.log("Nothing to do.");
+    return 0;
+  }
+
+  let current;
+  try {
+    const [insights, dashboards] = await Promise.all([
+      listManagedInsights(config, { verbose: args.verbose }),
+      listManagedDashboards(config, { verbose: args.verbose }),
+    ]);
+    current = { insights, dashboards };
+  } catch (err) {
+    return reportApiError(err, "while fetching current state");
+  }
+
+  const diffResult = diff(
+    { dashboards: desired.dashboards.map((d) => d.spec), insights: desired.insights.map((i) => i.spec) },
+    current,
+  );
+
+  printPlan(diffResult);
+
+  if (args.dryRun) {
+    console.log("\nDry run — no changes applied.");
+    return 0;
+  }
+
+  try {
+    const summary = await execute(config, diffResult, { verbose: args.verbose });
+    console.log(
+      `\nApplied: ${summary.insightsCreated + summary.dashboardsCreated} created, ` +
+        `${summary.insightsUpdated + summary.dashboardsUpdated} updated, ` +
+        `${summary.insightsUnchanged + summary.dashboardsUnchanged} unchanged.`,
+    );
+    return 0;
+  } catch (err) {
+    if (err instanceof SafetyViolationError) {
+      console.error(`error: ${err.message}`);
+      return 2;
+    }
+    return reportApiError(err, "during apply");
+  }
+}
+
+function printPlan(result: DiffResult): void {
+  const ins = countOps(result.insightOps);
+  const dash = countOps(result.dashboardOps);
+  console.log(`\nPlan:`);
+  console.log(
+    `  insights:   ${ins.create} to create, ${ins.update} to update, ${ins.unchanged} unchanged`,
+  );
+  console.log(
+    `  dashboards: ${dash.create} to create, ${dash.update} to update, ${dash.unchanged} unchanged`,
+  );
+  if (result.orphanInsights.length > 0 || result.orphanDashboards.length > 0) {
+    console.log(
+      `  orphans:    ${result.orphanInsights.length} insight(s), ${result.orphanDashboards.length} dashboard(s) ` +
+        `tagged iac:* with no matching source file (MVP leaves these alone)`,
+    );
+  }
+  for (const op of result.insightOps) {
+    if (op.kind !== "unchanged") console.log(`  ${op.kind} insight   ${op.key}`);
+  }
+  for (const op of result.dashboardOps) {
+    if (op.kind !== "unchanged") console.log(`  ${op.kind} dashboard ${op.key}`);
+  }
+}
+
+function countOps(
+  ops: Array<{ kind: "create" | "update" | "unchanged" }>,
+): { create: number; update: number; unchanged: number } {
+  return ops.reduce(
+    (acc, op) => {
+      acc[op.kind]++;
+      return acc;
+    },
+    { create: 0, update: 0, unchanged: 0 },
+  );
+}
+
+function reportApiError(err: unknown, context: string): number {
+  if (err instanceof ApiError) {
+    console.error(`error: PostHog API ${context}: ${err.message}`);
+    return 2;
+  }
+  throw err;
+}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,94 @@
+export type ApplyArgs = {
+  command: "apply";
+  dryRun: boolean;
+  verbose: boolean;
+  dir: string;
+  host?: string;
+  project?: string;
+};
+
+export type HelpArgs = { command: "help" };
+
+export type ParsedArgs = ApplyArgs | HelpArgs;
+
+export class ArgError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgError";
+  }
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h" || argv[0] === "help") {
+    return { command: "help" };
+  }
+
+  const command = argv[0];
+  if (command !== "apply") {
+    throw new ArgError(`Unknown command "${command}". Run "posthog-definitions help" for usage.`);
+  }
+
+  const args: ApplyArgs = {
+    command: "apply",
+    dryRun: false,
+    verbose: false,
+    dir: "posthog",
+  };
+
+  for (let i = 1; i < argv.length; i++) {
+    const flag = argv[i];
+    switch (flag) {
+      case "--dry-run":
+        args.dryRun = true;
+        break;
+      case "--verbose":
+      case "-v":
+        args.verbose = true;
+        break;
+      case "--dir":
+        args.dir = expectValue(argv, ++i, flag);
+        break;
+      case "--project":
+        args.project = expectValue(argv, ++i, flag);
+        break;
+      case "--host":
+        args.host = expectValue(argv, ++i, flag);
+        break;
+      case "--help":
+      case "-h":
+        return { command: "help" };
+      default:
+        throw new ArgError(`Unknown flag: ${flag}`);
+    }
+  }
+
+  return args;
+}
+
+function expectValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index];
+  if (value === undefined || value.startsWith("--")) {
+    throw new ArgError(`${flag} expects a value.`);
+  }
+  return value;
+}
+
+export const HELP_TEXT = `posthog-definitions — IaC for PostHog dashboards and insights
+
+Usage:
+  posthog-definitions apply [flags]
+
+Flags:
+  --dry-run            Compute the diff but make no API calls.
+  --verbose, -v        Log each HTTP call.
+  --dir <path>         Directory to scan for definition files (default: posthog).
+  --project <id>       Override POSTHOG_PROJECT_ID.
+  --host <url>         Override POSTHOG_HOST (default: https://us.posthog.com).
+  --help, -h           Show this help.
+
+Environment:
+  POSTHOG_PERSONAL_API_KEY   Required. Personal API key with dashboard:write
+                             and insight:write scopes.
+  POSTHOG_PROJECT_ID         Required. Numeric project id.
+  POSTHOG_HOST               Optional. Defaults to https://us.posthog.com.
+`;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { runApply } from "./apply.js";
+import { ArgError, HELP_TEXT, parseArgs } from "./args.js";
+
+export async function main(argv: string[]): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs(argv);
+  } catch (err) {
+    if (err instanceof ArgError) {
+      console.error(`error: ${err.message}`);
+      process.exit(3);
+    }
+    throw err;
+  }
+
+  if (parsed.command === "help") {
+    console.log(HELP_TEXT);
+    process.exit(0);
+  }
+
+  const code = await runApply(parsed);
+  process.exit(code);
+}
+
+const isDirectInvocation =
+  process.argv[1] !== undefined &&
+  (import.meta.url.endsWith(process.argv[1]) ||
+    import.meta.url === `file://${process.argv[1]}`);
+
+if (isDirectInvocation) {
+  main(process.argv.slice(2)).catch((err) => {
+    console.error(err instanceof Error ? err.stack ?? err.message : String(err));
+    process.exit(2);
+  });
+}

--- a/src/client/config.ts
+++ b/src/client/config.ts
@@ -1,0 +1,39 @@
+export type ClientConfig = {
+  host: string;
+  projectId: string;
+  apiKey: string;
+};
+
+export type ConfigOverrides = {
+  host?: string;
+  projectId?: string;
+};
+
+const DEFAULT_HOST = "https://us.posthog.com";
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+export function loadConfig(overrides: ConfigOverrides = {}): ClientConfig {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  if (!apiKey) {
+    throw new ConfigError(
+      "POSTHOG_PERSONAL_API_KEY is not set. Add it to .envrc (and run `direnv allow`) or export it in your shell.",
+    );
+  }
+
+  const projectId = overrides.projectId ?? process.env.POSTHOG_PROJECT_ID;
+  if (!projectId) {
+    throw new ConfigError(
+      "POSTHOG_PROJECT_ID is not set. Pass --project <id> or set it in .envrc.",
+    );
+  }
+
+  const host = (overrides.host ?? process.env.POSTHOG_HOST ?? DEFAULT_HOST).replace(/\/$/, "");
+
+  return { host, projectId, apiKey };
+}

--- a/src/client/dashboards.ts
+++ b/src/client/dashboards.ts
@@ -1,0 +1,81 @@
+import type { ClientConfig } from "./config.js";
+import { paginate, request } from "./http.js";
+
+export type ServerTile = {
+  id?: number;
+  insight?: { id: number; short_id?: string } | null;
+  text?: { body: string } | null;
+  layouts?: Record<string, { x: number; y: number; w: number; h: number }>;
+  color?: string | null;
+};
+
+export type ServerDashboard = {
+  id: number;
+  name: string;
+  description?: string | null;
+  pinned?: boolean;
+  tags: string[];
+  restriction_level?: number;
+  tiles?: ServerTile[];
+};
+
+export type DashboardCreate = {
+  name: string;
+  description?: string | null;
+  pinned?: boolean;
+  tags?: string[];
+  restriction_level?: number;
+  tiles?: unknown[];
+};
+
+export type DashboardUpdate = Partial<DashboardCreate>;
+
+function dashboardsPath(projectId: string, suffix = ""): string {
+  return `/api/projects/${projectId}/dashboards/${suffix}`;
+}
+
+export async function listManagedDashboards(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerDashboard[]> {
+  const all = await paginate<ServerDashboard>(config, dashboardsPath(config.projectId), {
+    query: { limit: 100 },
+    verbose: options.verbose,
+  });
+  return all.filter((d) => d.tags?.some((tag) => tag.startsWith("iac:dashboards:")));
+}
+
+export async function getDashboard(
+  config: ClientConfig,
+  id: number,
+  options: { verbose?: boolean } = {},
+): Promise<ServerDashboard> {
+  return request<ServerDashboard>(config, dashboardsPath(config.projectId, `${id}/`), {
+    verbose: options.verbose,
+  });
+}
+
+export async function createDashboard(
+  config: ClientConfig,
+  payload: DashboardCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerDashboard> {
+  return request<ServerDashboard>(config, dashboardsPath(config.projectId), {
+    method: "POST",
+    body: payload,
+    verbose: options.verbose,
+  });
+}
+
+export async function updateDashboard(
+  config: ClientConfig,
+  id: number,
+  payload: DashboardUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerDashboard> {
+  return request<ServerDashboard>(config, dashboardsPath(config.projectId, `${id}/`), {
+    method: "PATCH",
+    body: payload,
+    verbose: options.verbose,
+  });
+}

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -1,0 +1,85 @@
+import type { ClientConfig } from "./config.js";
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly method: string,
+    public readonly url: string,
+    public readonly body: string,
+  ) {
+    super(`${method} ${url} → ${status}\n${body}`);
+    this.name = "ApiError";
+  }
+}
+
+export type RequestOptions = {
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  query?: Record<string, string | number | undefined>;
+  body?: unknown;
+  verbose?: boolean;
+};
+
+export async function request<T>(
+  config: ClientConfig,
+  path: string,
+  options: RequestOptions = {},
+): Promise<T> {
+  const method = options.method ?? "GET";
+  const url = new URL(path, `${config.host}/`);
+  if (options.query) {
+    for (const [k, v] of Object.entries(options.query)) {
+      if (v !== undefined) url.searchParams.set(k, String(v));
+    }
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${config.apiKey}`,
+    Accept: "application/json",
+  };
+  if (options.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  if (options.verbose) {
+    console.error(`[http] ${method} ${url.toString()}`);
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new ApiError(response.status, method, url.toString(), text);
+  }
+  if (!text) {
+    return undefined as T;
+  }
+  return JSON.parse(text) as T;
+}
+
+export type Paginated<T> = {
+  count?: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+};
+
+export async function paginate<T>(
+  config: ClientConfig,
+  path: string,
+  options: RequestOptions = {},
+): Promise<T[]> {
+  const collected: T[] = [];
+  let page = await request<Paginated<T>>(config, path, options);
+  collected.push(...page.results);
+  while (page.next) {
+    const nextUrl = new URL(page.next);
+    const nextPath = `${nextUrl.pathname}${nextUrl.search}`;
+    page = await request<Paginated<T>>(config, nextPath, { verbose: options.verbose });
+    collected.push(...page.results);
+  }
+  return collected;
+}

--- a/src/client/insights.ts
+++ b/src/client/insights.ts
@@ -1,0 +1,70 @@
+import type { ClientConfig } from "./config.js";
+import { paginate, request } from "./http.js";
+
+export type ServerInsight = {
+  id: number;
+  short_id: string;
+  name: string;
+  description?: string | null;
+  query?: unknown;
+  tags: string[];
+};
+
+export type InsightCreate = {
+  name: string;
+  description?: string | null;
+  query: unknown;
+  tags?: string[];
+};
+
+export type InsightUpdate = Partial<InsightCreate>;
+
+function insightsPath(projectId: string, suffix = ""): string {
+  return `/api/projects/${projectId}/insights/${suffix}`;
+}
+
+export async function listManagedInsights(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerInsight[]> {
+  const all = await paginate<ServerInsight>(config, insightsPath(config.projectId), {
+    query: { limit: 100 },
+    verbose: options.verbose,
+  });
+  return all.filter((i) => i.tags?.some((tag) => tag.startsWith("iac:insights:")));
+}
+
+export async function getInsight(
+  config: ClientConfig,
+  id: number,
+  options: { verbose?: boolean } = {},
+): Promise<ServerInsight> {
+  return request<ServerInsight>(config, insightsPath(config.projectId, `${id}/`), {
+    verbose: options.verbose,
+  });
+}
+
+export async function createInsight(
+  config: ClientConfig,
+  payload: InsightCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerInsight> {
+  return request<ServerInsight>(config, insightsPath(config.projectId), {
+    method: "POST",
+    body: payload,
+    verbose: options.verbose,
+  });
+}
+
+export async function updateInsight(
+  config: ClientConfig,
+  id: number,
+  payload: InsightUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerInsight> {
+  return request<ServerInsight>(config, insightsPath(config.projectId, `${id}/`), {
+    method: "PATCH",
+    body: payload,
+    verbose: options.verbose,
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,19 @@
+export { dashboard } from "./sdk/dashboard.js";
+export { insight } from "./sdk/insight.js";
+export { text, button } from "./sdk/tiles.js";
+export { trends, hogql } from "./sdk/queries.js";
+export type {
+  Dashboard,
+  Insight,
+  Tile,
+  InsightTile,
+  TextTile,
+  ButtonTile,
+  Layout,
+  Filters,
+  Query,
+  TrendsQuery,
+  HogQLQuery,
+  EventsNode,
+  InsightVizNode,
+} from "./sdk/types.js";

--- a/src/sdk/dashboard.ts
+++ b/src/sdk/dashboard.ts
@@ -1,0 +1,5 @@
+import type { Dashboard } from "./types.js";
+
+export function dashboard(spec: Dashboard): Dashboard {
+  return spec;
+}

--- a/src/sdk/insight.ts
+++ b/src/sdk/insight.ts
@@ -1,0 +1,5 @@
+import type { Insight } from "./types.js";
+
+export function insight(spec: Insight): Insight {
+  return spec;
+}

--- a/src/sdk/queries.ts
+++ b/src/sdk/queries.ts
@@ -1,0 +1,28 @@
+import type { EventsNode, HogQLQuery, TrendsQuery } from "./types.js";
+
+export function trends(spec: {
+  series: EventsNode[];
+  interval?: TrendsQuery["interval"];
+  dateRange?: TrendsQuery["dateRange"];
+  breakdownFilter?: TrendsQuery["breakdownFilter"];
+  trendsFilter?: TrendsQuery["trendsFilter"];
+  properties?: TrendsQuery["properties"];
+}): TrendsQuery {
+  return {
+    kind: "TrendsQuery",
+    series: spec.series.map((node) => ({ kind: "EventsNode", ...node })),
+    ...(spec.interval !== undefined && { interval: spec.interval }),
+    ...(spec.dateRange !== undefined && { dateRange: spec.dateRange }),
+    ...(spec.breakdownFilter !== undefined && { breakdownFilter: spec.breakdownFilter }),
+    ...(spec.trendsFilter !== undefined && { trendsFilter: spec.trendsFilter }),
+    ...(spec.properties !== undefined && { properties: spec.properties }),
+  };
+}
+
+export function hogql(query: string, values?: Record<string, unknown>): HogQLQuery {
+  return {
+    kind: "HogQLQuery",
+    query,
+    ...(values !== undefined && { values }),
+  };
+}

--- a/src/sdk/tiles.ts
+++ b/src/sdk/tiles.ts
@@ -1,0 +1,22 @@
+import type { ButtonTile, Layout, TextTile } from "./types.js";
+
+export function text(spec: { body: string; layout: Layout }): TextTile {
+  return { kind: "text", body: spec.body, layout: spec.layout };
+}
+
+export function button(spec: {
+  url: string;
+  text: string;
+  layout: Layout;
+  placement?: "left" | "right";
+  style?: "primary" | "secondary";
+}): ButtonTile {
+  return {
+    kind: "button",
+    url: spec.url,
+    text: spec.text,
+    layout: spec.layout,
+    placement: spec.placement,
+    style: spec.style,
+  };
+}

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -1,0 +1,98 @@
+export type Layout = { x: number; y: number; w: number; h: number };
+
+export type Filters = Record<string, unknown>;
+
+export type EventsNode = {
+  kind?: "EventsNode";
+  event?: string | null;
+  name?: string;
+  math?: string;
+  math_property?: string;
+  properties?: unknown[];
+  [key: string]: unknown;
+};
+
+export type TrendsQuery = {
+  kind: "TrendsQuery";
+  series: EventsNode[];
+  interval?: "hour" | "day" | "week" | "month";
+  dateRange?: { date_from?: string; date_to?: string };
+  breakdownFilter?: Record<string, unknown>;
+  trendsFilter?: Record<string, unknown>;
+  properties?: unknown[];
+  [key: string]: unknown;
+};
+
+export type HogQLQuery = {
+  kind: "HogQLQuery";
+  query: string;
+  values?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type InsightVizNode = {
+  kind: "InsightVizNode";
+  source: TrendsQuery;
+};
+
+export type Query = TrendsQuery | HogQLQuery;
+
+export type Insight = {
+  key: string;
+  name: string;
+  description?: string;
+  query: Query;
+  tags?: string[];
+};
+
+export type InsightTile = {
+  insight: Insight;
+  layout: Layout;
+  color?: string;
+  filtersOverride?: Filters;
+  showDescription?: boolean;
+  transparent?: boolean;
+};
+
+export type TextTile = {
+  kind: "text";
+  body: string;
+  layout: Layout;
+};
+
+export type ButtonTile = {
+  kind: "button";
+  url: string;
+  text: string;
+  placement?: "left" | "right";
+  style?: "primary" | "secondary";
+  layout: Layout;
+};
+
+export type Tile = InsightTile | TextTile | ButtonTile;
+
+export type Dashboard = {
+  key: string;
+  name: string;
+  description?: string;
+  pinned?: boolean;
+  tags?: string[];
+  filters?: Filters;
+  variables?: Record<string, unknown>;
+  restriction?: "everyone" | "collaborators";
+  breakdownColors?: Array<{ value: string; color: string }>;
+  dataColorThemeKey?: string;
+  tiles: Tile[];
+};
+
+export function isInsightTile(tile: Tile): tile is InsightTile {
+  return "insight" in tile;
+}
+
+export function isTextTile(tile: Tile): tile is TextTile {
+  return "kind" in tile && tile.kind === "text";
+}
+
+export function isButtonTile(tile: Tile): tile is ButtonTile {
+  return "kind" in tile && tile.kind === "button";
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

First implementation pass at the MVP: `npx posthog-definitions apply` for dashboards (with inline insights) plus the SDK surface they're built on. Identity is tag-based per the design in `docs/implementation/identity.md`; the safety invariant (only touch resources we tagged) is enforced in three places.

What's in:

- **SDK** (`src/sdk/`) — `dashboard`, `insight`, `text`, `button`, `trends`, `hogql` factories returning plain objects. Loose types around the query shapes so we don't have to vendor `posthog.schema` for MVP.
- **API client** (`src/client/`) — hand-rolled, only the dashboards and insights endpoints. `loadConfig()` fails fast (exit 3) if `POSTHOG_PERSONAL_API_KEY` / `POSTHOG_PROJECT_ID` are missing. `listManaged*` filters `iac:*`-tagged resources client-side (risks R3 fallback).
- **Apply pipeline** (`src/apply/`) — `load → validate → diff → execute`, plus canonical-hash skip via the `iac:hash:<prefix>` tag. The executor re-fetches every target right before any `PATCH` and aborts with `SafetyViolationError` if the identity tag has gone missing.
- **CLI** (`src/cli/`) — `apply` with `--dry-run`, `--verbose`, `--dir`, `--project`, `--host`. Exit codes per the spec.
- **Dev credentials via direnv** — `.envrc.example` (committed) + gitignored `.envrc`; `direnv allow` makes credentials available without putting them in shell history.
- **Example dashboard** under `examples/posthog/dashboards/growth.ts` for end-to-end manual testing.

What's not in (deferred, see `docs/implementation/mvp-roadmap.md`):

- Automated test suite — verified manually against a dev project for the first ship.
- `dev` watch mode, `pull`, `--prune`, multi-env configs.
- Generated API client and the `posthog.schema` import (loose types for now).

## Test plan

- [ ] `pnpm install` after the Node upgrade (current system Node is too old for the pinned pnpm).
- [ ] `pnpm typecheck`.
- [ ] `cp .envrc.example .envrc`, fill in dev-project key + id, `direnv allow`.
- [ ] `pnpm dev apply --dir examples/posthog --dry-run` prints a plan with 2 insights + 1 dashboard to create.
- [ ] `pnpm dev apply --dir examples/posthog` creates them; verify the dashboard renders in the PostHog UI.
- [ ] Re-run — second pass reports everything `unchanged` (hash-skip works).
- [ ] Edit a name or query in `growth.ts`, re-run — exactly one resource updated.
- [ ] Pre-create a hand-built dashboard in the same project; run `apply`; confirm it's untouched (safety invariant).
- [ ] Manually strip the `iac:dashboards:growth` tag in the UI, re-run — CLI exits 2 with the safety-violation message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)