### PR TITLE
feat(action): pull codegen support

### DIFF
--- a/src/cli/pull.integration.test.ts
+++ b/src/cli/pull.integration.test.ts
@@ -1,5 +1,4 @@
 import { promises as fs } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { ClientConfig } from "../client/config.js";

--- a/src/client/typed-posthog.ts
+++ b/src/client/typed-posthog.ts
@@ -81,6 +81,9 @@ type EventSchemaMap<TEvents extends ReadonlyArray<{ name: string }>> = {
   [E in TEvents[number] as E["name"]]: EventPropertiesOf<E>;
 };
 
+// `{}` here means "the empty object type" — TProps has no required keys when the
+// empty object is assignable to it. This is the intended type-level check.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type HasRequired<TProps> = {} extends TProps ? false : true;
 
 // ---------- runtime ----------

--- a/src/resources/action/client.ts
+++ b/src/resources/action/client.ts
@@ -72,6 +72,15 @@ export async function listManagedActions(
   config: ClientConfig,
   options: { verbose?: boolean } = {},
 ): Promise<ServerAction[]> {
+  const all = await listActions(config, options);
+  return all.filter((row) => row.tags?.some((tag) => tag.startsWith("iac:actions:")));
+}
+
+/** Unfiltered list of every action in the project; used by pull. */
+export async function listActions(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerAction[]> {
   const api = createApiClient(config, { verbose: options.verbose });
   const { data } = await api.GET("/api/projects/{project_id}/actions/", {
     params: {
@@ -83,9 +92,7 @@ export async function listManagedActions(
   const allRaw = await followPagination<unknown>(config, firstPage, {
     verbose: options.verbose,
   });
-  return allRaw
-    .map((row) => ServerActionSchema.parse(row))
-    .filter((row) => row.tags?.some((tag) => tag.startsWith("iac:actions:")));
+  return allRaw.map((row) => ServerActionSchema.parse(row));
 }
 
 export async function getAction(

--- a/src/resources/action/codegen.test.ts
+++ b/src/resources/action/codegen.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { PullRenderContext } from "../../pull/types.js";
+import { pullFilter, pullLabel, renderToFile, serverIdOf } from "./codegen.js";
+import type { ServerAction } from "./client.js";
+
+function makeCtx(): PullRenderContext & { warnings: string[] } {
+  const taken = new Set<string>();
+  const warnings: string[] = [];
+  return {
+    warnings,
+    uniqueSlug: (base) => {
+      let s = base;
+      let i = 2;
+      while (taken.has(s)) s = `${base}-${i++}`;
+      taken.add(s);
+      return s;
+    },
+    importForServerId: () => {
+      throw new Error("action codegen should not call importForServerId");
+    },
+    importForServerIdOptional: () => undefined,
+    warn: (m) => warnings.push(m),
+  };
+}
+
+function serverAction(overrides: Partial<ServerAction> = {}): ServerAction {
+  return {
+    id: 1,
+    name: "Signed up",
+    description: "",
+    tags: ["iac:actions:signed-up", "iac:hash:abcd1234"],
+    steps: [{ event: "$autocapture", url: "/signup", url_matching: "contains" }],
+    ...overrides,
+  } as ServerAction;
+}
+
+describe("action codegen", () => {
+  it("pullFilter drops deleted actions", () => {
+    expect(pullFilter(serverAction({ deleted: true })).kept).toBe(false);
+    expect(pullFilter(serverAction()).kept).toBe(true);
+  });
+
+  it("pullLabel surfaces user tags, hides managed ones", () => {
+    expect(pullLabel(serverAction()).secondary).toBeUndefined();
+    expect(
+      pullLabel(serverAction({ tags: ["iac:actions:x", "iac:hash:y", "growth"] })).secondary,
+    ).toBe("[growth]");
+  });
+
+  it("serverIdOf returns the numeric id", () => {
+    expect(serverIdOf(serverAction({ id: 42 }))).toBe(42);
+  });
+
+  it("renderToFile emits an action with its steps, dropping null step fields", () => {
+    const ctx = makeCtx();
+    const result = renderToFile(serverAction(), ctx);
+    if ("skipped" in result) throw new Error(`Expected RenderedFile: ${result.reason}`);
+    expect(result.filename).toBe("signed-up.ts");
+    expect(result.contents).toContain('import { action } from "@posthog/definitions";');
+    expect(result.contents).toContain('key: "signed-up"');
+    expect(result.contents).toContain('event: "$autocapture"');
+    expect(result.contents).toContain('url: "/signup"');
+    // Managed tags never leak into the rendered file.
+    expect(result.contents).not.toContain("iac:");
+    // Unpopulated step fields (selector, text, href, …) are omitted.
+    expect(result.contents).not.toContain("selector");
+  });
+
+  it("renderToFile preserves user tags", () => {
+    const ctx = makeCtx();
+    const result = renderToFile(
+      serverAction({ tags: ["iac:actions:signed-up", "iac:hash:y", "growth", "billing"] }),
+      ctx,
+    );
+    if ("skipped" in result) throw new Error("Unexpected skip");
+    expect(result.contents).toContain('tags: ["growth", "billing"]');
+  });
+
+  it("renderToFile skips actions with no steps", () => {
+    const ctx = makeCtx();
+    const result = renderToFile(serverAction({ steps: [] }), ctx);
+    expect("skipped" in result).toBe(true);
+  });
+});

--- a/src/resources/action/codegen.ts
+++ b/src/resources/action/codegen.ts
@@ -1,0 +1,104 @@
+import type { ClientConfig } from "../../client/config.js";
+import { isManagedTag } from "../../apply/display.js";
+import { renderObject, renderRawLiteral, stringLiteral } from "../../pull/render.js";
+import { slugify } from "../../pull/slug.js";
+import type { PullRenderContext, RenderedFile } from "../../pull/types.js";
+import { type ServerAction, updateAction } from "./client.js";
+import { actionTag } from "./pipeline.js";
+import type { Action } from "./sdk.js";
+
+const HASH_TAG_PREFIX = "iac:hash:";
+
+// The step fields the SDK's ActionStep round-trips. The server returns every
+// one (often as null); we render only the populated ones so the codegen'd
+// file stays readable. apply's `normalizeStep` re-fills the nulls, so the
+// trimmed render still hashes identically to the server row.
+const STEP_FIELDS = [
+  "event",
+  "properties",
+  "selector",
+  "tag_name",
+  "text",
+  "text_matching",
+  "href",
+  "href_matching",
+  "url",
+  "url_matching",
+] as const;
+
+export function pullFilter(
+  server: ServerAction,
+): { kept: true } | { kept: false; reason: string } {
+  if (server.deleted) return { kept: false, reason: "deleted" };
+  return { kept: true };
+}
+
+export function pullLabel(server: ServerAction): { primary: string; secondary?: string } {
+  const userTags = (server.tags ?? []).filter((t) => !isManagedTag(t));
+  const secondary = userTags.length > 0 ? `[${userTags.join(", ")}]` : undefined;
+  return { primary: server.name?.trim() || `action-${server.id}`, secondary };
+}
+
+export function serverIdOf(server: ServerAction): number {
+  return server.id;
+}
+
+function cleanStep(step: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const field of STEP_FIELDS) {
+    const value = step[field];
+    if (value !== null && value !== undefined) out[field] = value;
+  }
+  return out;
+}
+
+export function renderToFile(
+  server: ServerAction,
+  ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const baseSlug = slugify(server.name ?? "") || `action-${server.id}`;
+  const slug = ctx.uniqueSlug(baseSlug);
+
+  const steps = (server.steps ?? []).map((s) => cleanStep(s as Record<string, unknown>));
+  if (steps.length === 0) {
+    return {
+      skipped: true,
+      reason: `Action "${slug}" has no steps — nothing to render.`,
+    };
+  }
+
+  const fields: Record<string, string> = {
+    key: stringLiteral(slug),
+    name: stringLiteral(server.name?.trim() || slug),
+  };
+  if (server.description) fields.description = stringLiteral(server.description);
+  fields.steps = renderRawLiteral(steps, 2);
+  if (server.post_to_slack) fields.post_to_slack = "true";
+  if (server.slack_message_format) {
+    fields.slack_message_format = stringLiteral(server.slack_message_format);
+  }
+  if (server.pinned_at) fields.pinned_at = stringLiteral(server.pinned_at);
+  const userTags = (server.tags ?? []).filter((t) => !isManagedTag(t));
+  if (userTags.length > 0) fields.tags = `[${userTags.map(stringLiteral).join(", ")}]`;
+
+  const contents =
+    `import { action } from "@posthog/definitions";\n\n` +
+    `export default action(${renderObject(fields, 2)});\n`;
+  return { filename: `${slug}.ts`, contents, specKey: slug };
+}
+
+export async function tagOnServer(
+  config: ClientConfig,
+  server: ServerAction,
+  spec: Action,
+  hash: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const userTags = (server.tags ?? []).filter((t) => !isManagedTag(t));
+  await updateAction(
+    config,
+    server.id,
+    { tags: [actionTag(spec.key), `${HASH_TAG_PREFIX}${hash}`, ...userTags] },
+    options,
+  );
+}

--- a/src/resources/action/index.ts
+++ b/src/resources/action/index.ts
@@ -1,4 +1,4 @@
-import type { ApplyContext, ResourceModule } from "../types.js";
+import type { ApplyContext, CollectionResourceModule } from "../types.js";
 import type { Action } from "./sdk.js";
 import {
   ACTION_TAG_PREFIX,
@@ -12,12 +12,13 @@ import {
   runActionOp,
   validateActions,
 } from "./pipeline.js";
-import { listManagedActions, type ServerAction } from "./client.js";
+import { getAction, listActions, listManagedActions, type ServerAction } from "./client.js";
+import { pullFilter, pullLabel, renderToFile, serverIdOf, tagOnServer } from "./codegen.js";
 
 export { action } from "./sdk.js";
 export type { Action, ActionStep, ActionStepMatching, ActionStepProperty } from "./sdk.js";
 
-export const actionResource: ResourceModule<Action, ServerAction> = {
+export const actionResource: CollectionResourceModule<Action, ServerAction> = {
   kind: "collection",
   name: "actions",
   displayName: "action",
@@ -37,4 +38,13 @@ export const actionResource: ResourceModule<Action, ServerAction> = {
 
   displaySpec: (spec, _ctx: ApplyContext) => displayAction(spec),
   displayServer: (server, _ctx: ApplyContext) => displayActionFromServer(server),
+
+  listAll: listActions,
+  getById: (config, id, options) =>
+    getAction(config, typeof id === "string" ? Number(id) : id, options),
+  pullFilter,
+  pullLabel,
+  serverIdOf,
+  renderToFile,
+  tagOnServer,
 };

--- a/src/resources/dashboard/pipeline.acceptance.test.ts
+++ b/src/resources/dashboard/pipeline.acceptance.test.ts
@@ -8,7 +8,7 @@ import {
   withCleanup,
 } from "../../test-helpers/acceptance.js";
 import { deleteInsight, listManagedInsights } from "../insight/client.js";
-import { insightHash, insightKeyFromTags, runInsightOp } from "../insight/pipeline.js";
+import { insightKeyFromTags, runInsightOp } from "../insight/pipeline.js";
 import { type Insight } from "../insight/sdk.js";
 import { deleteDashboard, getDashboard, listManagedDashboards } from "./client.js";
 import {

--- a/src/resources/types.ts
+++ b/src/resources/types.ts
@@ -1,6 +1,6 @@
 import type { ClientConfig } from "../client/config.js";
 import type { DisplayValue } from "../apply/display.js";
-import type { PullRenderContext, RenderedFile } from "../pull/types.js";
+import type { PullRenderContext } from "../pull/types.js";
 
 /**
  * Non-enumerable marker installed by each resource's user-facing factory


### PR DESCRIPTION
## What

Actions were seeded and applied but had **no pull rendering** — `actions` was the only resource module missing a `codegen.ts`. So `pull --kind actions` errored with *"actions is not a pullable resource"*, and because `scripts/smoke.sh` lists `actions` in `SMOKE_KINDS`, `pnpm smoke` was already red at the Pull step.

This adds the missing pull codegen, mirroring the tag-identified `event-definition` / `cohort` pattern:

- **New `src/resources/action/codegen.ts`**: `pullFilter` (drops deleted), `pullLabel`, `serverIdOf`, `renderToFile`, `tagOnServer`. `renderToFile` emits `key`/`name`/`steps` plus optional `slack`/`pinned_at`/user-tags, and renders only the *populated* step fields — apply's `normalizeStep` re-fills the nulls, so the trimmed render hashes identically to the server row (clean round-trip).
- **Client**: split an unfiltered `listActions` (listAll) out of `listManagedActions`.
- **`index.ts`**: promote `actionResource` to `CollectionResourceModule` and wire the pull hooks. No `pullDependencies` — action steps reference events by name string, not cross-resource ids.
- **Unit tests** (`codegen.test.ts`): filter/label/serverId/render/skip.

## Why (real fix, not a scope drop)

Investigated first, per the ask: actions merely lacked pull support (no deeper reason they can't be pulled), so this is the real fix rather than removing `actions` from the smoke kind list.

## Verification

- `pnpm typecheck`, `pnpm test` (297, +6), `pnpm lint` all green.
- **Live smoke passed with `actions` in the pull scope** (`pnpm smoke`, dev project): full seed→pull→verify→edit→apply→verify cycle went green; pull wrote the seeded action (tagged), and the no-op re-apply reported `orphans=0` for actions. (The run's `--kind` list temporarily omitted only `dashboards` — a *separate* pre-existing pull bug fixed in `pl/pull-dashboard-cascade`; `scripts/smoke.sh` is not modified by this PR.)

## Interaction with PR #80 (smoke registry)

No `SMOKE_KINDS` / seed-registry change was needed — `actions` already seeds and now pulls. **PR #80 needs no change** on account of this fix; once both land, `actions` is fully covered by the smoke as-is.

## Note

This bug predates the parity work and reproduces on `main`. Includes the shared preparatory `fix(lint)` commit (four eslint errors already red on `main`); whichever PR merges second drops the duplicate on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)