### PR TITLE
chore(codegen): daily schema refresh (2026-05-16)

### DIFF
--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -14178,15 +14178,28 @@ export interface components {
         };
         /** TrendsFilter */
         TrendsFilter: {
-            /** @default numeric */
+            /**
+             * @description Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
+             *
+             *     - `numeric` (default): raw numbers, e.g. `1,234`.
+             *     - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
+             *     - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
+             *     - `percentage`: values are already in the 0-100 range; appends `%`.
+             *     - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
+             *     - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
+             *     - `short`: compact notation for large counts (`1.2K`, `3.4M`).
+             * @default numeric
+             */
             aggregationAxisFormat: components["schemas"]["AggregationAxisFormat"] | null;
             /**
              * Aggregationaxispostfix
+             * @description Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself.
              * @default null
              */
             aggregationAxisPostfix: string | null;
             /**
              * Aggregationaxisprefix
+             * @description Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself.
              * @default null
              */
             aggregationAxisPrefix: string | null;
@@ -14202,6 +14215,7 @@ export interface components {
             confidenceLevel: number | null;
             /**
              * Decimalplaces
+             * @description Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency.
              * @default null
              */
             decimalPlaces: number | null;


### PR DESCRIPTION
## Summary

Daily refresh of `src/generated/api.d.ts` from the live PostHog OpenAPI spec.

**Spec diff size:** 15 lines added, 1 line removed — all on the `TrendsFilter` component.

The change is purely documentation: inline `description` strings were added to `aggregationAxisFormat`, `aggregationAxisPostfix`, `aggregationAxisPrefix`, and `decimalPlaces`. No structural change, no new fields, no removed fields.

## New operationIds added to `openapi-filter.yaml`

None. The drift report lists ~1,400 operationIds in the live spec that are not in our filter, but these are all auxiliary endpoints on resources we already manage (or resources we deliberately do not manage). Concrete categories:

- Activity / audit log endpoints (`*_activity_retrieve`, `*_all_activity_retrieve`)
- Bulk operations (`*_bulk_update_tags_create`, `*_bulk_delete_create`)
- Sharing / collaborators / passwords (`dashboards_sharing_*`, `dashboards_collaborators_*`, `insights_sharing_*`)
- Tile/layout helpers (`dashboards_copy_tile_create`, `dashboards_move_tile_partial_update`)
- Full-`PUT` variants of resources where the IaC client only consumes `PATCH` (`cohorts_update`, `experiments_update`, `event_definitions_update`, `schema_property_groups_update`, etc.) — none of the resource clients call `api.PUT`, so adding these would just inflate the generated surface.
- Experiment lifecycle actions outside the managed set (`experiments_duplicate_create`, `experiments_reset_create`, `experiments_ship_variant_create`, `experiments_recalculate_timeseries_create`, …)
- Endpoint sub-actions (`environments_endpoints_run_create`, `environments_endpoints_materialization_*`)
- Feature-flag introspection (`feature_flags_status_retrieve`, `feature_flags_my_flags_retrieve`, `feature_flags_dependent_flags_list`, …)

None of these are required by `src/resources/*/client.ts`, which only uses the standard `list / retrieve / create / partial_update / destroy` surface (plus the six experiment lifecycle actions and project-settings GET/PATCH that are already filtered in).

## Resources touched

- `src/generated/api.d.ts` — regenerated via `pnpm codegen`.

No resource clients, Zod schemas, or `pipeline.ts` projections required changes. `pnpm typecheck` is clean; `pnpm test` is 291/291 green.

## Unresolved drift

None. No operationIds disappeared from the live spec.

## Provenance

- Branch: `posthog-code/schema-refresh-2026-05-16`
- TaskRun: `85dfe592-51b9-41e4-bb15-9271a95dd2ce`