### PR TITLE
feat(session-recording-playlist): SDK factory + pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Alpha — do not use in production.**
 > This is pre-MVP software (`0.1.0-alpha.0`). The CLI, the on-disk file format, the SDK surface, and the tag-based identity model are all subject to breaking changes without notice. Use it on throwaway projects or in a sandbox while we stabilize.
 
-Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
+Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, experiment saved metrics, and session recording playlists in TypeScript, then sync them to a PostHog project with one command.
 
 ## Why
 
@@ -51,6 +51,7 @@ export default dashboard({
    - `event_definition:read`, `event_definition:write` (also covers property groups)
    - `experiment:read`, `experiment:write` (also covers experiment holdouts)
    - `experiment_saved_metric:read`, `experiment_saved_metric:write`
+   - `session_recording_playlist:read`, `session_recording_playlist:write`
 
    Then add it (and your numeric project ID) to a `.env` (or `.envrc`) file:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -18,6 +18,7 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 | Alerts              | ✅ `environments/{id}/alerts`            | ❌                  |                                               |
 | Insight variables   | ✅ `environments/{id}/insight_variables` | ❌                  |                                               |
 | Comments            | ✅ `projects/{id}/comments`              | —                   | Ephemeral by nature                           |
+| Session recording playlists | ✅ `projects/{id}/session_recording_playlists` | ✅        | Identity via `iac:session-recording-playlists:<key>` marker in `description`. Filter-based (dynamic) playlists only; pinned-recording (collection) membership is runtime data, same treatment as static cohorts. Full matrix refresh tracked in #78. |
 
 ## Behavior & experimentation
 

--- a/examples/posthog/session-recording-playlists/long-trial-sessions.ts
+++ b/examples/posthog/session-recording-playlists/long-trial-sessions.ts
@@ -1,0 +1,25 @@
+// Onboarding review queue: long sessions from trial accounts. The growth team
+// watches a few of these each week to see where new workspaces get stuck.
+// Duration + person-property filters combine into one saved view.
+import { sessionRecordingPlaylist } from "@posthog/definitions";
+
+export default sessionRecordingPlaylist({
+  key: "long-trial-sessions",
+  name: "Long trial sessions",
+  description: "Trials that spent 5+ minutes in one sitting — the ones worth watching.",
+  filters: {
+    date_from: "-14d",
+    duration: [{ type: "recording", key: "duration", value: 300, operator: "gt" }],
+    filter_group: {
+      type: "AND",
+      values: [
+        {
+          type: "AND",
+          values: [
+            { key: "plan", value: ["trial"], operator: "exact", type: "person" },
+          ],
+        },
+      ],
+    },
+  },
+});

--- a/examples/posthog/session-recording-playlists/rage-clicks.ts
+++ b/examples/posthog/session-recording-playlists/rage-clicks.ts
@@ -1,0 +1,24 @@
+// A saved-filter playlist the support team lives in: every recording where a
+// user rage-clicked in the last week. Filter-based (dynamic) — membership is
+// recomputed from `filters` on every visit, so you never curate it by hand.
+// (Manually-pinned "collection" playlists aren't managed here; that pinned
+// membership is runtime data, like static-cohort members.)
+import { sessionRecordingPlaylist } from "@posthog/definitions";
+
+export default sessionRecordingPlaylist({
+  key: "rage-clicks",
+  name: "Rage clicks (last 7d)",
+  description: "Sessions with a rage click — triage frustration before it churns.",
+  filters: {
+    date_from: "-7d",
+    filter_test_accounts: true,
+    events: [
+      {
+        id: "$rageclick",
+        name: "$rageclick",
+        type: "events",
+        order: 0,
+      },
+    ],
+  },
+});

--- a/openapi-filter.yaml
+++ b/openapi-filter.yaml
@@ -86,6 +86,12 @@ inverseOperationIds:
   - actions_partial_update
   - actions_destroy
 
+  - session_recording_playlists_list
+  - session_recording_playlists_create
+  - session_recording_playlists_retrieve
+  - session_recording_playlists_partial_update
+  - session_recording_playlists_destroy
+
 unusedComponents:
   - schemas
   - parameters

--- a/scripts/smoke-cleanup.ts
+++ b/scripts/smoke-cleanup.ts
@@ -82,6 +82,12 @@ import {
   pruneAction,
 } from "../src/resources/action/pipeline.js";
 
+import { listManagedSessionRecordingPlaylists } from "../src/resources/session-recording-playlist/client.js";
+import {
+  playlistKeyFromServer,
+  pruneSessionRecordingPlaylist,
+} from "../src/resources/session-recording-playlist/pipeline.js";
+
 import type { ClientConfig } from "../src/client/config.js";
 
 type Args = {
@@ -96,6 +102,7 @@ type Args = {
   "property-group"?: string;
   cohort?: string;
   endpoint?: string;
+  "session-recording-playlist"?: string;
 };
 
 const ARG_KEYS: Array<keyof Args> = [
@@ -110,6 +117,7 @@ const ARG_KEYS: Array<keyof Args> = [
   "property-group",
   "cohort",
   "endpoint",
+  "session-recording-playlist",
 ];
 
 function parseArgs(argv: string[]): Args {
@@ -268,6 +276,16 @@ async function main(): Promise<void> {
       listManagedEndpoints,
       (row) => endpointKeyFromServer(row),
       (c, row) => pruneEndpoint(c, row),
+    );
+  }
+  if (args["session-recording-playlist"]) {
+    await deleteByKey(
+      "session-recording-playlist",
+      args["session-recording-playlist"],
+      config,
+      listManagedSessionRecordingPlaylists,
+      (row) => playlistKeyFromServer(row),
+      (c, row) => pruneSessionRecordingPlaylist(c, row),
     );
   }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -63,6 +63,7 @@ SAVED_METRIC_KEY="smoke-metric-${STAMP}"
 EXPERIMENT_KEY="smoke-experiment-${STAMP}"
 COHORT_KEY="smoke-cohort-${STAMP}"
 ENDPOINT_KEY="smoke-endpoint-${STAMP}"
+PLAYLIST_KEY="smoke-playlist-${STAMP}"
 
 # Names that round-trip cleanly through pull's slug-from-name. We use the
 # event-definition `name` as both the spec key AND the on-the-wire event
@@ -71,7 +72,7 @@ EVENT_NAME="${EVENT_DEFINITION_KEY}"
 
 # Resource kinds we'll seed and pull. Used both in --kind for pull and in
 # the no-op assertion's filter (we don't want unrelated kinds dirtying it).
-SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints"
+SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints,session-recording-playlists"
 
 cleanup() {
   echo
@@ -88,6 +89,7 @@ cleanup() {
     "--property-group=${PROPERTY_GROUP_KEY}" \
     "--cohort=${COHORT_KEY}" \
     "--endpoint=${ENDPOINT_KEY}" \
+    "--session-recording-playlist=${PLAYLIST_KEY}" \
     || echo "smoke: cleanup hit an error (continuing)"
   echo "smoke: removing workdir $WORK_DIR"
   rm -rf "$WORK_DIR"
@@ -153,7 +155,8 @@ mkdir -p \
   "$SEED_DIR/experiment-saved-metrics" \
   "$SEED_DIR/experiments" \
   "$SEED_DIR/cohorts" \
-  "$SEED_DIR/endpoints"
+  "$SEED_DIR/endpoints" \
+  "$SEED_DIR/session-recording-playlists"
 
 # Insight — referenced by the dashboard tile below.
 cat > "$SEED_DIR/insights/smoke-insight.ts" <<EOF
@@ -306,6 +309,17 @@ export default endpoint({
   key: "${ENDPOINT_KEY}",
   name: "${ENDPOINT_KEY}",
   query: { kind: "HogQLQuery", query: "select 1 as smoke" },
+});
+EOF
+
+# Session recording playlist — independent. Filter-based (dynamic) only.
+cat > "$SEED_DIR/session-recording-playlists/smoke-playlist.ts" <<EOF
+import { sessionRecordingPlaylist } from "@posthog/definitions";
+export default sessionRecordingPlaylist({
+  key: "${PLAYLIST_KEY}",
+  name: "${PLAYLIST_KEY}",
+  description: "Smoke fixture playlist",
+  filters: { date_from: "-7d", filter_test_accounts: true },
 });
 EOF
 

--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -648,6 +648,48 @@ export interface paths {
         patch: operations["schema_property_groups_partial_update"];
         trace?: never;
     };
+    "/api/projects/{project_id}/session_recording_playlists/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * @description Override list to include synthetic playlists.
+         *
+         *     Synthetics have no DB row, so we compute each one's position in the merged
+         *     sort and split the requested page between synthetics and a DB queryset slice.
+         *     The merge/rank/sort is all in-memory, so each phase is wrapped in a span and
+         *     the input sizes are recorded as span attributes — a slow response on a team
+         *     with many playlists then shows up as a wide span against a large db_count.
+         */
+        get: operations["session_recording_playlists_list"];
+        put?: never;
+        post: operations["session_recording_playlists_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/session_recording_playlists/{short_id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["session_recording_playlists_retrieve"];
+        put?: never;
+        post?: never;
+        /** @description Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true */
+        delete: operations["session_recording_playlists_destroy"];
+        options?: never;
+        head?: never;
+        patch: operations["session_recording_playlists_partial_update"];
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -10302,6 +10344,21 @@ export interface components {
             previous?: string | null;
             results: components["schemas"]["SchemaPropertyGroup"][];
         };
+        PaginatedSessionRecordingPlaylistList: {
+            /** @example 123 */
+            count: number;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=400&limit=100
+             */
+            next?: string | null;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=200&limit=100
+             */
+            previous?: string | null;
+            results: components["schemas"]["SessionRecordingPlaylist"][];
+        };
         /**
          * ParserMode
          * @enum {string}
@@ -10736,6 +10793,43 @@ export interface components {
             /** Format: date-time */
             readonly updated_at?: string;
             readonly created_by?: components["schemas"]["UserBasic"];
+        };
+        PatchedSessionRecordingPlaylist: {
+            readonly id?: number;
+            readonly short_id?: string;
+            /** @description Human-readable name for the playlist. */
+            name?: string | null;
+            derived_name?: string | null;
+            /** @description Optional description of the playlist's purpose or contents. */
+            description?: string;
+            /** @description Whether this playlist is pinned to the top of the list. */
+            pinned?: boolean;
+            /** Format: date-time */
+            readonly created_at?: string;
+            readonly created_by?: components["schemas"]["UserBasic"];
+            /** @description Set to true to soft-delete the playlist. */
+            deleted?: boolean;
+            /** @description JSON object with recording filter criteria. Only used when type is 'filters'. Defines which recordings match this saved filter view. When updating a filters-type playlist, you must include the existing filters alongside any other changes — omitting filters will be treated as removing them. */
+            filters?: unknown;
+            /** Format: date-time */
+            readonly last_modified_at?: string;
+            readonly last_modified_by?: components["schemas"]["UserBasic"];
+            readonly recordings_counts?: {
+                [key: string]: {
+                    [key: string]: number | boolean | null;
+                };
+            };
+            /**
+             * @description Playlist type: 'collection' for manually curated recordings, 'filters' for saved filter views. Required on create, cannot be changed after.
+             *
+             *     * `collection` - Collection
+             *     * `filters` - Filters
+             */
+            type?: components["schemas"]["SessionRecordingPlaylistTypeEnum"] | components["schemas"]["NullEnum"];
+            /** @description Return whether this is a synthetic playlist */
+            readonly is_synthetic?: boolean;
+            /** create in folder */
+            _create_in_folder?: string;
         };
         PatchedTeam: {
             readonly id?: number;
@@ -14990,6 +15084,49 @@ export interface components {
              */
             warnings: (components["schemas"]["DataWarehouseSyncWarning"] | components["schemas"]["AccessControlFilterWarning"])[] | null;
         };
+        SessionRecordingPlaylist: {
+            readonly id: number;
+            readonly short_id: string;
+            /** @description Human-readable name for the playlist. */
+            name?: string | null;
+            derived_name?: string | null;
+            /** @description Optional description of the playlist's purpose or contents. */
+            description?: string;
+            /** @description Whether this playlist is pinned to the top of the list. */
+            pinned?: boolean;
+            /** Format: date-time */
+            readonly created_at: string;
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** @description Set to true to soft-delete the playlist. */
+            deleted?: boolean;
+            /** @description JSON object with recording filter criteria. Only used when type is 'filters'. Defines which recordings match this saved filter view. When updating a filters-type playlist, you must include the existing filters alongside any other changes — omitting filters will be treated as removing them. */
+            filters?: unknown;
+            /** Format: date-time */
+            readonly last_modified_at: string;
+            readonly last_modified_by: components["schemas"]["UserBasic"];
+            readonly recordings_counts: {
+                [key: string]: {
+                    [key: string]: number | boolean | null;
+                };
+            };
+            /**
+             * @description Playlist type: 'collection' for manually curated recordings, 'filters' for saved filter views. Required on create, cannot be changed after.
+             *
+             *     * `collection` - Collection
+             *     * `filters` - Filters
+             */
+            type?: components["schemas"]["SessionRecordingPlaylistTypeEnum"] | components["schemas"]["NullEnum"];
+            /** @description Return whether this is a synthetic playlist */
+            readonly is_synthetic: boolean;
+            /** create in folder */
+            _create_in_folder?: string;
+        };
+        /**
+         * @description * `collection` - Collection
+         *     * `filters` - Filters
+         * @enum {string}
+         */
+        SessionRecordingPlaylistTypeEnum: "collection" | "filters";
         /**
          * @description * `30d` - 30 Days
          *     * `90d` - 90 Days
@@ -20630,6 +20767,137 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SchemaPropertyGroup"];
+                };
+            };
+        };
+    };
+    session_recording_playlists_list: {
+        parameters: {
+            query?: {
+                created_by?: number;
+                /** @description Number of results to return per page. */
+                limit?: number;
+                /** @description The initial index from which to return the results. */
+                offset?: number;
+                short_id?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedSessionRecordingPlaylistList"];
+                };
+            };
+        };
+    };
+    session_recording_playlists_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["SessionRecordingPlaylist"];
+                "application/x-www-form-urlencoded": components["schemas"]["SessionRecordingPlaylist"];
+                "multipart/form-data": components["schemas"]["SessionRecordingPlaylist"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionRecordingPlaylist"];
+                };
+            };
+        };
+    };
+    session_recording_playlists_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+                short_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionRecordingPlaylist"];
+                };
+            };
+        };
+    };
+    session_recording_playlists_destroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+                short_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    session_recording_playlists_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+                short_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedSessionRecordingPlaylist"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedSessionRecordingPlaylist"];
+                "multipart/form-data": components["schemas"]["PatchedSessionRecordingPlaylist"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionRecordingPlaylist"];
                 };
             };
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,5 +75,11 @@ export type {
 export { projectSettings } from "./resources/project-settings/index.js";
 export type { ProjectSettings } from "./resources/project-settings/index.js";
 
+export { sessionRecordingPlaylist } from "./resources/session-recording-playlist/index.js";
+export type {
+  SessionRecordingPlaylist,
+  SessionRecordingPlaylistFilters,
+} from "./resources/session-recording-playlist/index.js";
+
 export { createTypedPostHog } from "./client/typed-posthog.js";
 export type { TypedPostHog, CaptureCapableClient } from "./client/typed-posthog.js";

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -12,6 +12,7 @@ import { experimentHoldoutResource } from "./experiment-holdout/index.js";
 import { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
+import { sessionRecordingPlaylistResource } from "./session-recording-playlist/index.js";
 
 /**
  * Source-of-truth registry. Listed in stable, human-readable order — the
@@ -31,6 +32,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
   insightResource as ResourceModule<unknown, unknown>,
   projectSettingsResource as ResourceModule<unknown, unknown>,
   propertyGroupResource as ResourceModule<unknown, unknown>,
+  sessionRecordingPlaylistResource as ResourceModule<unknown, unknown>,
 ];
 
 /**
@@ -53,6 +55,7 @@ export { experimentHoldoutResource } from "./experiment-holdout/index.js";
 export { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 export { experimentResource } from "./experiment/index.js";
 export { projectSettingsResource } from "./project-settings/index.js";
+export { sessionRecordingPlaylistResource } from "./session-recording-playlist/index.js";
 export type {
   ResourceModule,
   CollectionResourceModule,

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -16,6 +16,7 @@ import { experimentSavedMetricResource } from "./experiment-saved-metric/index.j
 import { featureFlagResource } from "./feature-flag/index.js";
 import { insightResource } from "./insight/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
+import { sessionRecordingPlaylistResource } from "./session-recording-playlist/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
 
 describe("topoOrder", () => {
@@ -185,6 +186,7 @@ describe("RESOURCES (real registry)", () => {
         insightResource,
         projectSettingsResource,
         propertyGroupResource,
+        sessionRecordingPlaylistResource,
       ].map((r) => r.name),
     );
     expect(new Set(RESOURCES.map((r) => r.name))).toEqual(expected);

--- a/src/resources/session-recording-playlist/client.test.ts
+++ b/src/resources/session-recording-playlist/client.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { ServerSessionRecordingPlaylistSchema } from "./client.js";
+
+// Shape hand-derived from a real GET
+// /api/projects/{id}/session_recording_playlists/{short_id}/ response (806).
+const realPlaylist = {
+  id: 12689,
+  short_id: "UvdSUJbr",
+  name: "Rage-click sessions",
+  derived_name: null,
+  description:
+    "Frustrated users\n\n<!-- iac:session-recording-playlists:rage iac:hash:abcd1234 -->",
+  type: "filters",
+  filters: {
+    date_from: "-7d",
+    duration: [{ type: "recording", key: "duration", value: 60, operator: "gt" }],
+    filter_test_accounts: true,
+  },
+  deleted: false,
+  is_synthetic: false,
+  recordings_counts: { collection: { count: null } },
+  created_at: "2026-07-23T00:00:00Z",
+  created_by: { id: 1, uuid: "u", distinct_id: "d" },
+};
+
+describe("ServerSessionRecordingPlaylistSchema", () => {
+  it("parses a real playlist payload", () => {
+    const parsed = ServerSessionRecordingPlaylistSchema.parse(realPlaylist);
+    expect(parsed.short_id).toBe("UvdSUJbr");
+    expect(parsed.type).toBe("filters");
+    expect(parsed.filters).toHaveProperty("date_from", "-7d");
+  });
+
+  it("throws when short_id is missing", () => {
+    const { short_id: _omit, ...withoutShortId } = realPlaylist;
+    void _omit;
+    expect(() => ServerSessionRecordingPlaylistSchema.parse(withoutShortId)).toThrow();
+  });
+
+  it("throws on an unknown playlist type", () => {
+    expect(() =>
+      ServerSessionRecordingPlaylistSchema.parse({ ...realPlaylist, type: "album" }),
+    ).toThrow();
+  });
+});

--- a/src/resources/session-recording-playlist/client.ts
+++ b/src/resources/session-recording-playlist/client.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+import type { ClientConfig } from "../../client/config.js";
+import type { components } from "../../generated/api.js";
+import { createApiClient, followPagination, type Paginated } from "../../client/typed.js";
+
+const MANAGED_DESCRIPTION_PREFIX = "<!-- iac:session-recording-playlists:";
+
+export const ServerSessionRecordingPlaylistSchema = z
+  .object({
+    id: z.number(),
+    short_id: z.string(),
+    name: z.string().nullable().optional(),
+    derived_name: z.string().nullable().optional(),
+    description: z.string().nullable().default(""),
+    type: z.enum(["collection", "filters"]).nullable().optional(),
+    filters: z.record(z.string(), z.unknown()).nullable().optional(),
+    deleted: z.boolean().nullable().optional(),
+    is_synthetic: z.boolean().nullable().optional(),
+  })
+  .loose();
+
+export type ServerSessionRecordingPlaylist = z.infer<typeof ServerSessionRecordingPlaylistSchema>;
+
+export type SessionRecordingPlaylistCreate = {
+  name: string;
+  description: string;
+  type: "filters";
+  filters: Record<string, unknown>;
+};
+
+export type SessionRecordingPlaylistUpdate = {
+  name?: string;
+  description?: string;
+  // Always sent on update — the API rejects a filters-type playlist update
+  // that omits filters ("cannot remove all filters when updating a saved
+  // filter").
+  filters: Record<string, unknown>;
+  deleted?: boolean;
+};
+
+type PlaylistBody = components["schemas"]["SessionRecordingPlaylist"];
+type PatchedPlaylistBody = components["schemas"]["PatchedSessionRecordingPlaylist"];
+type GeneratedPaginatedList = components["schemas"]["PaginatedSessionRecordingPlaylistList"];
+
+function paginatedFrom(raw: GeneratedPaginatedList): Paginated<unknown> {
+  return {
+    count: raw.count,
+    next: raw.next ?? null,
+    previous: raw.previous ?? null,
+    results: raw.results ?? [],
+  };
+}
+
+/** Unfiltered list of every playlist in the project; used by pull. */
+export async function listSessionRecordingPlaylists(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerSessionRecordingPlaylist[]> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/session_recording_playlists/", {
+    params: { path: { project_id: config.projectId }, query: { limit: 100 } },
+  });
+  const firstPage = paginatedFrom(data!);
+  const allRaw = await followPagination<unknown>(config, firstPage, { verbose: options.verbose });
+  return allRaw.map((row) => ServerSessionRecordingPlaylistSchema.parse(row));
+}
+
+export async function listManagedSessionRecordingPlaylists(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerSessionRecordingPlaylist[]> {
+  const all = await listSessionRecordingPlaylists(config, options);
+  return all.filter((row) => (row.description ?? "").includes(MANAGED_DESCRIPTION_PREFIX));
+}
+
+export async function getSessionRecordingPlaylist(
+  config: ClientConfig,
+  shortId: string,
+  options: { verbose?: boolean } = {},
+): Promise<ServerSessionRecordingPlaylist> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET(
+    "/api/projects/{project_id}/session_recording_playlists/{short_id}/",
+    { params: { path: { project_id: config.projectId, short_id: shortId } } },
+  );
+  return ServerSessionRecordingPlaylistSchema.parse(data);
+}
+
+export async function createSessionRecordingPlaylist(
+  config: ClientConfig,
+  payload: SessionRecordingPlaylistCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerSessionRecordingPlaylist> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.POST("/api/projects/{project_id}/session_recording_playlists/", {
+    params: { path: { project_id: config.projectId } },
+    body: payload as unknown as PlaylistBody,
+  });
+  return ServerSessionRecordingPlaylistSchema.parse(data);
+}
+
+export async function updateSessionRecordingPlaylist(
+  config: ClientConfig,
+  shortId: string,
+  payload: SessionRecordingPlaylistUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerSessionRecordingPlaylist> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.PATCH(
+    "/api/projects/{project_id}/session_recording_playlists/{short_id}/",
+    {
+      params: { path: { project_id: config.projectId, short_id: shortId } },
+      body: payload as unknown as PatchedPlaylistBody,
+    },
+  );
+  return ServerSessionRecordingPlaylistSchema.parse(data);
+}
+
+/**
+ * Delete a playlist. The `DELETE` verb returns 405 upstream; playlists
+ * soft-delete via `PATCH { deleted: true }`. The existing `filters` must ride
+ * along or the update is rejected as "removing all filters".
+ */
+export async function deleteSessionRecordingPlaylist(
+  config: ClientConfig,
+  shortId: string,
+  filters: Record<string, unknown>,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  await updateSessionRecordingPlaylist(config, shortId, { deleted: true, filters }, options);
+}

--- a/src/resources/session-recording-playlist/codegen.ts
+++ b/src/resources/session-recording-playlist/codegen.ts
@@ -1,0 +1,78 @@
+import type { ClientConfig } from "../../client/config.js";
+import { renderObject, renderRawLiteral, stringLiteral } from "../../pull/render.js";
+import { slugify } from "../../pull/slug.js";
+import type { PullRenderContext, RenderedFile } from "../../pull/types.js";
+import { type ServerSessionRecordingPlaylist, updateSessionRecordingPlaylist } from "./client.js";
+import { stripMarker } from "./pipeline.js";
+import type { SessionRecordingPlaylist } from "./sdk.js";
+
+const MARKER_PREFIX = "iac:session-recording-playlists:";
+const HASH_MARKER_PREFIX = "iac:hash:";
+
+export function pullFilter(
+  server: ServerSessionRecordingPlaylist,
+): { kept: true } | { kept: false; reason: string } {
+  if (server.deleted) return { kept: false, reason: "deleted" };
+  if (server.is_synthetic) return { kept: false, reason: "synthetic" };
+  // Only filter-based (dynamic) playlists are declarative; collection
+  // (manually-pinned) playlists are runtime membership data.
+  if (server.type && server.type !== "filters") {
+    return { kept: false, reason: `${server.type} (pinned-recording membership)` };
+  }
+  return { kept: true };
+}
+
+export function pullLabel(
+  server: ServerSessionRecordingPlaylist,
+): { primary: string; secondary?: string } {
+  return { primary: server.name ?? server.short_id, secondary: "[filters]" };
+}
+
+export function serverIdOf(server: ServerSessionRecordingPlaylist): string {
+  return server.short_id;
+}
+
+export function renderToFile(
+  server: ServerSessionRecordingPlaylist,
+  ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const baseSlug = slugify(server.name ?? "") || `playlist-${server.short_id}`;
+  const slug = ctx.uniqueSlug(baseSlug);
+
+  const fields: Record<string, string> = {
+    key: stringLiteral(slug),
+    name: stringLiteral(server.name ?? ""),
+  };
+  const userDescription = stripMarker(server.description);
+  if (userDescription) fields.description = stringLiteral(userDescription);
+  fields.filters = renderRawLiteral(server.filters ?? {}, 2);
+
+  const contents = [
+    `import { sessionRecordingPlaylist } from "@posthog/definitions";`,
+    "",
+    `export default sessionRecordingPlaylist(${renderObject(fields, 2)});`,
+    "",
+  ].join("\n");
+
+  return { filename: `${slug}.ts`, contents, specKey: slug };
+}
+
+export async function tagOnServer(
+  config: ClientConfig,
+  server: ServerSessionRecordingPlaylist,
+  spec: SessionRecordingPlaylist,
+  hash: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const userDescription = stripMarker(server.description);
+  const marker = `<!-- ${MARKER_PREFIX}${spec.key} ${HASH_MARKER_PREFIX}${hash} -->`;
+  const newDescription = userDescription ? `${userDescription}\n\n${marker}` : marker;
+  // Filters must ride along — the API rejects a filters-type update that omits
+  // them.
+  await updateSessionRecordingPlaylist(
+    config,
+    server.short_id,
+    { description: newDescription, filters: server.filters ?? {} },
+    options,
+  );
+}

--- a/src/resources/session-recording-playlist/index.ts
+++ b/src/resources/session-recording-playlist/index.ts
@@ -1,0 +1,60 @@
+import type { ApplyContext, CollectionResourceModule } from "../types.js";
+import type { SessionRecordingPlaylist } from "./sdk.js";
+import {
+  displaySessionRecordingPlaylist,
+  displaySessionRecordingPlaylistFromServer,
+  looksLikeSessionRecordingPlaylist,
+  playlistHash,
+  playlistHashFromServer,
+  playlistKeyFromServer,
+  pruneSessionRecordingPlaylist,
+  runSessionRecordingPlaylistOp,
+  SESSION_RECORDING_PLAYLIST_IDENTITY_PREFIX,
+  validateSessionRecordingPlaylists,
+} from "./pipeline.js";
+import {
+  getSessionRecordingPlaylist,
+  listManagedSessionRecordingPlaylists,
+  listSessionRecordingPlaylists,
+  type ServerSessionRecordingPlaylist,
+} from "./client.js";
+import { pullFilter, pullLabel, renderToFile, serverIdOf, tagOnServer } from "./codegen.js";
+
+export { sessionRecordingPlaylist } from "./sdk.js";
+export type {
+  SessionRecordingPlaylist,
+  SessionRecordingPlaylistFilters,
+} from "./sdk.js";
+
+export const sessionRecordingPlaylistResource: CollectionResourceModule<
+  SessionRecordingPlaylist,
+  ServerSessionRecordingPlaylist
+> = {
+  kind: "collection",
+  name: "session-recording-playlists",
+  displayName: "session recording playlist",
+  identityPrefix: SESSION_RECORDING_PLAYLIST_IDENTITY_PREFIX,
+
+  isSpec: looksLikeSessionRecordingPlaylist,
+  specKey: (spec) => spec.key,
+
+  list: listManagedSessionRecordingPlaylists,
+  keyFromServer: (server) => playlistKeyFromServer(server),
+  hashFromServer: (server) => playlistHashFromServer(server),
+
+  hash: playlistHash,
+  validate: (specs) => validateSessionRecordingPlaylists(specs),
+  executeOp: runSessionRecordingPlaylistOp,
+  prune: pruneSessionRecordingPlaylist,
+
+  displaySpec: (spec, _ctx: ApplyContext) => displaySessionRecordingPlaylist(spec),
+  displayServer: (server, _ctx: ApplyContext) => displaySessionRecordingPlaylistFromServer(server),
+
+  listAll: listSessionRecordingPlaylists,
+  getById: (config, id, options) => getSessionRecordingPlaylist(config, String(id), options),
+  pullFilter,
+  pullLabel,
+  serverIdOf,
+  renderToFile,
+  tagOnServer,
+};

--- a/src/resources/session-recording-playlist/pipeline.test.ts
+++ b/src/resources/session-recording-playlist/pipeline.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { diff } from "../../apply/diff.js";
+import type { DesiredState } from "../types.js";
+import type { SessionRecordingPlaylist } from "./sdk.js";
+import type { ServerSessionRecordingPlaylist } from "./client.js";
+import { playlistHash, validateSessionRecordingPlaylists } from "./pipeline.js";
+
+function spec(
+  key: string,
+  overrides: Partial<SessionRecordingPlaylist> = {},
+): SessionRecordingPlaylist {
+  return {
+    key,
+    name: `Playlist ${key}`,
+    filters: { date_from: "-7d", filter_test_accounts: true },
+    ...overrides,
+  };
+}
+
+function serverRow(
+  shortId: string,
+  key: string,
+  hash: string,
+  extraDescription = "",
+): ServerSessionRecordingPlaylist {
+  const marker = `<!-- iac:session-recording-playlists:${key} iac:hash:${hash} -->`;
+  return {
+    id: Math.floor(Math.random() * 100000),
+    short_id: shortId,
+    name: `Playlist ${key}`,
+    description: extraDescription ? `${extraDescription}\n\n${marker}` : marker,
+    type: "filters",
+    filters: { date_from: "-7d", filter_test_accounts: true },
+  };
+}
+
+function desiredFor(specs: SessionRecordingPlaylist[]): DesiredState {
+  const state: DesiredState = new Map();
+  state.set(
+    "session-recording-playlists",
+    specs.map((spec) => ({ path: "<test>", spec })),
+  );
+  return state;
+}
+
+function currentFor(rows: ServerSessionRecordingPlaylist[]): Map<string, unknown[]> {
+  return new Map<string, unknown[]>([["session-recording-playlists", rows]]);
+}
+
+describe("session-recording-playlist pipeline", () => {
+  it("emits create when desired has no matching server row", () => {
+    const result = diff(desiredFor([spec("rage")]), currentFor([]));
+    const slice = result.get("session-recording-playlists")!;
+    expect(slice.ops.length).toBe(1);
+    expect(slice.ops[0]!.kind).toBe("create");
+  });
+
+  it("emits unchanged when server hash matches", () => {
+    const desired = spec("rage");
+    const server = serverRow("AbCdEfGh", "rage", playlistHash(desired));
+    const op = diff(desiredFor([desired]), currentFor([server])).get(
+      "session-recording-playlists",
+    )!.ops[0]!;
+    expect(op.kind).toBe("unchanged");
+    if (op.kind === "unchanged")
+      expect((op.server as { short_id: string }).short_id).toBe("AbCdEfGh");
+  });
+
+  it("emits update when server hash differs", () => {
+    const desired = spec("rage");
+    const server = serverRow("AbCdEfGh", "rage", "stalehash00000000");
+    const op = diff(desiredFor([desired]), currentFor([server])).get(
+      "session-recording-playlists",
+    )!.ops[0]!;
+    expect(op.kind).toBe("update");
+  });
+
+  it("classifies a server-only managed playlist as an orphan", () => {
+    const server = serverRow("Ghost123", "ghost", "any");
+    const slice = diff(desiredFor([]), currentFor([server])).get("session-recording-playlists")!;
+    expect(slice.orphans.length).toBe(1);
+    expect((slice.orphans[0] as ServerSessionRecordingPlaylist).short_id).toBe("Ghost123");
+  });
+
+  it("safety invariant: ignores server rows without the identity marker", () => {
+    const handBuilt: ServerSessionRecordingPlaylist = {
+      id: 999,
+      short_id: "Handmade1",
+      name: "Hand-built",
+      description: "Just a saved filter someone made in the UI",
+      type: "filters",
+      filters: { date_from: "-30d" },
+    };
+    const slice = diff(desiredFor([]), currentFor([handBuilt])).get(
+      "session-recording-playlists",
+    )!;
+    expect(slice.ops.length).toBe(0);
+    expect(slice.orphans.length).toBe(0);
+  });
+
+  it("hash is stable when a user description precedes the marker", () => {
+    const desired = spec("rage", { description: "Frustrated users" });
+    const server = serverRow("AbCdEfGh", "rage", playlistHash(desired), "Frustrated users");
+    const op = diff(desiredFor([desired]), currentFor([server])).get(
+      "session-recording-playlists",
+    )!.ops[0]!;
+    expect(op.kind).toBe("unchanged");
+  });
+});
+
+describe("session-recording-playlist validation", () => {
+  it("rejects keys that don't match the allowed pattern", () => {
+    const issues = validateSessionRecordingPlaylists([spec("not valid!")]);
+    expect(issues.some((m) => m.includes("must match"))).toBeTruthy();
+  });
+
+  it("rejects duplicate keys", () => {
+    const issues = validateSessionRecordingPlaylists([spec("dup"), spec("dup")]);
+    expect(issues.some((m) => m.includes("Duplicate"))).toBeTruthy();
+  });
+
+  it("requires a non-empty name", () => {
+    const issues = validateSessionRecordingPlaylists([spec("ok", { name: "" })]);
+    expect(issues.some((m) => m.includes("name is required"))).toBeTruthy();
+  });
+
+  it("rejects empty filters (collection/pinned playlists are runtime data)", () => {
+    const issues = validateSessionRecordingPlaylists([spec("empty", { filters: {} })]);
+    expect(issues.some((m) => m.includes("non-empty `filters`"))).toBeTruthy();
+  });
+
+  it("accepts a minimal valid spec", () => {
+    const issues = validateSessionRecordingPlaylists([spec("ok")]);
+    expect(issues).toEqual([]);
+  });
+});

--- a/src/resources/session-recording-playlist/pipeline.ts
+++ b/src/resources/session-recording-playlist/pipeline.ts
@@ -1,0 +1,210 @@
+import type { ClientConfig } from "../../client/config.js";
+import { ApiError } from "../../client/typed.js";
+import { specHash } from "../../apply/hash.js";
+import { displayJson, obj, scalar, type DisplayValue } from "../../apply/display.js";
+import { SafetyViolationError } from "../../apply/errors.js";
+import { getResourceKind, type ApplyContext, type ResourceOp } from "../types.js";
+import type { SessionRecordingPlaylist } from "./sdk.js";
+import {
+  createSessionRecordingPlaylist,
+  deleteSessionRecordingPlaylist,
+  getSessionRecordingPlaylist,
+  type ServerSessionRecordingPlaylist,
+  type SessionRecordingPlaylistCreate,
+  type SessionRecordingPlaylistUpdate,
+  updateSessionRecordingPlaylist,
+} from "./client.js";
+
+/**
+ * Session recording playlists have no `tags` field. Identity sits in a
+ * trailing HTML-comment marker on `description` (endpoints / surveys pattern).
+ */
+export const SESSION_RECORDING_PLAYLIST_IDENTITY_PREFIX = "iac:session-recording-playlists:";
+
+const MARKER_REGEX =
+  /\n*<!--\s*iac:session-recording-playlists:(\S+)\s+iac:hash:(\S+)\s*-->\s*$/;
+const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+type ParsedMarker = { userDescription: string; key: string; hash: string };
+
+function parseMarker(description: string | null | undefined): ParsedMarker | undefined {
+  if (!description) return undefined;
+  const match = description.match(MARKER_REGEX);
+  if (!match || match.index === undefined) return undefined;
+  return {
+    userDescription: description.slice(0, match.index).replace(/\s+$/, ""),
+    key: match[1]!,
+    hash: match[2]!,
+  };
+}
+
+function withMarker(userDescription: string | undefined, key: string, hash: string): string {
+  const trailer = `<!-- iac:session-recording-playlists:${key} iac:hash:${hash} -->`;
+  const trimmed = (userDescription ?? "").replace(/\s+$/, "");
+  return trimmed ? `${trimmed}\n\n${trailer}` : trailer;
+}
+
+export function stripMarker(description: string | null | undefined): string | null {
+  if (!description) return null;
+  const parsed = parseMarker(description);
+  return parsed ? parsed.userDescription || null : description;
+}
+
+export function playlistKeyFromServer(server: ServerSessionRecordingPlaylist): string | undefined {
+  return parseMarker(server.description)?.key;
+}
+
+export function playlistHashFromServer(server: ServerSessionRecordingPlaylist): string | undefined {
+  return parseMarker(server.description)?.hash;
+}
+
+function specForHash(spec: SessionRecordingPlaylist): unknown {
+  return {
+    key: spec.key,
+    name: spec.name,
+    description: spec.description ?? "",
+    filters: spec.filters ?? {},
+  };
+}
+
+export function playlistHash(spec: SessionRecordingPlaylist): string {
+  return specHash(specForHash(spec));
+}
+
+function buildCreatePayload(
+  spec: SessionRecordingPlaylist,
+  hash: string,
+): SessionRecordingPlaylistCreate {
+  return {
+    name: spec.name,
+    description: withMarker(spec.description, spec.key, hash),
+    type: "filters",
+    filters: spec.filters ?? {},
+  };
+}
+
+function buildUpdatePayload(
+  spec: SessionRecordingPlaylist,
+  hash: string,
+): SessionRecordingPlaylistUpdate {
+  return {
+    name: spec.name,
+    description: withMarker(spec.description, spec.key, hash),
+    filters: spec.filters ?? {},
+  };
+}
+
+export function looksLikeSessionRecordingPlaylist(
+  value: unknown,
+): value is SessionRecordingPlaylist {
+  return getResourceKind(value) === "session-recording-playlist";
+}
+
+function isEmptyFilters(filters: unknown): boolean {
+  return !filters || typeof filters !== "object" || Object.keys(filters as object).length === 0;
+}
+
+export function validateSessionRecordingPlaylists(specs: SessionRecordingPlaylist[]): string[] {
+  const issues: string[] = [];
+  const seenKeys = new Set<string>();
+  const seenNames = new Set<string>();
+
+  for (const spec of specs) {
+    if (!spec.key) {
+      issues.push("session-recording-playlist.key is required");
+      continue;
+    }
+    if (!KEY_PATTERN.test(spec.key)) {
+      issues.push(`session recording playlist "${spec.key}" key must match ${KEY_PATTERN.source}`);
+    }
+    if (seenKeys.has(spec.key)) issues.push(`Duplicate session recording playlist key "${spec.key}"`);
+    seenKeys.add(spec.key);
+
+    if (!spec.name || spec.name.trim() === "") {
+      issues.push(`session recording playlist "${spec.key}" name is required`);
+    } else if (seenNames.has(spec.name)) {
+      issues.push(`Duplicate session recording playlist name "${spec.name}"`);
+    } else {
+      seenNames.add(spec.name);
+    }
+
+    if (isEmptyFilters(spec.filters)) {
+      issues.push(
+        `session recording playlist "${spec.key}" must declare non-empty \`filters\` — only filter-based (dynamic) playlists are managed; manually-pinned collection playlists are runtime data`,
+      );
+    }
+  }
+  return issues;
+}
+
+async function assertManaged(
+  config: ClientConfig,
+  shortId: string,
+  key: string,
+  options: { verbose?: boolean },
+): Promise<void> {
+  const current = await getSessionRecordingPlaylist(config, shortId, options);
+  if (playlistKeyFromServer(current) !== key) {
+    throw new SafetyViolationError("session-recording-playlist", shortId, key);
+  }
+}
+
+export async function runSessionRecordingPlaylistOp(
+  config: ClientConfig,
+  op: ResourceOp<SessionRecordingPlaylist, ServerSessionRecordingPlaylist>,
+  _ctx: ApplyContext,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+
+  const hash = playlistHash(op.spec);
+
+  if (op.kind === "create") {
+    await createSessionRecordingPlaylist(config, buildCreatePayload(op.spec, hash), options);
+    return;
+  }
+
+  await assertManaged(config, op.server.short_id, op.spec.key, options);
+  await updateSessionRecordingPlaylist(
+    config,
+    op.server.short_id,
+    buildUpdatePayload(op.spec, hash),
+    options,
+  );
+}
+
+export async function pruneSessionRecordingPlaylist(
+  config: ClientConfig,
+  orphan: ServerSessionRecordingPlaylist,
+  options: { verbose?: boolean } = {},
+): Promise<boolean> {
+  const key = playlistKeyFromServer(orphan) ?? `short_id:${orphan.short_id}`;
+  try {
+    await assertManaged(config, orphan.short_id, key, options);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return false;
+    throw err;
+  }
+  await deleteSessionRecordingPlaylist(config, orphan.short_id, orphan.filters ?? {}, options);
+  return true;
+}
+
+export function displaySessionRecordingPlaylist(spec: SessionRecordingPlaylist): DisplayValue {
+  return obj([
+    ["key", scalar(spec.key)],
+    ["name", scalar(spec.name)],
+    ["description", scalar(spec.description ?? null)],
+    ["filters", displayJson(spec.filters ?? {})],
+  ]);
+}
+
+export function displaySessionRecordingPlaylistFromServer(
+  server: ServerSessionRecordingPlaylist,
+): DisplayValue {
+  return obj([
+    ["key", scalar(playlistKeyFromServer(server) ?? null)],
+    ["name", scalar(server.name ?? "")],
+    ["description", scalar(stripMarker(server.description))],
+    ["filters", displayJson(server.filters ?? {})],
+  ]);
+}

--- a/src/resources/session-recording-playlist/sdk.ts
+++ b/src/resources/session-recording-playlist/sdk.ts
@@ -1,0 +1,34 @@
+import { markResourceKind } from "../types.js";
+
+/**
+ * A session recording playlist — the "saved filter" view in the recordings
+ * product. posthog-definitions manages **filter-based (dynamic)** playlists
+ * only: the `filters` object defines which recordings match, and membership is
+ * computed at query time.
+ *
+ * Manually-curated **collection** playlists (pinned recordings) are runtime
+ * data, not declarative state — same treatment as static-cohort membership.
+ * There is no field to declare pinned recordings here, and validation rejects
+ * an empty `filters`.
+ */
+export type SessionRecordingPlaylistFilters = Record<string, unknown>;
+
+export type SessionRecordingPlaylist = {
+  key: string;
+  /** Human-readable name shown in the recordings sidebar. */
+  name: string;
+  /** Optional description — also the identity-marker carrier. */
+  description?: string;
+  /**
+   * Recording filter criteria (date range, duration, events, person
+   * properties, …). Required and non-empty: a filter-based playlist without
+   * filters is a collection, which this resource does not manage.
+   */
+  filters: SessionRecordingPlaylistFilters;
+};
+
+export function sessionRecordingPlaylist(
+  spec: SessionRecordingPlaylist,
+): SessionRecordingPlaylist {
+  return markResourceKind(spec, "session-recording-playlist");
+}


### PR DESCRIPTION
Adds **session recording playlists** as a managed resource. Fourth resource in the API-parity campaign chunk.

## Identity
Playlists have no `tags` field → the **surveys/endpoints description-marker** pattern: a trailing `<!-- iac:session-recording-playlists:<key> iac:hash:<hex> -->` on `description`, stripped before display. Addressed by **`short_id`** (the detail route is `/session_recording_playlists/{short_id}/`), not the numeric id.

## Scope: filter-based only
Only **filter-based (dynamic)** playlists are managed — `filters` is required and non-empty. Manually-pinned **collection** playlists are runtime membership data (same treatment as static-cohort members): validation rejects empty `filters`, and pull skips non-`filters` and synthetic rows.

## Live verification (project 806)
Full add-resource flow: create → no-op re-apply (0/0/1, hash projection correct) → edit → single update → orphan left alone → hand-built playlist (no marker) untouched → kind-scoped prune deletes managed only. Pull round-trip (seed → pull → tag-back → apply --dry-run no-op) confirmed. All test rows cleaned up.

## Two API quirks confirmed and handled
- **Update must resend `filters`.** A filters-type playlist update that omits `filters` is rejected: `"You cannot remove all filters when updating a saved filter"`. Every update — and the soft-delete — resends the existing filters.
- **DELETE returns 405.** Playlists soft-delete via `PATCH { deleted: true }` (with filters riding along).

## Gates
`pnpm typecheck`, `pnpm typecheck:examples`, `pnpm test` (305 pass), `pnpm lint` all green. Note: full `smoke.sh` is currently red at the pull step on the pre-existing, unrelated `actions` pull gap on `pl/spec-migration` (lands separately on `pl/pull-actions`); the playlist smoke wiring is verified in isolation.

---

Stacks on #81 (base `pl/spec-migration`) — codegen only compiles there. Retarget to `main` when #81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)