### PR TITLE
chore(codegen): daily schema refresh (2026-05-17)

### DIFF
--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -14178,15 +14178,28 @@ export interface components {
         };
         /** TrendsFilter */
         TrendsFilter: {
-            /** @default numeric */
+            /**
+             * @description Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
+             *
+             *     - `numeric` (default): raw numbers, e.g. `1,234`.
+             *     - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
+             *     - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
+             *     - `percentage`: values are already in the 0-100 range; appends `%`.
+             *     - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
+             *     - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
+             *     - `short`: compact notation for large counts (`1.2K`, `3.4M`).
+             * @default numeric
+             */
             aggregationAxisFormat: components["schemas"]["AggregationAxisFormat"] | null;
             /**
              * Aggregationaxispostfix
+             * @description Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself.
              * @default null
              */
             aggregationAxisPostfix: string | null;
             /**
              * Aggregationaxisprefix
+             * @description Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself.
              * @default null
              */
             aggregationAxisPrefix: string | null;
@@ -14202,6 +14215,7 @@ export interface components {
             confidenceLevel: number | null;
             /**
              * Decimalplaces
+             * @description Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency.
              * @default null
              */
             decimalPlaces: number | null;


### PR DESCRIPTION
## Summary

Daily OpenAPI schema refresh against `https://us.posthog.com/api/schema/?format=json`.

**Spec diff size:** 1 file changed, 15 insertions(+), 1 deletion(-) in `src/generated/api.d.ts`. The only change is added docstrings on `TrendsFilter.aggregationAxisFormat`, `aggregationAxisPrefix`, `aggregationAxisPostfix`, and `decimalPlaces` (no structural changes).

**New operationIds added to `openapi-filter.yaml`:** none.

**Resources touched:** none (`openapi-filter.yaml` unchanged; only the generated `api.d.ts` shifted, and only in description comments).

## Triage of unmanaged operationIds

The drift report from the GitHub Actions step lists every operationId in the live spec that is not in our inverse-allowlist. None of them represent NEW CRUD endpoints for existing managed resource families that are worth wiring up today:

- `insights_*`, `dashboards_*`, `feature_flags_*`, `cohorts_*`, `actions_*`, `event_definitions_*`, `experiments_*`, `experiment_holdouts_*`, `experiment_saved_metrics_*`, `schema_property_groups_*`, `event_schemas_*`, `environments_endpoints_*`, `environments_*` — core CRUD already covered in the filter.
- Extras like `*_activity_retrieve`, `*_bulk_update_tags_create`, `*_sharing_*`, `*_my_last_viewed_retrieve`, etc. are admin/utility endpoints, not IaC primitives.
- Other resource families in the drift list (`alerts`, `annotations`, `surveys`, `notebooks`, `subscriptions`, `roles`, `comments`, `batch_exports`, `external_data_*`, `hog_flows_*`, `hog_functions_*`, LLM analytics, error tracking, logs, tracing, warehouse, etc.) are brand-new families that would each need a full `add-resource` (or `add-singleton-resource`) skill run including pipeline wiring, identity convention, and the safety invariant — out of scope for a daily drift refresh. Leave for a human to decide which to graduate to IaC management.

No managed operationIds disappeared from the live spec.

## Unresolved drift

None.

## TaskRun

PostHog Code TaskRun: `1fe10663-6a0c-49fa-8f02-564ac60b9a4b`

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm codegen`
- [x] `pnpm typecheck`
- [x] `pnpm test` (35 files, 291 tests passing)

Generated-By: PostHog Code