### PR TITLE
chore(codegen): daily schema refresh (2026-05-15)

### DIFF
--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -14178,15 +14178,28 @@ export interface components {
         };
         /** TrendsFilter */
         TrendsFilter: {
-            /** @default numeric */
+            /**
+             * @description Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
+             *
+             *     - `numeric` (default): raw numbers, e.g. `1,234`.
+             *     - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
+             *     - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
+             *     - `percentage`: values are already in the 0-100 range; appends `%`.
+             *     - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
+             *     - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
+             *     - `short`: compact notation for large counts (`1.2K`, `3.4M`).
+             * @default numeric
+             */
             aggregationAxisFormat: components["schemas"]["AggregationAxisFormat"] | null;
             /**
              * Aggregationaxispostfix
+             * @description Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself.
              * @default null
              */
             aggregationAxisPostfix: string | null;
             /**
              * Aggregationaxisprefix
+             * @description Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself.
              * @default null
              */
             aggregationAxisPrefix: string | null;
@@ -14202,6 +14215,7 @@ export interface components {
             confidenceLevel: number | null;
             /**
              * Decimalplaces
+             * @description Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency.
              * @default null
              */
             decimalPlaces: number | null;


### PR DESCRIPTION
## Summary

Daily OpenAPI schema refresh. The live spec changed in a docs-only way: `TrendsFilter` aggregation axis fields (`aggregationAxisFormat`, `aggregationAxisPrefix`, `aggregationAxisPostfix`, `decimalPlaces`) now carry inline descriptions. No new or removed operationIds in the managed surface.

## Spec diff size

`src/generated/api.d.ts`: +15 / −1 (description fields only, no schema or path changes).
`openapi-filter.yaml`: unchanged.

## New operationIds added to the filter

None. No managed resource family gained or lost an operationId. The drift detector's full list of live-spec operationIds outside the filter (~1000 entries) consists of intentionally-excluded internal/admin/non-CRUD endpoints — same as prior refreshes. None of them surfaced a new managed-resource family worth adopting in this pass.

## Resources touched

None. No `src/resources/**` Zod schemas or `pipeline.ts` projections needed changes — the description additions don't affect generated types.

## Unresolved drift

None. `pnpm typecheck && pnpm test` both pass (35 files, 291 tests).

## Operations removed from the live spec

None detected.

## TaskRun

50de40fd-c93a-4827-b888-c0346960b51c