### PR TITLE
chore(codegen): daily schema refresh (2026-05-14)

### DIFF
--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -4362,9 +4362,8 @@ export interface components {
              */
             kind: "ExperimentMetric";
             /**
-             * Metric Type
-             * @default funnel
-             * @constant
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
              */
             metric_type: "funnel";
             /**
@@ -4528,9 +4527,8 @@ export interface components {
              */
             lower_bound_percentile: number | null;
             /**
-             * Metric Type
-             * @default mean
-             * @constant
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
              */
             metric_type: "mean";
             /**
@@ -4693,7 +4691,7 @@ export interface components {
              * Metric
              * @default null
              */
-            metric: components["schemas"]["ExperimentMeanMetric"] | components["schemas"]["ExperimentFunnelMetric"] | components["schemas"]["ExperimentRatioMetric"] | components["schemas"]["ExperimentRetentionMetric"] | null;
+            metric: (components["schemas"]["ExperimentMeanMetric"] | components["schemas"]["ExperimentFunnelMetric"] | components["schemas"]["ExperimentRatioMetric"] | components["schemas"]["ExperimentRetentionMetric"]) | null;
             /**
              * P Value
              * @default null
@@ -4761,9 +4759,8 @@ export interface components {
              */
             kind: "ExperimentMetric";
             /**
-             * Metric Type
-             * @default ratio
-             * @constant
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
              */
             metric_type: "ratio";
             /**
@@ -4829,9 +4826,8 @@ export interface components {
              */
             kind: "ExperimentMetric";
             /**
-             * Metric Type
-             * @default retention
-             * @constant
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
              */
             metric_type: "retention";
             /**


### PR DESCRIPTION
## Daily OpenAPI schema refresh — 2026-05-14

Automated regeneration of `src/generated/api.d.ts` from the live PostHog OpenAPI spec, filtered by `openapi-filter.yaml`.

### Spec diff size
- `src/generated/api.d.ts`: **9 insertions, 13 deletions** (1 file)
- `openapi-filter.yaml`: unchanged

### What changed
Cosmetic only. `openapi-typescript` now emits a generic description for discriminator enum properties on `ExperimentMetric` variants in place of the prior `@default`/`@constant` annotations:

- `ExperimentFunnelMetric.metric_type`
- `ExperimentMeanMetric.metric_type`
- `ExperimentRatioMetric.metric_type`
- `ExperimentRetentionMetric.metric_type`

One additional change: parens added around the `metric` union type in `ExperimentSignificance` (no behavioral effect).

No structural changes to any operation, schema, parameter, or response.

### New operationIds added to filter
None. No additions to `openapi-filter.yaml` this run.

The live spec contains a large set of operationIds outside the filter — this is by design (the filter is an allowlist, not a denylist). Triaged the gaps relative to managed resource families:

- Full-update (`PUT`) variants of managed resources (`cohorts_update`, `event_definitions_update`, `experiments_update`, `experiment_holdouts_update`, `experiment_saved_metrics_update`, `schema_property_groups_update`, `event_schemas_update`, `event_schemas_partial_update`) — **intentionally excluded**: the pipeline uses `PATCH` (`partial_update`) for field-level diffs; full `PUT` semantics are not needed.
- Auxiliary experiment endpoints (`experiments_stats_retrieve`, `experiments_timeseries_results_retrieve`, `experiments_ship_variant_create`, `experiments_reset_create`, `experiments_duplicate_create`, `experiments_recalculate_timeseries_create`, `experiments_eligible_feature_flags_retrieve`, `experiments_requires_flag_implementation_retrieve`, `experiments_copy_to_project_create`, `experiments_create_exposure_cohort_for_experiment_create`) — **not in scope** for declarative IaC; these are read/action endpoints, not part of the create/diff/apply lifecycle.
- Cohort auxiliary endpoints (`cohorts_activity_retrieve`, `cohorts_persons_retrieve`, `cohorts_calculation_history_retrieve`, `cohorts_*_static_cohort_partial_update`, `cohorts_all_activity_retrieve`) — **not in scope** for declarative management.
- Other operationIds belong to resource families not currently managed by posthog-definitions (actions, alerts, annotations, batch_exports, hog_functions, surveys, persons, warehouse_*, error_tracking_*, llm_analytics_*, etc.) — leaving these out per the policy of only managing resources with a clear declarative shape.

### Resources touched
None. No `src/resources/*/client.ts` Zod schemas or `pipeline.ts` projections required updates — the cosmetic change does not affect any field accessed by the typed client.

### Unresolved drift
None.

### Removed operationIds
None observed.

### Verification
- `pnpm install --frozen-lockfile` ✓
- `pnpm codegen` ✓
- `pnpm typecheck` ✓
- `pnpm test` ✓ (173/173 across 20 suites)

### TaskRun
Task-Id: `8fcee614-d1fa-4a24-b17b-28f3cd2a4b58`

Generated-By: PostHog Code