### PR TITLE
feat(dashboard-template): SDK factory + pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ export default dashboard({
 
 1. **Authenticate** — create a personal API key ([US](https://us.posthog.com/settings/user-api-keys) / [EU](https://eu.posthog.com/settings/user-api-keys)) with these scopes:
    - `insight:read`, `insight:write`
-   - `dashboard:read`, `dashboard:write` (also covers dashboard templates)
+   - `dashboard:read`, `dashboard:write`
+   - `dashboard_template:read`, `dashboard_template:write`
    - `feature_flag:read`, `feature_flag:write`
    - `action:read`, `action:write`
    - `endpoint:read`, `endpoint:write`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Alpha — do not use in production.**
 > This is pre-MVP software (`0.1.0-alpha.0`). The CLI, the on-disk file format, the SDK surface, and the tag-based identity model are all subject to breaking changes without notice. Use it on throwaway projects or in a sandbox while we stabilize.
 
-Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
+Infrastructure-as-code for PostHog. Define dashboards, dashboard templates, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
 
 ## Why
 
@@ -44,7 +44,7 @@ export default dashboard({
 
 1. **Authenticate** — create a personal API key ([US](https://us.posthog.com/settings/user-api-keys) / [EU](https://eu.posthog.com/settings/user-api-keys)) with these scopes:
    - `insight:read`, `insight:write`
-   - `dashboard:read`, `dashboard:write`
+   - `dashboard:read`, `dashboard:write` (also covers dashboard templates)
    - `feature_flag:read`, `feature_flag:write`
    - `action:read`, `action:write`
    - `endpoint:read`, `endpoint:write`

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -12,7 +12,7 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 | ------------------- | ---------------------------------------- | ------------------- | --------------------------------------------- |
 | Dashboards          | ✅ `projects/{id}/dashboards`            | ✅                  | Tag-identified via `iac:dashboards:<key>`     |
 | Insights            | ✅ `projects/{id}/insights`              | ✅                  | Standalone or inlined inside a dashboard tile |
-| Dashboard templates | ✅ `projects/{id}/dashboard_templates`   | ❌                  |                                               |
+| Dashboard templates | ✅ `projects/{id}/dashboard_templates`   | ✅                  | Tag-identified via `iac:dashboard-templates:<key>`; project-scoped (`team`) only — global/official templates are read-only. Full matrix refresh tracked in #78. |
 | Annotations         | ✅ `projects/{id}/annotations`           | ❌                  |                                               |
 | Notebooks           | ✅ `projects/{id}/notebooks`             | ❌                  |                                               |
 | Alerts              | ✅ `environments/{id}/alerts`            | ❌                  |                                               |

--- a/examples/posthog/dashboard-templates/activation-funnel.ts
+++ b/examples/posthog/dashboard-templates/activation-funnel.ts
@@ -1,0 +1,39 @@
+// Onboarding template the growth team hands to every new workspace: a couple
+// of trend tiles that answer "are trials turning into activated accounts?".
+// A dashboard TEMPLATE isn't a live dashboard — it's the reusable blueprint
+// people pick from "New dashboard → From template". Tiles embed their query
+// inline (there's no link to a standalone insight), so the whole tile array
+// is round-tripped verbatim.
+import { dashboardTemplate } from "@posthog/definitions";
+
+export default dashboardTemplate({
+  key: "activation-funnel",
+  name: "Trial activation",
+  description: "How trials move from signup to first activated action. Duplicate per team.",
+  tags: ["growth", "onboarding"],
+  filters: { date_from: "-30d" },
+  tiles: [
+    {
+      type: "INSIGHT",
+      name: "Trial signups",
+      layouts: {},
+      color: null,
+      query: {
+        kind: "TrendsQuery",
+        series: [{ kind: "EventsNode", event: "trial_started", math: "total" }],
+        interval: "day",
+      },
+    },
+    {
+      type: "INSIGHT",
+      name: "Activated accounts",
+      layouts: {},
+      color: "green",
+      query: {
+        kind: "TrendsQuery",
+        series: [{ kind: "EventsNode", event: "workspace_activated", math: "dau" }],
+        interval: "day",
+      },
+    },
+  ],
+});

--- a/examples/posthog/dashboard-templates/revenue-health.ts
+++ b/examples/posthog/dashboard-templates/revenue-health.ts
@@ -1,0 +1,35 @@
+// A revenue starter template with a `variables` placeholder — the person
+// instantiating it picks which plan-change event to track, so the same
+// blueprint works whether your billing events are called `subscription_upgraded`
+// or `plan_changed`. Variables are round-tripped verbatim, same as tiles.
+import { dashboardTemplate } from "@posthog/definitions";
+
+export default dashboardTemplate({
+  key: "revenue-health",
+  name: "Revenue health",
+  description: "Expansion, contraction, and paid-seat growth. Fill in your billing event on setup.",
+  tags: ["revenue", "finance"],
+  variables: [
+    {
+      id: "PLAN_CHANGE_EVENT",
+      name: "Plan change event",
+      type: "event",
+      default: { id: "subscription_upgraded", name: "subscription_upgraded", type: "events" },
+      required: true,
+      description: "The event your billing system emits when a plan changes",
+    },
+  ],
+  tiles: [
+    {
+      type: "INSIGHT",
+      name: "Paid seats",
+      layouts: {},
+      color: null,
+      query: {
+        kind: "TrendsQuery",
+        series: [{ kind: "EventsNode", event: "seat_assigned", math: "total" }],
+        interval: "week",
+      },
+    },
+  ],
+});

--- a/examples/posthog/dashboard-templates/support-load.ts
+++ b/examples/posthog/dashboard-templates/support-load.ts
@@ -1,0 +1,25 @@
+// The smallest useful template: a single tile the support team pins in every
+// new project. `featured` asks the UI to surface it near the top of the
+// template picker.
+import { dashboardTemplate } from "@posthog/definitions";
+
+export default dashboardTemplate({
+  key: "support-load",
+  name: "Support load",
+  description: "Ticket volume over time — a one-tile starting point.",
+  tags: ["support"],
+  featured: true,
+  tiles: [
+    {
+      type: "INSIGHT",
+      name: "Tickets opened",
+      layouts: {},
+      color: null,
+      query: {
+        kind: "TrendsQuery",
+        series: [{ kind: "EventsNode", event: "support_ticket_opened", math: "total" }],
+        interval: "day",
+      },
+    },
+  ],
+});

--- a/openapi-filter.yaml
+++ b/openapi-filter.yaml
@@ -86,6 +86,12 @@ inverseOperationIds:
   - actions_partial_update
   - actions_destroy
 
+  - dashboard_templates_list
+  - dashboard_templates_create
+  - dashboard_templates_retrieve
+  - dashboard_templates_partial_update
+  - dashboard_templates_destroy
+
 unusedComponents:
   - schemas
   - parameters

--- a/scripts/smoke-cleanup.ts
+++ b/scripts/smoke-cleanup.ts
@@ -82,6 +82,12 @@ import {
   pruneAction,
 } from "../src/resources/action/pipeline.js";
 
+import { listManagedDashboardTemplates } from "../src/resources/dashboard-template/client.js";
+import {
+  dashboardTemplateKeyFromTags,
+  pruneDashboardTemplate,
+} from "../src/resources/dashboard-template/pipeline.js";
+
 import type { ClientConfig } from "../src/client/config.js";
 
 type Args = {
@@ -96,6 +102,7 @@ type Args = {
   "property-group"?: string;
   cohort?: string;
   endpoint?: string;
+  "dashboard-template"?: string;
 };
 
 const ARG_KEYS: Array<keyof Args> = [
@@ -110,6 +117,7 @@ const ARG_KEYS: Array<keyof Args> = [
   "property-group",
   "cohort",
   "endpoint",
+  "dashboard-template",
 ];
 
 function parseArgs(argv: string[]): Args {
@@ -268,6 +276,16 @@ async function main(): Promise<void> {
       listManagedEndpoints,
       (row) => endpointKeyFromServer(row),
       (c, row) => pruneEndpoint(c, row),
+    );
+  }
+  if (args["dashboard-template"]) {
+    await deleteByKey(
+      "dashboard-template",
+      args["dashboard-template"],
+      config,
+      listManagedDashboardTemplates,
+      (row) => dashboardTemplateKeyFromTags(row.tags),
+      (c, row) => pruneDashboardTemplate(c, row),
     );
   }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -63,6 +63,7 @@ SAVED_METRIC_KEY="smoke-metric-${STAMP}"
 EXPERIMENT_KEY="smoke-experiment-${STAMP}"
 COHORT_KEY="smoke-cohort-${STAMP}"
 ENDPOINT_KEY="smoke-endpoint-${STAMP}"
+DASHBOARD_TEMPLATE_KEY="smoke-dashboard-template-${STAMP}"
 
 # Names that round-trip cleanly through pull's slug-from-name. We use the
 # event-definition `name` as both the spec key AND the on-the-wire event
@@ -71,7 +72,7 @@ EVENT_NAME="${EVENT_DEFINITION_KEY}"
 
 # Resource kinds we'll seed and pull. Used both in --kind for pull and in
 # the no-op assertion's filter (we don't want unrelated kinds dirtying it).
-SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints"
+SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints,dashboard-templates"
 
 cleanup() {
   echo
@@ -88,6 +89,7 @@ cleanup() {
     "--property-group=${PROPERTY_GROUP_KEY}" \
     "--cohort=${COHORT_KEY}" \
     "--endpoint=${ENDPOINT_KEY}" \
+    "--dashboard-template=${DASHBOARD_TEMPLATE_KEY}" \
     || echo "smoke: cleanup hit an error (continuing)"
   echo "smoke: removing workdir $WORK_DIR"
   rm -rf "$WORK_DIR"
@@ -153,7 +155,8 @@ mkdir -p \
   "$SEED_DIR/experiment-saved-metrics" \
   "$SEED_DIR/experiments" \
   "$SEED_DIR/cohorts" \
-  "$SEED_DIR/endpoints"
+  "$SEED_DIR/endpoints" \
+  "$SEED_DIR/dashboard-templates"
 
 # Insight — referenced by the dashboard tile below.
 cat > "$SEED_DIR/insights/smoke-insight.ts" <<EOF
@@ -306,6 +309,25 @@ export default endpoint({
   key: "${ENDPOINT_KEY}",
   name: "${ENDPOINT_KEY}",
   query: { kind: "HogQLQuery", query: "select 1 as smoke" },
+});
+EOF
+
+# Dashboard template — independent. Tiles embed their query inline.
+cat > "$SEED_DIR/dashboard-templates/smoke-dashboard-template.ts" <<EOF
+import { dashboardTemplate } from "@posthog/definitions";
+export default dashboardTemplate({
+  key: "${DASHBOARD_TEMPLATE_KEY}",
+  name: "${DASHBOARD_TEMPLATE_KEY}",
+  description: "Smoke fixture dashboard template",
+  tiles: [
+    {
+      type: "INSIGHT",
+      name: "Smoke tile",
+      layouts: {},
+      color: null,
+      query: { kind: "TrendsQuery", series: [{ kind: "EventsNode", event: "\$pageview", math: "total" }] },
+    },
+  ],
 });
 EOF
 

--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -65,6 +65,39 @@ export interface paths {
         patch: operations["cohorts_partial_update"];
         trace?: never;
     };
+    "/api/projects/{project_id}/dashboard_templates/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["dashboard_templates_list"];
+        put?: never;
+        post: operations["dashboard_templates_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/dashboard_templates/{id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["dashboard_templates_retrieve"];
+        put?: never;
+        post?: never;
+        /** @description Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true */
+        delete: operations["dashboard_templates_destroy"];
+        options?: never;
+        head?: never;
+        patch: operations["dashboard_templates_partial_update"];
+        trace?: never;
+    };
     "/api/projects/{project_id}/dashboards/": {
         parameters: {
             query?: never;
@@ -2681,6 +2714,33 @@ export interface components {
          * @enum {string}
          */
         DashboardPatchWidgetOpenApiWidgetTypeEnum: "activity_events_list" | "error_tracking_list" | "experiment_results" | "experiments_list" | "logs_list" | "session_replay_list" | "survey_results";
+        DashboardTemplate: {
+            /** Format: uuid */
+            readonly id: string;
+            template_name?: string | null;
+            dashboard_description?: string | null;
+            tags?: string[] | null;
+            deleted?: boolean | null;
+            /** Format: date-time */
+            readonly created_at: string | null;
+            readonly created_by: components["schemas"]["UserBasic"];
+            image_url?: string | null;
+            readonly team_id: number | null;
+            scope?: components["schemas"]["DashboardTemplateScopeEnum"] | components["schemas"]["BlankEnum"] | components["schemas"]["NullEnum"];
+            availability_contexts?: string[] | null;
+            /** @description Manually curated; used to highlight templates in the UI. */
+            is_featured?: boolean;
+            /** @description Read-only. Project-specific references (actions, cohorts, data warehouse tables) embedded in this template's tiles that may not resolve when it is used in another project. Events and properties are matched by name and are portable, so they are not reported here. */
+            readonly non_portable_references: components["schemas"]["NonPortableReferences"];
+        };
+        /**
+         * @description * `team` - Only team
+         *     * `organization` - Organization
+         *     * `global` - Global
+         *     * `feature_flag` - Feature Flag
+         * @enum {string}
+         */
+        DashboardTemplateScopeEnum: "team" | "organization" | "global" | "feature_flag";
         DashboardTileBasic: {
             readonly id: number;
             readonly dashboard_id: number;
@@ -10048,6 +10108,14 @@ export interface components {
              */
             warnings: (components["schemas"]["DataWarehouseSyncWarning"] | components["schemas"]["AccessControlFilterWarning"])[] | null;
         };
+        NonPortableReferences: {
+            /** @description Count of distinct action references in the template's tiles that are specific to the source project. */
+            actions: number;
+            /** @description Count of distinct cohort references in the template's tiles that are specific to the source project. */
+            cohorts: number;
+            /** @description Names of data warehouse tables referenced by the template's tiles that are specific to the source project. */
+            warehouse_tables: string[];
+        };
         NullEnum: null;
         /** @description Matches numeric values with comparison operators. */
         NumericPropertyFilter: {
@@ -10166,6 +10234,21 @@ export interface components {
              */
             previous?: string | null;
             results: components["schemas"]["DashboardBasic"][];
+        };
+        PaginatedDashboardTemplateList: {
+            /** @example 123 */
+            count: number;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=400&limit=100
+             */
+            next?: string | null;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=200&limit=100
+             */
+            previous?: string | null;
+            results: components["schemas"]["DashboardTemplate"][];
         };
         PaginatedEndpointResponseList: {
             /** @example 123 */
@@ -10385,6 +10468,25 @@ export interface components {
              * @default []
              */
             _create_static_person_ids: string[];
+        };
+        PatchedDashboardTemplate: {
+            /** Format: uuid */
+            readonly id?: string;
+            template_name?: string | null;
+            dashboard_description?: string | null;
+            tags?: string[] | null;
+            deleted?: boolean | null;
+            /** Format: date-time */
+            readonly created_at?: string | null;
+            readonly created_by?: components["schemas"]["UserBasic"];
+            image_url?: string | null;
+            readonly team_id?: number | null;
+            scope?: components["schemas"]["DashboardTemplateScopeEnum"] | components["schemas"]["BlankEnum"] | components["schemas"]["NullEnum"];
+            availability_contexts?: string[] | null;
+            /** @description Manually curated; used to highlight templates in the UI. */
+            is_featured?: boolean;
+            /** @description Read-only. Project-specific references (actions, cohorts, data warehouse tables) embedded in this template's tiles that may not resolve when it is used in another project. Events and properties are matched by name and are portable, so they are not reported here. */
+            readonly non_portable_references?: components["schemas"]["NonPortableReferences"];
         };
         /** @description Schema for creating/updating endpoints. OpenAPI docs only — validation uses Pydantic. */
         PatchedEndpointRequest: {
@@ -18876,6 +18978,146 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Cohort"];
+                };
+            };
+        };
+    };
+    dashboard_templates_list: {
+        parameters: {
+            query?: {
+                /** @description Omit for all templates. When set, filter by featured flag; parsed with str_to_bool (same as other API query booleans). */
+                is_featured?: boolean;
+                /** @description Number of results to return per page. */
+                limit?: number;
+                /** @description The initial index from which to return the results. */
+                offset?: number;
+                /** @description Optional. When not using `search`, results are sorted with featured templates first (`is_featured=true`), then by `template_name` (case-insensitive A–Z; `-template_name` for Z–A) or by `created_at` (`-created_at` for newest first). When `search` is set, order is featured first, then relevance rank, then case-insensitive name for ties. */
+                ordering?: "-created_at" | "-template_name" | "created_at" | "template_name";
+                /** @description Optional. `global`: official templates only. `team`: this project's saved templates only (`scope=team` rows for the current project). `organization`: templates shared across all projects in this organization. `feature_flag`: feature-flag dashboard templates only. Omit for official, organization, and this project's templates (default dashboard template picker behavior). */
+                scope?: "feature_flag" | "global" | "organization" | "team";
+                /** @description Optional. Full-text search across template name, tags, and description, ranked by relevance. Use it to find templates for a topic (e.g. `retention`, `revenue`, `product analytics`). */
+                search?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedDashboardTemplateList"];
+                };
+            };
+        };
+    };
+    dashboard_templates_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["DashboardTemplate"];
+                "application/x-www-form-urlencoded": components["schemas"]["DashboardTemplate"];
+                "multipart/form-data": components["schemas"]["DashboardTemplate"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DashboardTemplate"];
+                };
+            };
+        };
+    };
+    dashboard_templates_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this dashboard template. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DashboardTemplate"];
+                };
+            };
+        };
+    };
+    dashboard_templates_destroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this dashboard template. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    dashboard_templates_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this dashboard template. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedDashboardTemplate"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedDashboardTemplate"];
+                "multipart/form-data": components["schemas"]["PatchedDashboardTemplate"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DashboardTemplate"];
                 };
             };
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,14 @@ export type {
   Filters,
 } from "./resources/dashboard/index.js";
 
+export { dashboardTemplate } from "./resources/dashboard-template/index.js";
+export type {
+  DashboardTemplate,
+  DashboardTemplateScope,
+  DashboardTemplateTile,
+  DashboardTemplateVariable,
+} from "./resources/dashboard-template/index.js";
+
 export { insight, trends, funnels, hogql } from "./resources/insight/index.js";
 export type {
   Insight,

--- a/src/resources/dashboard-template/client.test.ts
+++ b/src/resources/dashboard-template/client.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { ServerDashboardTemplateSchema } from "./client.js";
+
+// Shape hand-derived from a real GET
+// /api/projects/{id}/dashboard_templates/{id}/ response (project 806).
+const realTemplate = {
+  id: "019f90ac-d895-0000-80ae-7b149b3e4a2f",
+  template_name: "Growth overview",
+  dashboard_description: "Signups, activation, and retention at a glance",
+  tags: ["iac:dashboard-templates:growth", "iac:hash:abcd1234", "growth"],
+  dashboard_filters: { date_from: "-30d" },
+  variables: [{ id: "a1", name: "Event", type: "event", required: true }],
+  tiles: [
+    {
+      name: "Signups",
+      type: "INSIGHT",
+      color: null,
+      layouts: {},
+      query: { kind: "TrendsQuery", series: [{ kind: "EventsNode", event: "$pageview" }] },
+    },
+  ],
+  scope: "team",
+  is_featured: false,
+  deleted: null,
+  created_at: "2026-07-23T00:00:00Z",
+  created_by: { id: 1, uuid: "u", distinct_id: "d" },
+  team_id: 806,
+};
+
+describe("ServerDashboardTemplateSchema", () => {
+  it("parses a real dashboard-template payload", () => {
+    const parsed = ServerDashboardTemplateSchema.parse(realTemplate);
+    expect(parsed.id).toBe("019f90ac-d895-0000-80ae-7b149b3e4a2f");
+    expect(parsed.template_name).toBe("Growth overview");
+    expect(parsed.scope).toBe("team");
+    expect(parsed.tiles).toHaveLength(1);
+    expect(parsed.tags).toContain("iac:dashboard-templates:growth");
+  });
+
+  it("coerces null tags to an empty array", () => {
+    const parsed = ServerDashboardTemplateSchema.parse({ ...realTemplate, tags: null });
+    expect(parsed.tags).toEqual([]);
+  });
+
+  it("throws when a required field is missing (id)", () => {
+    const { id: _omit, ...withoutId } = realTemplate;
+    void _omit;
+    expect(() => ServerDashboardTemplateSchema.parse(withoutId)).toThrow();
+  });
+});

--- a/src/resources/dashboard-template/client.ts
+++ b/src/resources/dashboard-template/client.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+import type { ClientConfig } from "../../client/config.js";
+import type { components } from "../../generated/api.js";
+import { createApiClient, followPagination, type Paginated } from "../../client/typed.js";
+
+/**
+ * The DashboardTemplate serializer schema upstream omits `tiles`, `variables`,
+ * and `dashboard_filters` — yet the live API round-trips all three. We schema
+ * them explicitly (passthrough on the root keeps the rest) so the fields we
+ * actually read are validated.
+ */
+export const ServerDashboardTemplateSchema = z
+  .object({
+    id: z.string(),
+    template_name: z.string().nullable().default(""),
+    dashboard_description: z.string().nullable().optional(),
+    tags: z
+      .array(z.string())
+      .nullish()
+      .transform((v) => v ?? []),
+    tiles: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
+    variables: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
+    dashboard_filters: z.record(z.string(), z.unknown()).nullable().optional(),
+    scope: z.string().nullable().optional(),
+    is_featured: z.boolean().nullable().optional(),
+    deleted: z.boolean().nullable().optional(),
+  })
+  .loose();
+
+export type ServerDashboardTemplate = z.infer<typeof ServerDashboardTemplateSchema>;
+
+export type DashboardTemplateCreate = {
+  template_name: string;
+  dashboard_description?: string;
+  tags?: string[];
+  tiles: unknown[];
+  variables?: unknown[] | null;
+  dashboard_filters?: Record<string, unknown>;
+  is_featured?: boolean;
+};
+
+export type DashboardTemplateUpdate = Partial<DashboardTemplateCreate> & { deleted?: boolean };
+
+type DashboardTemplateBody = components["schemas"]["DashboardTemplate"];
+type PatchedDashboardTemplateBody = components["schemas"]["PatchedDashboardTemplate"];
+type GeneratedPaginatedList = components["schemas"]["PaginatedDashboardTemplateList"];
+
+const MANAGED_TAG_PREFIX = "iac:dashboard-templates:";
+
+function paginatedFrom(raw: GeneratedPaginatedList): Paginated<unknown> {
+  return {
+    count: raw.count,
+    next: raw.next ?? null,
+    previous: raw.previous ?? null,
+    results: raw.results ?? [],
+  };
+}
+
+/** Unfiltered list of every dashboard template in the project; used by pull. */
+export async function listDashboardTemplates(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerDashboardTemplate[]> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/dashboard_templates/", {
+    params: { path: { project_id: config.projectId }, query: { limit: 100 } },
+  });
+  const firstPage = paginatedFrom(data!);
+  const allRaw = await followPagination<unknown>(config, firstPage, { verbose: options.verbose });
+  return allRaw.map((row) => ServerDashboardTemplateSchema.parse(row));
+}
+
+export async function listManagedDashboardTemplates(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerDashboardTemplate[]> {
+  const all = await listDashboardTemplates(config, options);
+  return all.filter((row) => row.tags?.some((tag) => tag.startsWith(MANAGED_TAG_PREFIX)));
+}
+
+export async function getDashboardTemplate(
+  config: ClientConfig,
+  id: string,
+  options: { verbose?: boolean } = {},
+): Promise<ServerDashboardTemplate> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/dashboard_templates/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+  });
+  return ServerDashboardTemplateSchema.parse(data);
+}
+
+export async function createDashboardTemplate(
+  config: ClientConfig,
+  payload: DashboardTemplateCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerDashboardTemplate> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.POST("/api/projects/{project_id}/dashboard_templates/", {
+    params: { path: { project_id: config.projectId } },
+    body: payload as unknown as DashboardTemplateBody,
+  });
+  return ServerDashboardTemplateSchema.parse(data);
+}
+
+export async function updateDashboardTemplate(
+  config: ClientConfig,
+  id: string,
+  payload: DashboardTemplateUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerDashboardTemplate> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.PATCH("/api/projects/{project_id}/dashboard_templates/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+    body: payload as unknown as PatchedDashboardTemplateBody,
+  });
+  return ServerDashboardTemplateSchema.parse(data);
+}
+
+/**
+ * Delete a template. The `DELETE` verb is a no-op upstream (it does not remove
+ * the row); templates soft-delete via `PATCH { deleted: true }`, same as
+ * dashboards and insights.
+ */
+export async function deleteDashboardTemplate(
+  config: ClientConfig,
+  id: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  await updateDashboardTemplate(config, id, { deleted: true }, options);
+}

--- a/src/resources/dashboard-template/codegen.ts
+++ b/src/resources/dashboard-template/codegen.ts
@@ -1,0 +1,72 @@
+import type { ClientConfig } from "../../client/config.js";
+import { renderObject, renderRawLiteral, stringLiteral } from "../../pull/render.js";
+import { slugify } from "../../pull/slug.js";
+import type { PullRenderContext, RenderedFile } from "../../pull/types.js";
+import { type ServerDashboardTemplate, updateDashboardTemplate } from "./client.js";
+import { dashboardTemplateTag, HASH_TAG_PREFIX } from "./pipeline.js";
+import type { DashboardTemplate } from "./sdk.js";
+
+export function pullFilter(
+  server: ServerDashboardTemplate,
+): { kept: true } | { kept: false; reason: string } {
+  if (server.deleted) return { kept: false, reason: "deleted" };
+  // Only project-scoped (`team`) templates are manageable; global / org /
+  // feature-flag templates are read-only surface owned elsewhere.
+  if (server.scope && server.scope !== "team") {
+    return { kept: false, reason: `${server.scope}-scoped (read-only)` };
+  }
+  return { kept: true };
+}
+
+export function pullLabel(server: ServerDashboardTemplate): { primary: string; secondary?: string } {
+  const tileCount = server.tiles?.length ?? 0;
+  return { primary: server.template_name ?? "(unnamed)", secondary: `[${tileCount} tiles]` };
+}
+
+export function serverIdOf(server: ServerDashboardTemplate): string {
+  return server.id;
+}
+
+export function renderToFile(
+  server: ServerDashboardTemplate,
+  ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const baseSlug = slugify(server.template_name ?? "") || `dashboard-template-${server.id}`;
+  const slug = ctx.uniqueSlug(baseSlug);
+
+  const fields: Record<string, string> = {
+    key: stringLiteral(slug),
+    name: stringLiteral(server.template_name ?? ""),
+  };
+  if (server.dashboard_description) fields.description = stringLiteral(server.dashboard_description);
+  fields.tiles = renderRawLiteral(server.tiles ?? [], 2);
+  if (server.dashboard_filters && Object.keys(server.dashboard_filters).length > 0) {
+    fields.filters = renderRawLiteral(server.dashboard_filters, 2);
+  }
+  if (server.variables != null) fields.variables = renderRawLiteral(server.variables, 2);
+  if (server.is_featured) fields.featured = "true";
+
+  const userTags = (server.tags ?? []).filter((t) => !t.startsWith("iac:"));
+  if (userTags.length > 0) fields.tags = renderRawLiteral(userTags, 2);
+
+  const contents = [
+    `import { dashboardTemplate } from "@posthog/definitions";`,
+    "",
+    `export default dashboardTemplate(${renderObject(fields, 2)});`,
+    "",
+  ].join("\n");
+
+  return { filename: `${slug}.ts`, contents, specKey: slug };
+}
+
+export async function tagOnServer(
+  config: ClientConfig,
+  server: ServerDashboardTemplate,
+  spec: DashboardTemplate,
+  hash: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const userTags = (server.tags ?? []).filter((t) => !t.startsWith("iac:"));
+  const tags = [dashboardTemplateTag(spec.key), `${HASH_TAG_PREFIX}${hash}`, ...userTags];
+  await updateDashboardTemplate(config, server.id, { tags }, options);
+}

--- a/src/resources/dashboard-template/index.ts
+++ b/src/resources/dashboard-template/index.ts
@@ -1,0 +1,62 @@
+import type { ApplyContext, CollectionResourceModule } from "../types.js";
+import type { DashboardTemplate } from "./sdk.js";
+import {
+  DASHBOARD_TEMPLATE_TAG_PREFIX,
+  dashboardTemplateHash,
+  dashboardTemplateHashFromTags,
+  dashboardTemplateKeyFromTags,
+  displayDashboardTemplate,
+  displayDashboardTemplateFromServer,
+  looksLikeDashboardTemplate,
+  pruneDashboardTemplate,
+  runDashboardTemplateOp,
+  validateDashboardTemplates,
+} from "./pipeline.js";
+import {
+  getDashboardTemplate,
+  listDashboardTemplates,
+  listManagedDashboardTemplates,
+  type ServerDashboardTemplate,
+} from "./client.js";
+import { pullFilter, pullLabel, renderToFile, serverIdOf, tagOnServer } from "./codegen.js";
+
+export { dashboardTemplate } from "./sdk.js";
+export type {
+  DashboardTemplate,
+  DashboardTemplateScope,
+  DashboardTemplateTile,
+  DashboardTemplateVariable,
+} from "./sdk.js";
+
+export const dashboardTemplateResource: CollectionResourceModule<
+  DashboardTemplate,
+  ServerDashboardTemplate
+> = {
+  kind: "collection",
+  name: "dashboard-templates",
+  displayName: "dashboard template",
+  identityPrefix: DASHBOARD_TEMPLATE_TAG_PREFIX,
+
+  isSpec: looksLikeDashboardTemplate,
+  specKey: (spec) => spec.key,
+
+  list: listManagedDashboardTemplates,
+  keyFromServer: (server) => dashboardTemplateKeyFromTags(server.tags),
+  hashFromServer: (server) => dashboardTemplateHashFromTags(server.tags),
+
+  hash: dashboardTemplateHash,
+  validate: (specs) => validateDashboardTemplates(specs),
+  executeOp: runDashboardTemplateOp,
+  prune: pruneDashboardTemplate,
+
+  displaySpec: (spec, _ctx: ApplyContext) => displayDashboardTemplate(spec),
+  displayServer: (server, _ctx: ApplyContext) => displayDashboardTemplateFromServer(server),
+
+  listAll: listDashboardTemplates,
+  getById: (config, id, options) => getDashboardTemplate(config, String(id), options),
+  pullFilter,
+  pullLabel,
+  serverIdOf,
+  renderToFile,
+  tagOnServer,
+};

--- a/src/resources/dashboard-template/pipeline.test.ts
+++ b/src/resources/dashboard-template/pipeline.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { diff } from "../../apply/diff.js";
+import type { DesiredState } from "../types.js";
+import type { DashboardTemplate } from "./sdk.js";
+import type { ServerDashboardTemplate } from "./client.js";
+import { dashboardTemplateHash, validateDashboardTemplates } from "./pipeline.js";
+
+function spec(key: string, overrides: Partial<DashboardTemplate> = {}): DashboardTemplate {
+  return {
+    key,
+    name: `Template ${key}`,
+    tiles: [{ type: "INSIGHT", name: "Signups", query: { kind: "TrendsQuery", series: [] } }],
+    ...overrides,
+  };
+}
+
+function serverRow(
+  id: string,
+  key: string,
+  hash: string,
+  extra: string[] = [],
+): ServerDashboardTemplate {
+  return {
+    id,
+    template_name: `Template ${key}`,
+    dashboard_description: "",
+    tiles: [{ type: "INSIGHT", name: "Signups", query: { kind: "TrendsQuery", series: [] } }],
+    dashboard_filters: {},
+    scope: "team",
+    tags: [`iac:dashboard-templates:${key}`, `iac:hash:${hash}`, ...extra],
+  };
+}
+
+function desiredFor(specs: DashboardTemplate[]): DesiredState {
+  const state: DesiredState = new Map();
+  state.set(
+    "dashboard-templates",
+    specs.map((spec) => ({ path: "<test>", spec })),
+  );
+  return state;
+}
+
+function currentFor(rows: ServerDashboardTemplate[]): Map<string, unknown[]> {
+  return new Map<string, unknown[]>([["dashboard-templates", rows]]);
+}
+
+describe("dashboard-template pipeline", () => {
+  it("emits create when desired has no matching server row", () => {
+    const result = diff(desiredFor([spec("growth")]), currentFor([]));
+    const slice = result.get("dashboard-templates")!;
+    expect(slice.ops.length).toBe(1);
+    expect(slice.ops[0]!.kind).toBe("create");
+    expect((slice.ops[0]!.spec as { key: string }).key).toBe("growth");
+  });
+
+  it("emits unchanged when server hash matches the desired spec's hash", () => {
+    const desired = spec("growth");
+    const server = serverRow("abc", "growth", dashboardTemplateHash(desired));
+    const result = diff(desiredFor([desired]), currentFor([server]));
+    const op = result.get("dashboard-templates")!.ops[0]!;
+    expect(op.kind).toBe("unchanged");
+    if (op.kind === "unchanged") expect((op.server as { id: string }).id).toBe("abc");
+  });
+
+  it("emits update when server hash differs", () => {
+    const desired = spec("growth");
+    const server = serverRow("abc", "growth", "stalehash00000000");
+    const result = diff(desiredFor([desired]), currentFor([server]));
+    const op = result.get("dashboard-templates")!.ops[0]!;
+    expect(op.kind).toBe("update");
+    if (op.kind === "update") expect((op.server as { id: string }).id).toBe("abc");
+  });
+
+  it("classifies a server-only managed template as an orphan", () => {
+    const server = serverRow("z9", "ghost", "any");
+    const result = diff(desiredFor([]), currentFor([server]));
+    const slice = result.get("dashboard-templates")!;
+    expect(slice.orphans.length).toBe(1);
+    expect((slice.orphans[0] as ServerDashboardTemplate).id).toBe("z9");
+  });
+
+  it("safety invariant: ignores server rows without an iac:* tag", () => {
+    const handBuilt: ServerDashboardTemplate = {
+      id: "hand",
+      template_name: "Hand-built",
+      dashboard_description: "",
+      tiles: [],
+      tags: ["curated"],
+    };
+    const result = diff(desiredFor([]), currentFor([handBuilt]));
+    const slice = result.get("dashboard-templates")!;
+    expect(slice.ops.length).toBe(0);
+    expect(slice.orphans.length).toBe(0);
+  });
+});
+
+describe("dashboard-template validation", () => {
+  it("rejects keys that don't match the allowed pattern", () => {
+    const issues = validateDashboardTemplates([spec("not valid!")]);
+    expect(issues.some((m) => m.includes("must match"))).toBeTruthy();
+  });
+
+  it("rejects duplicate keys", () => {
+    const issues = validateDashboardTemplates([spec("dup"), spec("dup")]);
+    expect(issues.some((m) => m.includes("Duplicate"))).toBeTruthy();
+  });
+
+  it("requires a non-empty name", () => {
+    const issues = validateDashboardTemplates([spec("ok", { name: "" })]);
+    expect(issues.some((m) => m.includes("name is required"))).toBeTruthy();
+  });
+
+  it("requires at least one tile", () => {
+    const issues = validateDashboardTemplates([spec("notile", { tiles: [] })]);
+    expect(issues.some((m) => m.includes("at least one tile"))).toBeTruthy();
+  });
+
+  it("rejects a non-team scope (global/official templates are read-only)", () => {
+    const issues = validateDashboardTemplates([
+      spec("official", { scope: "global" as DashboardTemplate["scope"] }),
+    ]);
+    expect(issues.some((m) => m.includes("only project-scoped"))).toBeTruthy();
+  });
+
+  it("accepts a minimal valid spec", () => {
+    const issues = validateDashboardTemplates([spec("ok")]);
+    expect(issues).toEqual([]);
+  });
+});

--- a/src/resources/dashboard-template/pipeline.ts
+++ b/src/resources/dashboard-template/pipeline.ts
@@ -1,0 +1,209 @@
+import type { ClientConfig } from "../../client/config.js";
+import { ApiError } from "../../client/typed.js";
+import { specHash } from "../../apply/hash.js";
+import { arr, displayJson, filterUserTags, obj, scalar, type DisplayValue } from "../../apply/display.js";
+import { SafetyViolationError } from "../../apply/errors.js";
+import { getResourceKind, type ApplyContext, type ResourceOp } from "../types.js";
+import type { DashboardTemplate } from "./sdk.js";
+import {
+  createDashboardTemplate,
+  type DashboardTemplateCreate,
+  deleteDashboardTemplate,
+  getDashboardTemplate,
+  type ServerDashboardTemplate,
+  updateDashboardTemplate,
+} from "./client.js";
+
+/**
+ * Dashboard templates carry a real `tags` field, so identity is the plain
+ * dashboards pattern: an `iac:dashboard-templates:<key>` tag plus the shared
+ * `iac:hash:<hex>` tag.
+ */
+export const DASHBOARD_TEMPLATE_TAG_PREFIX = "iac:dashboard-templates:";
+export const HASH_TAG_PREFIX = "iac:hash:";
+
+const KEY_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export function dashboardTemplateTag(key: string): string {
+  return `${DASHBOARD_TEMPLATE_TAG_PREFIX}${key}`;
+}
+
+export function dashboardTemplateKeyFromTags(tags: string[] | undefined): string | undefined {
+  const tag = tags?.find((t) => t.startsWith(DASHBOARD_TEMPLATE_TAG_PREFIX));
+  return tag?.slice(DASHBOARD_TEMPLATE_TAG_PREFIX.length);
+}
+
+export function dashboardTemplateHashFromTags(tags: string[] | undefined): string | undefined {
+  return tags?.find((t) => t.startsWith(HASH_TAG_PREFIX))?.slice(HASH_TAG_PREFIX.length);
+}
+
+function hashTag(hex: string): string {
+  return `${HASH_TAG_PREFIX}${hex}`;
+}
+
+function mergeTags(userTags: string[] | undefined, managedTags: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const tag of managedTags) {
+    if (seen.has(tag)) continue;
+    seen.add(tag);
+    result.push(tag);
+  }
+  for (const tag of userTags ?? []) {
+    if (tag.startsWith("iac:")) continue;
+    if (seen.has(tag)) continue;
+    seen.add(tag);
+    result.push(tag);
+  }
+  return result;
+}
+
+function dashboardTemplateSpecForHash(spec: DashboardTemplate): unknown {
+  // Everything the API round-trips, EXCLUDING server-only fields and managed
+  // tags. `scope` is excluded — it is validated to a constant ("team"). Tiles
+  // and variables are order-sensitive; array order is preserved by specHash.
+  return {
+    key: spec.key,
+    name: spec.name,
+    description: spec.description ?? "",
+    tiles: spec.tiles ?? [],
+    filters: spec.filters ?? {},
+    variables: spec.variables ?? null,
+    featured: spec.featured ?? false,
+    tags: filterUserTags(spec.tags),
+  };
+}
+
+export function dashboardTemplateHash(spec: DashboardTemplate): string {
+  return specHash(dashboardTemplateSpecForHash(spec));
+}
+
+export function dashboardTemplatePayload(
+  spec: DashboardTemplate,
+  hash: string,
+): DashboardTemplateCreate {
+  const payload: DashboardTemplateCreate = {
+    template_name: spec.name,
+    tiles: spec.tiles ?? [],
+    tags: mergeTags(spec.tags, [dashboardTemplateTag(spec.key), hashTag(hash)]),
+    dashboard_filters: spec.filters ?? {},
+  };
+  if (spec.description !== undefined) payload.dashboard_description = spec.description;
+  if (spec.variables !== undefined) payload.variables = spec.variables;
+  if (spec.featured !== undefined) payload.is_featured = spec.featured;
+  return payload;
+}
+
+export function looksLikeDashboardTemplate(value: unknown): value is DashboardTemplate {
+  return getResourceKind(value) === "dashboard-template";
+}
+
+export function validateDashboardTemplates(specs: DashboardTemplate[]): string[] {
+  const issues: string[] = [];
+  const seenKeys = new Set<string>();
+  const seenNames = new Set<string>();
+
+  for (const spec of specs) {
+    if (!spec.key) {
+      issues.push("dashboard-template.key is required");
+      continue;
+    }
+    if (!KEY_PATTERN.test(spec.key)) {
+      issues.push(`dashboard template "${spec.key}" key must match ${KEY_PATTERN.source}`);
+    }
+    if (seenKeys.has(spec.key)) issues.push(`Duplicate dashboard template key "${spec.key}"`);
+    seenKeys.add(spec.key);
+
+    if (!spec.name || spec.name.trim() === "") {
+      issues.push(`dashboard template "${spec.key}" name is required`);
+    } else if (seenNames.has(spec.name)) {
+      issues.push(`Duplicate dashboard template name "${spec.name}"`);
+    } else {
+      seenNames.add(spec.name);
+    }
+
+    if (!Array.isArray(spec.tiles) || spec.tiles.length === 0) {
+      issues.push(`dashboard template "${spec.key}" must have at least one tile`);
+    }
+
+    if (spec.scope !== undefined && spec.scope !== "team") {
+      issues.push(
+        `dashboard template "${spec.key}" declares scope "${spec.scope}" — only project-scoped (scope: "team") templates are managed; global / organization / feature_flag templates are read-only surface`,
+      );
+    }
+  }
+  return issues;
+}
+
+async function assertManagedDashboardTemplate(
+  config: ClientConfig,
+  id: string,
+  key: string,
+  options: { verbose?: boolean },
+): Promise<void> {
+  const current = await getDashboardTemplate(config, id, options);
+  if (!current.tags?.includes(dashboardTemplateTag(key))) {
+    throw new SafetyViolationError("dashboard-template", id, key);
+  }
+}
+
+export async function runDashboardTemplateOp(
+  config: ClientConfig,
+  op: ResourceOp<DashboardTemplate, ServerDashboardTemplate>,
+  _ctx: ApplyContext,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+
+  const payload = dashboardTemplatePayload(op.spec, dashboardTemplateHash(op.spec));
+
+  if (op.kind === "create") {
+    await createDashboardTemplate(config, payload, options);
+    return;
+  }
+
+  await assertManagedDashboardTemplate(config, op.server.id, op.spec.key, options);
+  await updateDashboardTemplate(config, op.server.id, payload, options);
+}
+
+export async function pruneDashboardTemplate(
+  config: ClientConfig,
+  orphan: ServerDashboardTemplate,
+  options: { verbose?: boolean } = {},
+): Promise<boolean> {
+  const key = dashboardTemplateKeyFromTags(orphan.tags) ?? `id:${orphan.id}`;
+  try {
+    await assertManagedDashboardTemplate(config, orphan.id, key, options);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return false;
+    throw err;
+  }
+  await deleteDashboardTemplate(config, orphan.id, options);
+  return true;
+}
+
+export function displayDashboardTemplate(spec: DashboardTemplate): DisplayValue {
+  return obj([
+    ["key", scalar(spec.key)],
+    ["name", scalar(spec.name)],
+    ["description", scalar(spec.description ?? "")],
+    ["tiles", displayJson(spec.tiles ?? [])],
+    ["filters", displayJson(spec.filters ?? {})],
+    ["variables", displayJson(spec.variables ?? null)],
+    ["featured", scalar(spec.featured ?? false)],
+    ["tags", arr(filterUserTags(spec.tags).map(scalar))],
+  ]);
+}
+
+export function displayDashboardTemplateFromServer(server: ServerDashboardTemplate): DisplayValue {
+  return obj([
+    ["key", scalar(dashboardTemplateKeyFromTags(server.tags) ?? "")],
+    ["name", scalar(server.template_name ?? "")],
+    ["description", scalar(server.dashboard_description ?? "")],
+    ["tiles", displayJson(server.tiles ?? [])],
+    ["filters", displayJson(server.dashboard_filters ?? {})],
+    ["variables", displayJson(server.variables ?? null)],
+    ["featured", scalar(server.is_featured ?? false)],
+    ["tags", arr(filterUserTags(server.tags).map(scalar))],
+  ]);
+}

--- a/src/resources/dashboard-template/sdk.ts
+++ b/src/resources/dashboard-template/sdk.ts
@@ -1,0 +1,47 @@
+import { markResourceKind } from "../types.js";
+
+/**
+ * Scope of a dashboard template. Only `team` (project-scoped) templates are
+ * managed by posthog-definitions — `global` / `organization` / `feature_flag`
+ * templates are read-only surface owned elsewhere (validation rejects them).
+ */
+export type DashboardTemplateScope = "team";
+
+/**
+ * A single tile in the template. Tiles are round-tripped verbatim — the
+ * template stores each tile's `query` inline (unlike a live dashboard, whose
+ * tiles link to standalone insights), so the whole array is a passthrough bag
+ * that posthog-definitions canonically hashes but does not enumerate field by
+ * field. Shape mirrors the dashboard-template editor: `{ type, name, query,
+ * layouts, color, … }`.
+ */
+export type DashboardTemplateTile = Record<string, unknown>;
+
+/** A template variable placeholder — passthrough, same treatment as tiles. */
+export type DashboardTemplateVariable = Record<string, unknown>;
+
+export type DashboardTemplate = {
+  key: string;
+  /** Display name — maps to the server's `template_name`. */
+  name: string;
+  /** Free-text blurb — maps to the server's `dashboard_description`. */
+  description?: string;
+  /** The tiles that get instantiated when the template is applied. */
+  tiles: DashboardTemplateTile[];
+  /** Default dashboard-level filters — maps to `dashboard_filters`. */
+  filters?: Record<string, unknown>;
+  /** Optional template variables users fill in when instantiating. */
+  variables?: DashboardTemplateVariable[];
+  /** Whether the UI highlights this template. Maps to `is_featured`. */
+  featured?: boolean;
+  /**
+   * Project-scoped by default; only `team` is accepted. Declaring any other
+   * scope is a validation error (global/official templates are read-only).
+   */
+  scope?: DashboardTemplateScope;
+  tags?: string[];
+};
+
+export function dashboardTemplate(spec: DashboardTemplate): DashboardTemplate {
+  return markResourceKind(spec, "dashboard-template");
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -3,6 +3,7 @@ import { topoOrder } from "./order.js";
 import { actionResource } from "./action/index.js";
 import { cohortResource } from "./cohort/index.js";
 import { dashboardResource } from "./dashboard/index.js";
+import { dashboardTemplateResource } from "./dashboard-template/index.js";
 import { endpointResource } from "./endpoint/index.js";
 import { featureFlagResource } from "./feature-flag/index.js";
 import { insightResource } from "./insight/index.js";
@@ -22,6 +23,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
   actionResource as ResourceModule<unknown, unknown>,
   cohortResource as ResourceModule<unknown, unknown>,
   dashboardResource as ResourceModule<unknown, unknown>,
+  dashboardTemplateResource as ResourceModule<unknown, unknown>,
   endpointResource as ResourceModule<unknown, unknown>,
   eventDefinitionResource as ResourceModule<unknown, unknown>,
   experimentResource as ResourceModule<unknown, unknown>,
@@ -43,6 +45,7 @@ export const RESOURCES: ReadonlyArray<ResourceModule<unknown, unknown>> = topoOr
 
 export { insightResource } from "./insight/index.js";
 export { dashboardResource } from "./dashboard/index.js";
+export { dashboardTemplateResource } from "./dashboard-template/index.js";
 export { actionResource } from "./action/index.js";
 export { cohortResource } from "./cohort/index.js";
 export { featureFlagResource } from "./feature-flag/index.js";

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -8,6 +8,7 @@ import { RESOURCES } from "./index.js";
 import { actionResource } from "./action/index.js";
 import { cohortResource } from "./cohort/index.js";
 import { dashboardResource } from "./dashboard/index.js";
+import { dashboardTemplateResource } from "./dashboard-template/index.js";
 import { endpointResource } from "./endpoint/index.js";
 import { eventDefinitionResource } from "./event-definition/index.js";
 import { experimentResource } from "./experiment/index.js";
@@ -176,6 +177,7 @@ describe("RESOURCES (real registry)", () => {
         actionResource,
         cohortResource,
         dashboardResource,
+        dashboardTemplateResource,
         endpointResource,
         eventDefinitionResource,
         experimentResource,


### PR DESCRIPTION
Adds **dashboard templates** as a managed resource. Third resource in the API-parity campaign chunk (follows #76–#85).

## Identity
Dashboard templates carry a real `tags` array → the plain **dashboards pattern**: `iac:dashboard-templates:<key>` + shared `iac:hash:<hex>`. Easiest identity case.

## Scope handling
Only project-scoped (`scope: "team"`) templates are managed. Declaring a `global` / `organization` / `feature_flag` scope is a validation error (those are read-only surface owned elsewhere), and pull skips non-team rows. Live-confirmed the scope enum is `team | organization | global | feature_flag` — `"project"` is not a valid choice; omitting scope defaults to `team`.

## Live verification (project 806, field by field)
- `template_name`, `tags`, `dashboard_description`, `dashboard_filters`, `tiles`, and `variables` all round-trip on create and PATCH.
- Unlike live dashboards (whose tiles are read-only and link to standalone insights), **template tiles embed their query inline and round-trip verbatim** — so the tile array is a passthrough bag.
- Delete is a **soft-delete via PATCH `{deleted: true}`**; the `DELETE` verb is a no-op upstream.
- Full add-resource flow verified: create → no-op re-apply (0/0/1, hash projection correct) → edit → single update → orphan left alone → hand-built row (no iac tag) untouched → kind-scoped prune deletes managed only. All test rows cleaned up.

## Spec surprise
The upstream `DashboardTemplate` OpenAPI serializer schema **omits `tiles`, `variables`, and `dashboard_filters`** (the template's actual content), even though the live API round-trips all three. The client carries them via a passthrough Zod schema + hand-written payload types (same casting approach as surveys/actions).

## Gates
`pnpm typecheck`, `pnpm typecheck:examples`, `pnpm test` (305 pass), `pnpm lint` all green. Dashboard-template smoke portion verified in isolation (seed → pull → tag-back → no-op). Note: full `smoke.sh` is currently red at the pull step on a pre-existing, unrelated gap — `actions` is in `SMOKE_KINDS` but has no pull codegen on `pl/spec-migration` (lands separately on `pl/pull-actions`).

---

Stacks on #81 (base `pl/spec-migration`) — codegen only compiles there. Retarget to `main` when #81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)