### PR TITLE
fix(insight): wrap FunnelsQuery in InsightVizNode on apply

### DIFF
--- a/src/resources/insight/pipeline.test.ts
+++ b/src/resources/insight/pipeline.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { diff } from "../../apply/diff.js";
 import type { DesiredState } from "../types.js";
-import { type Insight, type TrendsQuery } from "./sdk.js";
+import { type FunnelsQuery, type HogQLQuery, type Insight, type TrendsQuery } from "./sdk.js";
 import { type ServerInsight } from "./client.js";
-import { insightHash } from "./pipeline.js";
+import { insightHash, insightPayload } from "./pipeline.js";
 
 function trends(event: string): TrendsQuery {
   return { kind: "TrendsQuery", series: [{ event }] };
+}
+
+function funnels(...events: string[]): FunnelsQuery {
+  return { kind: "FunnelsQuery", series: events.map((event) => ({ event })) };
 }
 
 function spec(key: string, name = key): Insight {
@@ -89,5 +93,25 @@ describe("insight pipeline", () => {
     const slice = result.get("insights")!;
     expect(slice.ops.length).toBe(0);
     expect(slice.orphans.length).toBe(0);
+  });
+});
+
+describe("insightPayload query wrapping", () => {
+  it("wraps a TrendsQuery in an InsightVizNode", () => {
+    const query = trends("user signed up");
+    const payload = insightPayload({ key: "signups", name: "Signups", query }, "hash");
+    expect(payload.query).toEqual({ kind: "InsightVizNode", source: query });
+  });
+
+  it("wraps a FunnelsQuery in an InsightVizNode", () => {
+    const query = funnels("signed up", "activated");
+    const payload = insightPayload({ key: "activation", name: "Activation", query }, "hash");
+    expect(payload.query).toEqual({ kind: "InsightVizNode", source: query });
+  });
+
+  it("wraps a HogQLQuery in a DataTableNode", () => {
+    const query: HogQLQuery = { kind: "HogQLQuery", query: "select 1" };
+    const payload = insightPayload({ key: "raw", name: "Raw", query }, "hash");
+    expect(payload.query).toEqual({ kind: "DataTableNode", source: query });
   });
 });

--- a/src/resources/insight/pipeline.ts
+++ b/src/resources/insight/pipeline.ts
@@ -58,7 +58,7 @@ function mergeTags(userTags: string[] | undefined, managedTags: string[]): strin
 }
 
 function wrapQuery(query: Query): unknown {
-  if (query.kind === "TrendsQuery") {
+  if (query.kind === "TrendsQuery" || query.kind === "FunnelsQuery") {
     return { kind: "InsightVizNode", source: query };
   }
   return { kind: "DataTableNode", source: query };


### PR DESCRIPTION
Fixes #53

### Problem
`wrapQuery` (apply side) only wrapped `TrendsQuery` into an `InsightVizNode`; `FunnelsQuery`
fell through to `DataTableNode`, so funnels defined in code were applied to PostHog as data
tables. The pull side (`codegen.renderQuery`, `unwrapServerQuery`) already handled funnels,
and `InsightVizNode.source` is typed `TrendsQuery | FunnelsQuery` — only apply was out of sync.

### Change
- `wrapQuery` now routes both `TrendsQuery` and `FunnelsQuery` to `InsightVizNode`.
  `HogQLQuery` stays on `DataTableNode` (not a valid `InsightVizNode.source`).
- Added tests covering all three query kinds via `insightPayload`.

### Verification
- `pnpm typecheck` ✓
- `pnpm test` — new insight tests pass (8/8). The unrelated `src/pull/run.test.ts` timeout
  and the pre-existing lint errors in `client/typed-posthog.ts`, `resources/types.ts` and
  `dashboard/pipeline.acceptance.test.ts` reproduce on a clean `main` and are untouched here.
