### PR TITLE
chore(codegen): daily schema refresh (2026-05-18)

### DIFF
--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -14178,15 +14178,28 @@ export interface components {
         };
         /** TrendsFilter */
         TrendsFilter: {
-            /** @default numeric */
+            /**
+             * @description Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
+             *
+             *     - `numeric` (default): raw numbers, e.g. `1,234`.
+             *     - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
+             *     - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
+             *     - `percentage`: values are already in the 0-100 range; appends `%`.
+             *     - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
+             *     - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
+             *     - `short`: compact notation for large counts (`1.2K`, `3.4M`).
+             * @default numeric
+             */
             aggregationAxisFormat: components["schemas"]["AggregationAxisFormat"] | null;
             /**
              * Aggregationaxispostfix
+             * @description Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself.
              * @default null
              */
             aggregationAxisPostfix: string | null;
             /**
              * Aggregationaxisprefix
+             * @description Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself.
              * @default null
              */
             aggregationAxisPrefix: string | null;
@@ -14202,6 +14215,7 @@ export interface components {
             confidenceLevel: number | null;
             /**
              * Decimalplaces
+             * @description Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency.
              * @default null
              */
             decimalPlaces: number | null;


### PR DESCRIPTION
## Summary

Daily OpenAPI schema refresh against `https://us.posthog.com/api/schema/?format=json`.

**Spec diff size:** 15 lines added, 1 removed in `src/generated/api.d.ts`. Purely docstring additions on `TrendsFilter`:
- `aggregationAxisFormat` — full description of the supported formats (`numeric`, `duration`, `duration_ms`, `percentage`, `percentage_scaled`, `currency`, `short`).
- `aggregationAxisPostfix` / `aggregationAxisPrefix` — guidance on when to use literal suffixes/prefixes vs picking the matching format.
- `decimalPlaces` — note on typical values for percentages and currency.

No structural schema changes. `openapi-filter.yaml` unchanged.

## Filter changes

None. No new operationIds added.

## Resources touched

None. No client/pipeline edits required.

## New operationIds in live spec (not added to filter)

The live spec exposes a very large set of operationIds outside the managed resource families (`action`, `cohort`, `dashboard`, `endpoint`, `event-definition`, `experiment`, `experiment-holdout`, `experiment-saved-metric`, `feature-flag`, `insight`, `project-settings`, `property-group`). None of them are missing core CRUD ops for a managed family, so nothing was added.

Notable categories that remain intentionally out of scope:
- **Adjacent resource families** (not managed by posthog-definitions): `persons_*`, `groups_*`, `cohorts_persons_*`, `external_data_*`, `warehouse_*`, `llm_analytics_*`, `hog_flows_*`, `hog_functions_*`, `session_recordings_*`, `notebooks_*`, `surveys_*`, `error_tracking_*`, `logs_*`, `subscriptions_*`, `roles_*`, `members_*`, `organizations_*`, `tasks_*`, `tracing_spans_*`, `visual_review_*`, `signals_*`, etc.
- **`environments_*` mirrors** of project-scoped routes (e.g. `environments_insights_*`, `environments_dashboards_*`) — duplicates of the routes we already use under `projects/*`.
- **Extras on managed families** that are not core CRUD and not currently needed:
  - `actions_bulk_update_tags_create`, `actions_references_list`
  - `cohorts_activity_retrieve`, `cohorts_all_activity_retrieve`, `cohorts_calculation_history_retrieve`, `cohorts_persons_retrieve`, `cohorts_add_persons_to_static_cohort_partial_update`, `cohorts_remove_person_from_static_cohort_partial_update`, `cohorts_update` (PUT — we use PATCH)
  - `dashboards_*` activity/collaborator/sharing/snapshot/copy/move/reorder helpers, `dashboards_bulk_update_tags_create`
  - `endpoints_*` materialization/run/versions/last_execution_times helpers
  - `event_definitions_bulk_update_tags_create`, `event_definitions_by_name_retrieve`, `event_definitions_metrics_retrieve`, `event_definitions_primary_properties_retrieve`, `event_definitions_{golang,python,typescript}_retrieve`, `event_definitions_update` (PUT)
  - `event_schemas_partial_update`, `event_schemas_update` (we only need list/create/destroy server-side)
  - `experiment_holdouts_update` (PUT)
  - `experiment_saved_metrics_update` (PUT)
  - `experiments_copy_to_project_create`, `experiments_create_exposure_cohort_for_experiment_create`, `experiments_duplicate_create`, `experiments_eligible_feature_flags_retrieve`, `experiments_recalculate_timeseries_create`, `experiments_requires_flag_implementation_retrieve`, `experiments_reset_create`, `experiments_ship_variant_create`, `experiments_stats_retrieve`, `experiments_timeseries_results_retrieve`, `experiments_update` (PUT)
  - `feature_flags_*` activity/dashboard/blast-radius/local-evaluation/remote-config/status/versions helpers, `feature_flags_bulk_*`
  - `insights_*` activity/sharing/suggestions/thresholds/trending/viewed helpers, `insights_bulk_update_tags_create`, `insights_analyze_retrieve`, `insights_my_last_viewed_retrieve`, `insights_cancel_create`, `insights_generate_metadata_create`
  - `schema_property_groups_update` (PUT)

Convention: managed families intentionally use `PATCH` (`*_partial_update`) and skip `PUT` (`*_update`) where both exist, except where the existing filter already includes `_update` (actions, insights, dashboards, feature_flags, endpoints) — left as-is in this PR.

## Unresolved drift

- One pre-existing flaky test: `src/pull/run.test.ts > runPull orchestrator > writes files and calls tagOnServer on a non-dry run` times out at 500ms under full-suite load (~318ms in isolation). Not caused by this refresh — schema change is doc-only. Suggest bumping the per-test timeout or relaxing this case.
- No operationIds removed from the live spec relative to the current filter.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm codegen`
- [x] `pnpm typecheck`
- [x] `pnpm test` (1 flaky timeout unrelated to schema; passes in isolation)

## TaskRun

Task-Id: `dc9b071d-e37e-442f-aec0-cc3315a3c350`