### PR TITLE
feat: OAuth login flow with stored credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dist/
 # Claude Code per-project state — track shared skills, ignore local settings
 .claude/*
 !.claude/skills/
+
+# Local pull output from the user's own PostHog project (root only;
+# examples/*/posthog/ are still tracked).
+/posthog/

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,9 +52,23 @@ docs/
 
 Pre-MVP. The MVP scope is **dashboard synchronization via `npx posthog-definitions apply`** — see [`implementation/mvp-roadmap.md`](implementation/mvp-roadmap.md).
 
+## Authentication
+
+```
+$ npx posthog-definitions login
+```
+
+Opens a browser, completes a PKCE OAuth flow against `https://us.posthog.com` (or `--host https://eu.posthog.com`), and prompts you to pick a project. Credentials are saved to `$XDG_CONFIG_HOME/posthog-definitions/config.json` (default `~/.config/posthog-definitions/config.json`) with mode `0600`. Subsequent `apply` / `pull` runs read from that file and auto-refresh the access token.
+
+The CLI uses the CIMD (Client ID Metadata Document) pattern — the same one `posthog/wizard` uses. The `client_id` is `${host}/api/oauth/posthog-definitions/client-metadata`. No DB row needs to be created up-front on the PostHog backend; the OAuth server fetches the metadata document on first authorize and auto-creates the application record.
+
+To switch projects without re-authenticating: `npx posthog-definitions login --switch-project`. To clear credentials: `npx posthog-definitions logout`.
+
+For CI and automation, set `POSTHOG_PERSONAL_API_KEY` and `POSTHOG_PROJECT_ID` in the environment — they take precedence over the stored OAuth token, so existing setups keep working.
+
 ## Local development
 
-This repo uses [direnv](https://direnv.net/) to load PostHog credentials for testing `apply` against a dev project:
+For testing `apply` against a dev project, you can either run `posthog-definitions login` or use [direnv](https://direnv.net/) to load a personal API key:
 
 ```
 cp .envrc.example .envrc
@@ -62,4 +76,4 @@ cp .envrc.example .envrc
 direnv allow
 ```
 
-`.envrc` is gitignored. The CLI reads `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID`, and optionally `POSTHOG_HOST` from the environment — direnv just keeps them out of your shell history and out of git.
+`.envrc` is gitignored. Resolution order for each setting: `--project` / `--host` CLI flag → `POSTHOG_*` env var → stored OAuth config.

--- a/src/apply/execute.test.ts
+++ b/src/apply/execute.test.ts
@@ -8,7 +8,7 @@ import { execute, fetchCurrentState, SafetyViolationError } from "./execute.js";
 const FAKE_CONFIG: ClientConfig = {
   host: "https://test.example",
   projectId: "1",
-  apiKey: "test",
+  auth: { getHeader: () => "Bearer test" },
 };
 
 function diffOf(byResource: Record<string, ResourceDiff<unknown, unknown>>): DiffResult {

--- a/src/auth/clients.ts
+++ b/src/auth/clients.ts
@@ -1,0 +1,34 @@
+// OAuth client identification for posthog-definitions.
+//
+// This CLI uses the CIMD (Client ID Metadata Document) pattern — the same one
+// `posthog/wizard` uses. Our client_id is the URL where PostHog serves the
+// metadata document, e.g.:
+//   https://us.posthog.com/api/oauth/posthog-definitions/client-metadata
+//
+// On first authorize call against a region, the PostHog backend fetches the
+// document, caches it, and auto-creates an OAuthApplication row tagged as a
+// CIMD client. No DB migration is required.
+//
+// Backend prerequisite: PostHog must expose the metadata document at
+// `${SITE_URL}/api/oauth/posthog-definitions/client-metadata`. See
+// `posthog/posthog/api/oauth/wizard_metadata.py` for the pattern to copy. The
+// document must register `http://localhost/callback` (portless) as a redirect
+// URI so the OAuth validator's loopback port-flexibility logic accepts any of
+// our ephemeral callback ports at runtime.
+const CIMD_PATH = "/api/oauth/posthog-definitions/client-metadata";
+
+export const OAUTH_REDIRECT_PORTS = [8239, 8238, 8240, 8237, 8236, 8235] as const;
+
+export const OAUTH_SCOPES = [
+  "user:read",
+  "project:read",
+  "organization:read",
+  "dashboard:write",
+  "insight:write",
+].join(" ");
+
+export function resolveClientId(host: string): string {
+  const override = process.env.POSTHOG_OAUTH_CLIENT_ID;
+  if (override) return override;
+  return `${host.replace(/\/$/, "")}${CIMD_PATH}`;
+}

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -1,0 +1,282 @@
+import { spawn } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { AddressInfo } from "node:net";
+import { OAUTH_REDIRECT_PORTS, OAUTH_SCOPES } from "./clients.js";
+
+export type OAuthTokens = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number; // Unix seconds
+  scope: string;
+  tokenType: string;
+};
+
+export type LoginOptions = {
+  host: string;
+  clientId: string;
+  // How long to wait for the callback before giving up. Default 360s.
+  timeoutMs?: number;
+  // Called with the URL the user should open in their browser. Defaults to
+  // launching the system browser.
+  openUrl?: (url: string) => void;
+};
+
+export class OAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OAuthError";
+  }
+}
+
+export async function performOAuthFlow(opts: LoginOptions): Promise<OAuthTokens> {
+  const verifier = base64url(randomBytes(32));
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+  const state = base64url(randomBytes(16));
+
+  const { server, port } = await bindLoopback();
+  const redirectUri = `http://localhost:${port}/callback`;
+
+  const authorizeUrl = new URL(`${opts.host}/oauth/authorize`);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set("client_id", opts.clientId);
+  authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizeUrl.searchParams.set("code_challenge", challenge);
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+  authorizeUrl.searchParams.set("scope", OAUTH_SCOPES);
+  authorizeUrl.searchParams.set("state", state);
+
+  console.error(`Opening browser for PostHog login: ${authorizeUrl.toString()}`);
+  if (opts.openUrl) {
+    opts.openUrl(authorizeUrl.toString());
+  } else {
+    openBrowser(authorizeUrl.toString());
+  }
+
+  let code: string;
+  try {
+    code = await waitForCallback(server, state, opts.timeoutMs ?? 360_000);
+  } finally {
+    server.close();
+  }
+
+  return exchangeCode({
+    host: opts.host,
+    clientId: opts.clientId,
+    code,
+    verifier,
+    redirectUri,
+  });
+}
+
+export async function refreshAccessToken(
+  refreshToken: string,
+  host: string,
+  clientId: string,
+): Promise<OAuthTokens> {
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: clientId,
+  });
+  const response = await fetch(`${host}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+    body: body.toString(),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new OAuthError(
+      `Token refresh failed: ${response.status} ${response.statusText}\n${text}`,
+    );
+  }
+  return parseTokenResponse(text, refreshToken);
+}
+
+async function exchangeCode(args: {
+  host: string;
+  clientId: string;
+  code: string;
+  verifier: string;
+  redirectUri: string;
+}): Promise<OAuthTokens> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: args.code,
+    redirect_uri: args.redirectUri,
+    client_id: args.clientId,
+    code_verifier: args.verifier,
+  });
+  const response = await fetch(`${args.host}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+    body: body.toString(),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new OAuthError(
+      `Token exchange failed: ${response.status} ${response.statusText}\n${text}`,
+    );
+  }
+  return parseTokenResponse(text);
+}
+
+function parseTokenResponse(text: string, fallbackRefresh?: string): OAuthTokens {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    throw new OAuthError(`Token endpoint returned non-JSON: ${text.slice(0, 200)}`);
+  }
+  const accessToken = parsed.access_token;
+  const refreshToken = parsed.refresh_token ?? fallbackRefresh;
+  const expiresIn = parsed.expires_in;
+  if (typeof accessToken !== "string" || accessToken.length === 0) {
+    throw new OAuthError("Token response missing access_token.");
+  }
+  if (typeof refreshToken !== "string" || refreshToken.length === 0) {
+    throw new OAuthError("Token response missing refresh_token.");
+  }
+  if (typeof expiresIn !== "number" || expiresIn <= 0) {
+    throw new OAuthError("Token response missing expires_in.");
+  }
+  return {
+    accessToken,
+    refreshToken,
+    expiresAt: Math.floor(Date.now() / 1000) + expiresIn,
+    scope: typeof parsed.scope === "string" ? parsed.scope : "",
+    tokenType: typeof parsed.token_type === "string" ? parsed.token_type : "Bearer",
+  };
+}
+
+async function bindLoopback(): Promise<{ server: Server; port: number }> {
+  for (const port of OAUTH_REDIRECT_PORTS) {
+    try {
+      const server = await listenOn(port);
+      return { server, port };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EADDRINUSE") continue;
+      throw err;
+    }
+  }
+  throw new OAuthError(
+    `Could not bind any of the loopback ports ${OAUTH_REDIRECT_PORTS.join(", ")}. ` +
+      `Free one of them and try again.`,
+  );
+}
+
+function listenOn(port: number): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    const onError = (err: NodeJS.ErrnoException): void => {
+      server.removeListener("listening", onListening);
+      reject(err);
+    };
+    const onListening = (): void => {
+      server.removeListener("error", onError);
+      const addr = server.address() as AddressInfo | null;
+      if (!addr || addr.port !== port) {
+        server.close();
+        reject(new Error(`Bound to wrong port: expected ${port}, got ${addr?.port ?? "null"}`));
+        return;
+      }
+      resolve(server);
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+function waitForCallback(
+  server: Server,
+  expectedState: string,
+  timeoutMs: number,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      server.removeListener("request", handler);
+      reject(new OAuthError(`Timed out waiting for OAuth callback after ${timeoutMs}ms.`));
+    }, timeoutMs);
+
+    const handler = (req: IncomingMessage, res: ServerResponse): void => {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      if (url.pathname !== "/callback") {
+        res.statusCode = 404;
+        res.end("Not Found");
+        return;
+      }
+      const error = url.searchParams.get("error");
+      const code = url.searchParams.get("code");
+      const state = url.searchParams.get("state");
+
+      if (error) {
+        respondHtml(res, 400, "Login failed", `PostHog returned an error: ${escapeHtml(error)}.`);
+        clearTimeout(timer);
+        server.removeListener("request", handler);
+        reject(new OAuthError(`OAuth error: ${error}`));
+        return;
+      }
+      if (!code || !state) {
+        respondHtml(res, 400, "Login failed", "Missing code or state parameter.");
+        clearTimeout(timer);
+        server.removeListener("request", handler);
+        reject(new OAuthError("Callback missing code or state."));
+        return;
+      }
+      if (state !== expectedState) {
+        respondHtml(res, 400, "Login failed", "State mismatch — possible CSRF.");
+        clearTimeout(timer);
+        server.removeListener("request", handler);
+        reject(new OAuthError("State mismatch in OAuth callback."));
+        return;
+      }
+      respondHtml(res, 200, "Logged in", "You can close this tab and return to your terminal.");
+      clearTimeout(timer);
+      server.removeListener("request", handler);
+      resolve(code);
+    };
+
+    server.on("request", handler);
+  });
+}
+
+function respondHtml(res: ServerResponse, status: number, title: string, body: string): void {
+  const html = `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>
+<style>body{font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#f6f6f6;color:#222}main{max-width:480px;padding:32px;background:#fff;border-radius:12px;box-shadow:0 4px 20px rgba(0,0,0,0.08);text-align:center}h1{margin-top:0}</style>
+</head><body><main><h1>${escapeHtml(title)}</h1><p>${escapeHtml(body)}</p></main></body></html>`;
+  res.statusCode = status;
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.end(html);
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function openBrowser(url: string): void {
+  const platform = process.platform;
+  const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
+  const args = platform === "win32" ? ["", url] : [url];
+  try {
+    const child = spawn(cmd, args, {
+      stdio: "ignore",
+      detached: true,
+      shell: platform === "win32",
+    });
+    child.on("error", () => {
+      // Browser launcher missing — the URL is already printed to stderr.
+    });
+    child.unref();
+  } catch {
+    // Already logged the URL; user can copy it manually.
+  }
+}

--- a/src/auth/store.test.ts
+++ b/src/auth/store.test.ts
@@ -1,0 +1,70 @@
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearStore, readStore, storePath, writeStore, type StoredAuth } from "./store.js";
+
+const SAMPLE: StoredAuth = {
+  host: "https://us.posthog.com",
+  projectId: "42",
+  accessToken: "access-xyz",
+  refreshToken: "refresh-xyz",
+  expiresAt: 1_700_000_000,
+  clientId: "client-abc",
+};
+
+let dir: string;
+let original: string | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "posthog-defs-store-"));
+  original = process.env.POSTHOG_DEFINITIONS_CONFIG_DIR;
+  process.env.POSTHOG_DEFINITIONS_CONFIG_DIR = dir;
+});
+
+afterEach(() => {
+  if (original === undefined) delete process.env.POSTHOG_DEFINITIONS_CONFIG_DIR;
+  else process.env.POSTHOG_DEFINITIONS_CONFIG_DIR = original;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("store", () => {
+  it("returns undefined when no config file exists", () => {
+    expect(readStore()).toBeUndefined();
+  });
+
+  it("round-trips StoredAuth via write+read", () => {
+    writeStore(SAMPLE);
+    expect(readStore()).toEqual(SAMPLE);
+  });
+
+  it("writes the config file with mode 0600", () => {
+    writeStore(SAMPLE);
+    const mode = statSync(storePath()).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("places the file under the override directory", () => {
+    expect(storePath()).toBe(path.join(dir, "config.json"));
+  });
+
+  it("clearStore deletes an existing file and returns true", () => {
+    writeStore(SAMPLE);
+    expect(clearStore()).toBe(true);
+    expect(readStore()).toBeUndefined();
+  });
+
+  it("clearStore returns false when no file exists", () => {
+    expect(clearStore()).toBe(false);
+  });
+
+  it("rejects a malformed config", () => {
+    writeFileSync(storePath(), "not json at all", { mode: 0o600 });
+    expect(() => readStore()).toThrow(/Failed to parse/);
+  });
+
+  it("rejects a config missing required fields", () => {
+    writeFileSync(storePath(), JSON.stringify({ host: "x" }), { mode: 0o600 });
+    expect(() => readStore()).toThrow(/not a valid/);
+  });
+});

--- a/src/auth/store.ts
+++ b/src/auth/store.ts
@@ -1,0 +1,82 @@
+import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export type StoredAuth = {
+  host: string;
+  projectId: string;
+  accessToken: string;
+  refreshToken: string;
+  // Unix seconds when the access token expires.
+  expiresAt: number;
+  clientId: string;
+};
+
+export class StoreError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StoreError";
+  }
+}
+
+export function storePath(): string {
+  const override = process.env.POSTHOG_DEFINITIONS_CONFIG_DIR;
+  if (override) return path.join(override, "config.json");
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const base = xdg && xdg.length > 0 ? xdg : path.join(homedir(), ".config");
+  return path.join(base, "posthog-definitions", "config.json");
+}
+
+export function readStore(): StoredAuth | undefined {
+  const file = storePath();
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw new StoreError(`Failed to read ${file}: ${(err as Error).message}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new StoreError(`Failed to parse ${file}: ${(err as Error).message}`);
+  }
+  if (!isStoredAuth(parsed)) {
+    throw new StoreError(`${file} is not a valid posthog-definitions config.`);
+  }
+  return parsed;
+}
+
+export function writeStore(auth: StoredAuth): void {
+  const file = storePath();
+  const dir = path.dirname(file);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(file, JSON.stringify(auth, null, 2), { mode: 0o600 });
+  // writeFileSync only sets the mode on file creation; force it for overwrites.
+  chmodSync(file, 0o600);
+}
+
+export function clearStore(): boolean {
+  const file = storePath();
+  try {
+    rmSync(file);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw new StoreError(`Failed to delete ${file}: ${(err as Error).message}`);
+  }
+}
+
+function isStoredAuth(value: unknown): value is StoredAuth {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.host === "string" &&
+    typeof v.projectId === "string" &&
+    typeof v.accessToken === "string" &&
+    typeof v.refreshToken === "string" &&
+    typeof v.expiresAt === "number" &&
+    typeof v.clientId === "string"
+  );
+}

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -19,7 +19,7 @@ export async function runApply(args: ApplyArgs): Promise<number> {
   debug("loading config", { host: overrides.host, project: overrides.projectId });
   let config;
   try {
-    config = loadConfig(overrides);
+    config = await loadConfig(overrides);
   } catch (err) {
     if (err instanceof ConfigError) {
       console.error(`error: ${err.message}`);

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -21,9 +21,17 @@ export type PullArgs = {
   project?: string;
 };
 
+export type LoginArgs = {
+  command: "login";
+  switchProject: boolean;
+  host?: string;
+};
+
+export type LogoutArgs = { command: "logout" };
+
 export type HelpArgs = { command: "help" };
 
-export type ParsedArgs = ApplyArgs | PullArgs | HelpArgs;
+export type ParsedArgs = ApplyArgs | PullArgs | LoginArgs | LogoutArgs | HelpArgs;
 
 const SUPPORTED_PULL_KINDS: readonly PullKind[] = ["dashboards"];
 
@@ -42,7 +50,41 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const command = argv[0];
   if (command === "apply") return parseApply(argv);
   if (command === "pull") return parsePull(argv);
+  if (command === "login") return parseLogin(argv);
+  if (command === "logout") return parseLogout(argv);
   throw new ArgError(`Unknown command "${command}". Run "posthog-definitions help" for usage.`);
+}
+
+function parseLogin(argv: string[]): LoginArgs {
+  const args: LoginArgs = { command: "login", switchProject: false };
+  for (let i = 1; i < argv.length; i++) {
+    const flag = argv[i];
+    switch (flag) {
+      case "--switch-project":
+        args.switchProject = true;
+        break;
+      case "--host":
+        args.host = expectValue(argv, ++i, flag);
+        break;
+      case "--help":
+      case "-h":
+        throw new ArgError("Run 'posthog-definitions help' for usage.");
+      default:
+        throw new ArgError(`Unknown flag: ${flag}`);
+    }
+  }
+  return args;
+}
+
+function parseLogout(argv: string[]): LogoutArgs {
+  for (let i = 1; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === "--help" || flag === "-h") {
+      throw new ArgError("Run 'posthog-definitions help' for usage.");
+    }
+    throw new ArgError(`Unknown flag: ${flag}`);
+  }
+  return { command: "logout" };
 }
 
 function parseApply(argv: string[]): ApplyArgs {
@@ -157,16 +199,22 @@ function expectValue(argv: string[], index: number, flag: string): string {
 export const HELP_TEXT = `posthog-definitions — IaC for PostHog dashboards and insights
 
 Usage:
-  posthog-definitions apply [flags]
-  posthog-definitions pull  [flags]
+  posthog-definitions login  [flags]
+  posthog-definitions logout
+  posthog-definitions apply  [flags]
+  posthog-definitions pull   [flags]
 
 Common flags:
   --dry-run            Compute the plan but make no changes.
   --verbose, -v        Log each HTTP call.
   --dir <path>         Definitions directory (default: posthog).
-  --project <id>       Override POSTHOG_PROJECT_ID.
-  --host <url>         Override POSTHOG_HOST (default: https://us.posthog.com).
+  --project <id>       Override the stored project (or POSTHOG_PROJECT_ID).
+  --host <url>         Override the stored host (or POSTHOG_HOST).
   --help, -h           Show this help.
+
+Login flags:
+  --host <url>         Skip the host picker and use this host.
+  --switch-project     Re-run the project picker against the existing token.
 
 Apply flags:
   --prune              Delete IaC-tagged resources that no longer have a
@@ -181,9 +229,18 @@ Pull flags:
   --all                Skip the interactive picker and import everything.
                        (Required when stdin is not a TTY.)
 
+Authentication:
+  Run \`posthog-definitions login\` once to authenticate via OAuth in your
+  browser and pick a project. Credentials are saved to
+  $XDG_CONFIG_HOME/posthog-definitions/config.json (default
+  ~/.config/posthog-definitions/config.json) with mode 0600.
+
+  For CI/automation, set POSTHOG_PERSONAL_API_KEY and POSTHOG_PROJECT_ID;
+  env vars take precedence over the stored OAuth token.
+
 Environment:
-  POSTHOG_PERSONAL_API_KEY   Required. Personal API key with dashboard:read/write
-                             and insight:read/write scopes.
-  POSTHOG_PROJECT_ID         Required. Numeric project id.
-  POSTHOG_HOST               Optional. Defaults to https://us.posthog.com.
+  POSTHOG_PERSONAL_API_KEY   Optional. Personal API key (used by CI).
+  POSTHOG_PROJECT_ID         Optional. Numeric project id (overrides store).
+  POSTHOG_HOST               Optional. Overrides host (default: https://us.posthog.com).
+  POSTHOG_OAUTH_CLIENT_ID    Optional. Override the OAuth client ID (testing).
 `;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { runApply } from "./apply.js";
 import { ArgError, HELP_TEXT, parseArgs } from "./args.js";
+import { runLogin, runLogout } from "./login.js";
 import { runPull } from "./pull.js";
 
 export async function main(argv: string[]): Promise<void> {
@@ -22,8 +23,23 @@ export async function main(argv: string[]): Promise<void> {
     process.exit(0);
   }
 
-  const code = parsed.command === "apply" ? await runApply(parsed) : await runPull(parsed);
+  const code = await dispatch(parsed);
   process.exit(code);
+}
+
+async function dispatch(
+  parsed: Exclude<ReturnType<typeof parseArgs>, { command: "help" }>,
+): Promise<number> {
+  switch (parsed.command) {
+    case "apply":
+      return runApply(parsed);
+    case "pull":
+      return runPull(parsed);
+    case "login":
+      return runLogin(parsed);
+    case "logout":
+      return runLogout(parsed);
+  }
 }
 
 // Resolve both sides through realpath so symlinked invocations (pnpm workspace,

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -1,0 +1,201 @@
+import enquirer from "enquirer";
+import { resolveClientId } from "../auth/clients.js";
+import { OAuthError, performOAuthFlow, refreshAccessToken } from "../auth/oauth.js";
+import { clearStore, readStore, storePath, writeStore, type StoredAuth } from "../auth/store.js";
+import type { LoginArgs, LogoutArgs } from "./args.js";
+
+type Project = { id: number; name: string };
+
+const DEFAULT_HOST = "https://us.posthog.com";
+const HOST_CHOICES: ReadonlyArray<{ label: string; value: string }> = [
+  { label: "US Cloud (https://us.posthog.com)", value: DEFAULT_HOST },
+  { label: "EU Cloud (https://eu.posthog.com)", value: "https://eu.posthog.com" },
+];
+
+export async function runLogin(args: LoginArgs): Promise<number> {
+  const existing = safeReadStore();
+
+  if (args.switchProject) {
+    if (!existing) {
+      console.error("error: no stored credentials. Run `posthog-definitions login` first.");
+      return 3;
+    }
+    const refreshed = await ensureFreshToken(existing);
+    const projects = await fetchProjects(refreshed);
+    const picked = await pickProject(projects, existing.projectId);
+    if (!picked) return 3;
+    writeStore({ ...refreshed, projectId: String(picked.id) });
+    console.error(`Selected project: ${picked.name} (${picked.id}).`);
+    console.error(`Saved to ${storePath()}.`);
+    return 0;
+  }
+
+  const host = args.host ?? (await pickHost(existing?.host));
+  const clientId = resolveClientId(host);
+
+  let tokens;
+  try {
+    tokens = await performOAuthFlow({ host, clientId });
+  } catch (err) {
+    if (err instanceof OAuthError) {
+      console.error(`error: ${err.message}`);
+      return 3;
+    }
+    throw err;
+  }
+
+  const partial: StoredAuth = {
+    host,
+    projectId: existing?.projectId ?? "",
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+    clientId,
+  };
+
+  let projects: Project[];
+  try {
+    projects = await fetchProjects(partial);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`error: failed to list projects: ${msg}`);
+    return 1;
+  }
+
+  if (projects.length === 0) {
+    console.error("error: your account has no accessible projects on this host.");
+    return 1;
+  }
+
+  const picked = await pickProject(projects, existing?.projectId);
+  if (!picked) return 3;
+
+  writeStore({ ...partial, projectId: String(picked.id) });
+  console.error(`Logged in. Project: ${picked.name} (${picked.id}).`);
+  console.error(`Saved to ${storePath()}.`);
+  return 0;
+}
+
+export async function runLogout(_: LogoutArgs): Promise<number> {
+  const removed = clearStore();
+  if (removed) {
+    console.error(`Cleared ${storePath()}.`);
+  } else {
+    console.error("No stored credentials to clear.");
+  }
+  return 0;
+}
+
+async function pickHost(currentHost: string | undefined): Promise<string> {
+  const choices = HOST_CHOICES.map((c) => ({ name: c.value, message: c.label }));
+  choices.push({ name: "__custom__", message: "Custom URL…" });
+  const defaultName = currentHost ?? DEFAULT_HOST;
+  const initialIndex = Math.max(
+    0,
+    choices.findIndex((c) => c.name === defaultName),
+  );
+
+  let answer: { host: string };
+  try {
+    answer = await enquirer.prompt<{ host: string }>({
+      type: "select",
+      name: "host",
+      message: "PostHog host",
+      choices,
+      initial: initialIndex,
+    } as Parameters<typeof enquirer.prompt>[0]);
+  } catch {
+    throw new Error("Host selection aborted.");
+  }
+
+  if (answer.host !== "__custom__") return answer.host;
+
+  let custom: { url: string };
+  try {
+    custom = await enquirer.prompt<{ url: string }>({
+      type: "input",
+      name: "url",
+      message: "Custom host URL",
+      initial: currentHost ?? "https://",
+    } as Parameters<typeof enquirer.prompt>[0]);
+  } catch {
+    throw new Error("Host entry aborted.");
+  }
+  return custom.url.replace(/\/$/, "");
+}
+
+async function pickProject(
+  projects: Project[],
+  currentId: string | undefined,
+): Promise<Project | undefined> {
+  const sorted = [...projects].sort((a, b) => a.name.localeCompare(b.name));
+  const choices = sorted.map((p) => ({
+    name: String(p.id),
+    message: p.name || `(untitled #${p.id})`,
+    hint: `#${p.id}`,
+  }));
+  const initialIndex = currentId
+    ? Math.max(
+        0,
+        choices.findIndex((c) => c.name === currentId),
+      )
+    : 0;
+
+  try {
+    const answer = await enquirer.prompt<{ project: string }>({
+      type: "autocomplete",
+      name: "project",
+      message: `Select a project (${projects.length} total)`,
+      limit: 15,
+      choices,
+      initial: initialIndex,
+      footer: "type to search · enter to confirm",
+    } as Parameters<typeof enquirer.prompt>[0]);
+    return sorted.find((p) => String(p.id) === answer.project);
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchProjects(store: StoredAuth): Promise<Project[]> {
+  // /api/projects/ is not in the codegen filter, so issue raw fetches here.
+  type Page = { next: string | null; results: Project[] };
+  const all: Project[] = [];
+  let url: string | null = `${store.host}/api/projects/`;
+  while (url) {
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${store.accessToken}`, Accept: "application/json" },
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`HTTP ${response.status}: ${body}`);
+    }
+    const page = (await response.json()) as Page;
+    for (const p of page.results) all.push({ id: p.id, name: p.name });
+    url = page.next;
+  }
+  return all;
+}
+
+async function ensureFreshToken(store: StoredAuth): Promise<StoredAuth> {
+  const now = Math.floor(Date.now() / 1000);
+  if (store.expiresAt - 60 > now) return store;
+  const next = await refreshAccessToken(store.refreshToken, store.host, store.clientId);
+  const updated: StoredAuth = {
+    ...store,
+    accessToken: next.accessToken,
+    refreshToken: next.refreshToken,
+    expiresAt: next.expiresAt,
+  };
+  writeStore(updated);
+  return updated;
+}
+
+function safeReadStore(): StoredAuth | undefined {
+  try {
+    return readStore();
+  } catch (err) {
+    console.error(`warning: could not read stored credentials (${(err as Error).message}).`);
+    return undefined;
+  }
+}

--- a/src/cli/pull.ts
+++ b/src/cli/pull.ts
@@ -14,7 +14,7 @@ export async function runPull(args: PullArgs): Promise<number> {
 
   let config;
   try {
-    config = loadConfig(overrides);
+    config = await loadConfig(overrides);
   } catch (err) {
     if (err instanceof ConfigError) {
       console.error(`error: ${err.message}`);

--- a/src/client/config.test.ts
+++ b/src/client/config.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { writeStore, type StoredAuth } from "../auth/store.js";
+import { ConfigError, loadConfig } from "./config.js";
+
+const SAMPLE: StoredAuth = {
+  host: "https://eu.posthog.com",
+  projectId: "99",
+  accessToken: "stored-token",
+  refreshToken: "stored-refresh",
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+  clientId: "stored-client",
+};
+
+let dir: string;
+const ENV_KEYS = [
+  "POSTHOG_DEFINITIONS_CONFIG_DIR",
+  "POSTHOG_PERSONAL_API_KEY",
+  "POSTHOG_PROJECT_ID",
+  "POSTHOG_HOST",
+] as const;
+const originals: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "posthog-defs-config-"));
+  for (const k of ENV_KEYS) {
+    originals[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.POSTHOG_DEFINITIONS_CONFIG_DIR = dir;
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originals[k] === undefined) delete process.env[k];
+    else process.env[k] = originals[k];
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("loadConfig", () => {
+  it("uses env-var personal key when set, ignoring any stored OAuth token", async () => {
+    writeStore(SAMPLE);
+    process.env.POSTHOG_PERSONAL_API_KEY = "env-key";
+    process.env.POSTHOG_PROJECT_ID = "7";
+    const c = await loadConfig();
+    expect(c.projectId).toBe("7");
+    expect(await c.auth.getHeader()).toBe("Bearer env-key");
+    expect(c.auth.refreshOnUnauthorized).toBeUndefined();
+  });
+
+  it("falls back to the stored OAuth token when no env key is set", async () => {
+    writeStore(SAMPLE);
+    const c = await loadConfig();
+    expect(c.host).toBe(SAMPLE.host);
+    expect(c.projectId).toBe(SAMPLE.projectId);
+    expect(await c.auth.getHeader()).toBe(`Bearer ${SAMPLE.accessToken}`);
+    expect(typeof c.auth.refreshOnUnauthorized).toBe("function");
+  });
+
+  it("prefers CLI overrides over env vars and store", async () => {
+    writeStore(SAMPLE);
+    process.env.POSTHOG_PROJECT_ID = "env-project";
+    process.env.POSTHOG_HOST = "https://env.posthog.com";
+    const c = await loadConfig({ projectId: "cli-project", host: "https://cli.posthog.com" });
+    expect(c.projectId).toBe("cli-project");
+    expect(c.host).toBe("https://cli.posthog.com");
+  });
+
+  it("env vars beat the store but lose to CLI overrides", async () => {
+    writeStore(SAMPLE);
+    process.env.POSTHOG_PROJECT_ID = "env-project";
+    const c = await loadConfig();
+    expect(c.projectId).toBe("env-project");
+  });
+
+  it("throws ConfigError when no credentials anywhere", async () => {
+    await expect(loadConfig({ projectId: "1" })).rejects.toThrow(ConfigError);
+    await expect(loadConfig({ projectId: "1" })).rejects.toThrow(/No credentials/);
+  });
+
+  it("throws ConfigError when no project anywhere", async () => {
+    process.env.POSTHOG_PERSONAL_API_KEY = "env-key";
+    await expect(loadConfig()).rejects.toThrow(ConfigError);
+    await expect(loadConfig()).rejects.toThrow(/No project/);
+  });
+
+  it("strips a trailing slash from the host", async () => {
+    process.env.POSTHOG_PERSONAL_API_KEY = "env-key";
+    process.env.POSTHOG_PROJECT_ID = "7";
+    const c = await loadConfig({ host: "https://cli.posthog.com/" });
+    expect(c.host).toBe("https://cli.posthog.com");
+  });
+});

--- a/src/client/config.ts
+++ b/src/client/config.ts
@@ -1,7 +1,17 @@
+import { refreshAccessToken } from "../auth/oauth.js";
+import { readStore, writeStore, type StoredAuth } from "../auth/store.js";
+
+export type AuthHandler = {
+  /** Returns the value for the `Authorization` header on each request. */
+  getHeader(): Promise<string> | string;
+  /** Called when the server returns 401. Returns true if the handler refreshed and the caller should retry once. */
+  refreshOnUnauthorized?(): Promise<boolean>;
+};
+
 export type ClientConfig = {
   host: string;
   projectId: string;
-  apiKey: string;
+  auth: AuthHandler;
 };
 
 export type ConfigOverrides = {
@@ -10,6 +20,8 @@ export type ConfigOverrides = {
 };
 
 const DEFAULT_HOST = "https://us.posthog.com";
+// Refresh OAuth tokens this many seconds before they expire to avoid races.
+const REFRESH_LEEWAY_SECONDS = 60;
 
 export class ConfigError extends Error {
   constructor(message: string) {
@@ -18,22 +30,81 @@ export class ConfigError extends Error {
   }
 }
 
-export function loadConfig(overrides: ConfigOverrides = {}): ClientConfig {
-  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
-  if (!apiKey) {
-    throw new ConfigError(
-      "POSTHOG_PERSONAL_API_KEY is not set. Add it to .envrc (and run `direnv allow`) or export it in your shell.",
-    );
-  }
+export async function loadConfig(overrides: ConfigOverrides = {}): Promise<ClientConfig> {
+  const envApiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const envProjectId = process.env.POSTHOG_PROJECT_ID;
+  const envHost = process.env.POSTHOG_HOST;
 
-  const projectId = overrides.projectId ?? process.env.POSTHOG_PROJECT_ID;
+  const store = readStore();
+
+  // Host: CLI override > env var > store > default.
+  const host = normalizeHost(overrides.host ?? envHost ?? store?.host ?? DEFAULT_HOST);
+
+  // Project: CLI override > env var > store.
+  const projectId = overrides.projectId ?? envProjectId ?? store?.projectId;
   if (!projectId) {
     throw new ConfigError(
-      "POSTHOG_PROJECT_ID is not set. Pass --project <id> or set it in .envrc.",
+      "No project selected. Run `posthog-definitions login`, pass --project <id>, or set POSTHOG_PROJECT_ID.",
     );
   }
 
-  const host = (overrides.host ?? process.env.POSTHOG_HOST ?? DEFAULT_HOST).replace(/\/$/, "");
+  // Auth: personal API key from env beats stored OAuth (so CI overrides work).
+  if (envApiKey) {
+    return { host, projectId, auth: personalKeyAuth(envApiKey) };
+  }
 
-  return { host, projectId, apiKey };
+  if (store) {
+    return { host, projectId, auth: oauthAuth(store) };
+  }
+
+  throw new ConfigError(
+    "No credentials found. Run `posthog-definitions login`, or set POSTHOG_PERSONAL_API_KEY.",
+  );
+}
+
+function normalizeHost(host: string): string {
+  return host.replace(/\/$/, "");
+}
+
+export function personalKeyAuth(apiKey: string): AuthHandler {
+  return {
+    getHeader: () => `Bearer ${apiKey}`,
+  };
+}
+
+export function oauthAuth(initial: StoredAuth): AuthHandler {
+  // Mutate in-place so retries after refresh see the new token without
+  // re-reading the file from disk.
+  let current = initial;
+
+  const ensureFresh = async (): Promise<void> => {
+    const now = Math.floor(Date.now() / 1000);
+    if (current.expiresAt - REFRESH_LEEWAY_SECONDS > now) return;
+    const next = await refreshAccessToken(current.refreshToken, current.host, current.clientId);
+    current = {
+      ...current,
+      accessToken: next.accessToken,
+      refreshToken: next.refreshToken,
+      expiresAt: next.expiresAt,
+    };
+    writeStore(current);
+  };
+
+  return {
+    async getHeader() {
+      await ensureFresh();
+      return `Bearer ${current.accessToken}`;
+    },
+    async refreshOnUnauthorized() {
+      const next = await refreshAccessToken(current.refreshToken, current.host, current.clientId);
+      current = {
+        ...current,
+        accessToken: next.accessToken,
+        refreshToken: next.refreshToken,
+        expiresAt: next.expiresAt,
+      };
+      writeStore(current);
+      return true;
+    },
+  };
 }

--- a/src/client/typed.ts
+++ b/src/client/typed.ts
@@ -1,6 +1,6 @@
 import createClient, { type Client } from "openapi-fetch";
 import type { paths } from "../generated/api.js";
-import type { ClientConfig } from "./config.js";
+import type { AuthHandler, ClientConfig } from "./config.js";
 
 export type ApiClient = Client<paths>;
 
@@ -36,8 +36,7 @@ export type ApiClientOptions = {
 export function createApiClient(config: ClientConfig, options: ApiClientOptions = {}): ApiClient {
   const client = createClient<paths>({
     baseUrl: config.host,
-    headers: { Authorization: `Bearer ${config.apiKey}` },
-    fetch: makeRetriedFetch({ verbose: options.verbose }),
+    fetch: makeRetriedFetch({ verbose: options.verbose, auth: config.auth }),
   });
 
   // openapi-fetch returns { data, error, response }. We escalate non-ok responses
@@ -80,13 +79,10 @@ export async function followPagination<T>(
   options: ApiClientOptions = {},
 ): Promise<T[]> {
   const all = [...firstPage.results];
-  const fetchImpl = makeRetriedFetch({ verbose: options.verbose });
+  const fetchImpl = makeRetriedFetch({ verbose: options.verbose, auth: config.auth });
   let next = firstPage.next;
   while (next) {
-    const response = await fetchImpl(next, {
-      method: "GET",
-      headers: { Authorization: `Bearer ${config.apiKey}` },
-    });
+    const response = await fetchImpl(next, { method: "GET" });
     if (!response.ok) {
       const text = await response.text();
       throw new ApiError(
@@ -115,13 +111,14 @@ const POST_RETRYABLE_STATUSES = new Set([408, 425, 429]);
 type FetchInput = Parameters<typeof fetch>[0];
 type FetchInit = Parameters<typeof fetch>[1];
 
-function makeRetriedFetch(opts: { verbose?: boolean }): typeof fetch {
+function makeRetriedFetch(opts: { verbose?: boolean; auth: AuthHandler }): typeof fetch {
   return async function retriedFetch(input: FetchInput, init?: FetchInit) {
     const method = (init?.method ?? "GET").toUpperCase();
     const url =
       typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     const debug = opts.verbose || isDebugEnv();
     const deadlineMs = Date.now() + overallTimeoutMs();
+    let triedReauth = false;
 
     for (let attempt = 1; ; attempt++) {
       const remaining = Math.max(0, deadlineMs - Date.now());
@@ -131,9 +128,18 @@ function makeRetriedFetch(opts: { verbose?: boolean }): typeof fetch {
       const startedAt = Date.now();
       if (debug) console.error(`[http] → ${method} ${url} (timeout ${timeoutMs}ms)`);
 
+      // Inject Authorization per attempt so OAuth refreshes are picked up.
+      const authHeader = await opts.auth.getHeader();
+      const mergedHeaders = new Headers(init?.headers);
+      mergedHeaders.set("Authorization", authHeader);
+
       let response: Response;
       try {
-        response = await fetch(input, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+        response = await fetch(input, {
+          ...init,
+          headers: mergedHeaders,
+          signal: AbortSignal.timeout(timeoutMs),
+        });
       } catch (err) {
         const verdict = classifyNetworkError(err, method);
         if (verdict.kind === "fatal") throw err;
@@ -160,6 +166,23 @@ function makeRetriedFetch(opts: { verbose?: boolean }): typeof fetch {
         );
       }
 
+      // 401 → ask the auth handler to refresh once, then retry without consuming
+      // a normal retry slot. Falls through to the regular path if refresh fails
+      // or the handler doesn't support refresh.
+      if (response.status === 401 && !triedReauth && opts.auth.refreshOnUnauthorized) {
+        triedReauth = true;
+        await response.arrayBuffer().catch(() => undefined);
+        try {
+          const refreshed = await opts.auth.refreshOnUnauthorized();
+          if (refreshed) {
+            if (debug) console.error(`[http] retry after auth refresh — HTTP 401`);
+            continue;
+          }
+        } catch (refreshErr) {
+          if (debug) console.error(`[http] auth refresh failed: ${reason(refreshErr)}`);
+        }
+      }
+
       const verdict = classifyHttpStatus(response.status, method);
       if (verdict.kind === "ok") return response;
 
@@ -175,7 +198,8 @@ function makeRetriedFetch(opts: { verbose?: boolean }): typeof fetch {
       }
       // Drain body to release the connection before retrying.
       await response.arrayBuffer().catch(() => undefined);
-      if (debug) console.error(`[http] retry ${attempt + 1} in ${delayMs}ms — HTTP ${response.status}`);
+      if (debug)
+        console.error(`[http] retry ${attempt + 1} in ${delayMs}ms — HTTP ${response.status}`);
       await sleep(delayMs);
     }
   };

--- a/src/resources/dashboard/client.integration.test.ts
+++ b/src/resources/dashboard/client.integration.test.ts
@@ -34,7 +34,7 @@ describe("dashboard client (integration)", () => {
   let config: ClientConfig;
 
   beforeAll(async () => {
-    config = loadAcceptanceConfig();
+    config = await loadAcceptanceConfig();
     await purgeStale(
       config,
       listManagedDashboards,

--- a/src/resources/dashboard/pipeline.acceptance.test.ts
+++ b/src/resources/dashboard/pipeline.acceptance.test.ts
@@ -59,7 +59,7 @@ function desiredFor(insights: Insight[], dashboards: Dashboard[]): DesiredState 
 
 describe("dashboard pipeline (acceptance)", () => {
   it("creates, updates, re-diffs unchanged, then prunes a real dashboard", async () => {
-    const config = loadAcceptanceConfig();
+    const config = await loadAcceptanceConfig();
     await purgeStale(
       config,
       listManagedDashboards,

--- a/src/resources/insight/client.integration.test.ts
+++ b/src/resources/insight/client.integration.test.ts
@@ -48,7 +48,7 @@ describe("insight client (integration)", () => {
   let config: ClientConfig;
 
   beforeAll(async () => {
-    config = loadAcceptanceConfig();
+    config = await loadAcceptanceConfig();
     await purgeStale(config, listManagedInsights, deleteInsight, insightKeyFromTags, PURGE_PREFIX);
   });
 

--- a/src/resources/insight/pipeline.acceptance.test.ts
+++ b/src/resources/insight/pipeline.acceptance.test.ts
@@ -39,7 +39,7 @@ function desiredFor(insights: Insight[]): DesiredState {
 
 describe("insight pipeline (acceptance)", () => {
   it("creates, updates, re-diffs unchanged, then prunes a real insight", async () => {
-    const config = loadAcceptanceConfig();
+    const config = await loadAcceptanceConfig();
     await purgeStale(
       config,
       listManagedInsights,

--- a/src/test-helpers/acceptance.ts
+++ b/src/test-helpers/acceptance.ts
@@ -1,9 +1,9 @@
 import { randomBytes } from "node:crypto";
 import { type ClientConfig, ConfigError, loadConfig } from "../client/config.js";
 
-export function loadAcceptanceConfig(): ClientConfig {
+export async function loadAcceptanceConfig(): Promise<ClientConfig> {
   try {
-    return loadConfig();
+    return await loadConfig();
   } catch (err) {
     if (err instanceof ConfigError) {
       throw new Error(


### PR DESCRIPTION
## Summary

- Add `posthog-definitions login` / `logout` commands. Login opens a browser, runs PKCE OAuth against the chosen host (US/EU/custom), prompts for a project, and saves the result to `$XDG_CONFIG_HOME/posthog-definitions/config.json` with mode 0600.
- Use the CIMD (Client ID Metadata Document) pattern — same as `posthog/wizard`. No DB row needs to be created up-front; the OAuth server fetches the metadata doc on first authorize.
- HTTP client now resolves the `Authorization` header per request through an `AuthHandler`, auto-refreshes tokens nearing expiry, and retries once on 401 after a refresh.
- `POSTHOG_PERSONAL_API_KEY` env var still wins over the stored token so CI/automation keep working unchanged. Resolution: CLI flag > env var > store > default.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` clean
- [ ] `pnpm test` — all 119 unit tests pass
- [ ] `posthog-definitions login` against `https://us.posthog.com`, pick a project, then `apply --dry-run` works without `POSTHOG_*` env vars
- [ ] `posthog-definitions login --switch-project` reuses the existing token
- [ ] `posthog-definitions logout` clears the file
- [ ] Setting `POSTHOG_PERSONAL_API_KEY` overrides the stored OAuth token
- [ ] Expired access token triggers a silent refresh on the next `apply`/`pull`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*