### PR TITLE
feat(apply): --kind scoping for plan and prune

### DIFF
--- a/src/cli/apply-kind.test.ts
+++ b/src/cli/apply-kind.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { resolveActiveResources } from "./apply.js";
+import { parseArgs } from "./args.js";
+import { RESOURCES } from "../resources/index.js";
+
+describe("resolveActiveResources", () => {
+  it("returns every resource when no kinds are given", () => {
+    const res = resolveActiveResources([]);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.value).toBe(RESOURCES);
+  });
+
+  it("restricts to the named kinds", () => {
+    const res = resolveActiveResources(["dashboards", "insights"]);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.value.map((r) => r.name).sort()).toEqual(["dashboards", "insights"]);
+    }
+  });
+
+  it("preserves RESOURCES' topological order regardless of --kind order", () => {
+    // insights run before dashboards in the registry (dependency order).
+    const forward = resolveActiveResources(["insights", "dashboards"]);
+    const reversed = resolveActiveResources(["dashboards", "insights"]);
+    expect(forward.ok && reversed.ok).toBe(true);
+    if (forward.ok && reversed.ok) {
+      expect(forward.value.map((r) => r.name)).toEqual(reversed.value.map((r) => r.name));
+      const idxInsights = RESOURCES.findIndex((r) => r.name === "insights");
+      const idxDashboards = RESOURCES.findIndex((r) => r.name === "dashboards");
+      const ordered = forward.value.map((r) => r.name);
+      // Whichever comes first in RESOURCES comes first here too.
+      if (idxInsights < idxDashboards) {
+        expect(ordered).toEqual(["insights", "dashboards"]);
+      } else {
+        expect(ordered).toEqual(["dashboards", "insights"]);
+      }
+    }
+  });
+
+  it("dedupes repeated kinds", () => {
+    const res = resolveActiveResources(["cohorts", "cohorts"]);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.value.filter((r) => r.name === "cohorts")).toHaveLength(1);
+  });
+
+  it("rejects an unknown kind with a stage:args error listing valid kinds", () => {
+    const res = resolveActiveResources(["dashboards", "not_a_kind"]);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.stage).toBe("args");
+      expect(res.error).toContain("not_a_kind");
+      expect(res.error).toContain("Known:");
+    }
+  });
+});
+
+describe("parseArgs apply --kind", () => {
+  it("defaults kinds to an empty array", () => {
+    const args = parseArgs(["apply"]);
+    expect(args.command).toBe("apply");
+    if (args.command === "apply") expect(args.kinds).toEqual([]);
+  });
+
+  it("parses a comma-separated --kind list, trimming whitespace", () => {
+    const args = parseArgs(["apply", "--kind", "dashboards, feature-flags ,cohorts"]);
+    if (args.command === "apply") {
+      expect(args.kinds).toEqual(["dashboards", "feature-flags", "cohorts"]);
+    }
+  });
+
+  it("carries --kind alongside --prune", () => {
+    const args = parseArgs(["apply", "--prune", "--kind", "dashboards"]);
+    if (args.command === "apply") {
+      expect(args.prune).toBe(true);
+      expect(args.kinds).toEqual(["dashboards"]);
+    }
+  });
+});

--- a/src/cli/apply.integration.test.ts
+++ b/src/cli/apply.integration.test.ts
@@ -26,6 +26,7 @@ function applyArgs(dir: string, overrides: Partial<ApplyArgs> = {}): ApplyArgs {
     verbose: false,
     prune: false,
     json: true,
+    kinds: [],
     ...overrides,
   };
 }

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -2,6 +2,7 @@ import type { ClientConfig } from "../client/config.js";
 import { ConfigError, loadConfig } from "../client/config.js";
 import { ApiError } from "../client/typed.js";
 import { RESOURCES } from "../resources/index.js";
+import type { ResourceModule } from "../resources/types.js";
 import { diff, type DiffResult } from "../apply/diff.js";
 import { execute, fetchCurrentState, SafetyViolationError } from "../apply/execute.js";
 import { formatPlan } from "../apply/format-plan.js";
@@ -69,6 +70,13 @@ export async function buildApplyResult(
 ): Promise<ApplyResult> {
   const debug = options.debug ?? (() => {});
 
+  // Resolve the kind scope up front so an invalid --kind fails before any
+  // filesystem or network work.
+  const activeResult = resolveActiveResources(args.kinds);
+  if (!activeResult.ok) return activeResult;
+  const activeResources = activeResult.value;
+  const scope = args.kinds.length > 0 ? activeResources.map((r) => r.name) : null;
+
   debug("loading definitions", { dir: args.dir });
   const loaded = await loadDefinitions(args.dir);
   if (!loaded.ok) {
@@ -80,8 +88,12 @@ export async function buildApplyResult(
     Object.fromEntries(Array.from(desired.entries()).map(([k, v]) => [k, v.length])),
   );
 
-  debug("validating definitions");
-  const validation = validate(desired);
+  debug("validating definitions", { scope });
+  // Validate only the in-scope kinds. Cross-resource references still resolve
+  // against the full loaded `desired` state (passed as the second arg), so a
+  // scoped apply of a dependent kind can still see its dependencies for
+  // reference checks even when those kinds aren't themselves applied.
+  const validation = validate(desired, activeResources);
   if (!validation.ok) {
     return {
       ok: false,
@@ -94,12 +106,19 @@ export async function buildApplyResult(
   }
   debug("validation passed");
 
-  const totalDesired = RESOURCES.reduce((sum, r) => sum + (desired.get(r.name)?.length ?? 0), 0);
-  if (args.dryRun && totalDesired === 0) {
+  const totalDesired = activeResources.reduce(
+    (sum, r) => sum + (desired.get(r.name)?.length ?? 0),
+    0,
+  );
+  // Short-circuit a dry run with nothing declared — but NOT under --prune,
+  // which wants to scan for orphans even when no specs are declared (that is
+  // the whole point of a prune preview).
+  if (args.dryRun && totalDesired === 0 && !args.prune) {
     return {
       ok: true,
       dryRun: true,
       applied: false,
+      scope,
       plan: { totalOps: 0, byResource: [] },
     };
   }
@@ -110,7 +129,7 @@ export async function buildApplyResult(
     current = await fetchCurrentState(
       config,
       { verbose: args.verbose, prune: args.prune },
-      undefined,
+      activeResources,
       desired,
     );
   } catch (err) {
@@ -129,23 +148,26 @@ export async function buildApplyResult(
   );
 
   debug("diffing");
-  const diffResult = diff(desired, current);
+  const diffResult = diff(desired, current, activeResources);
 
   if (args.dryRun) {
     return {
       ok: true,
       dryRun: true,
       applied: false,
+      scope,
       plan: planToJson(diffResult, args.prune),
     };
   }
 
-  debug("executing apply", { prune: args.prune });
+  debug("executing apply", { prune: args.prune, scope });
   try {
-    const summary = await execute(config, diffResult, {
-      verbose: args.verbose,
-      prune: args.prune,
-    });
+    const summary = await execute(
+      config,
+      diffResult,
+      { verbose: args.verbose, prune: args.prune },
+      activeResources,
+    );
     let totalCreated = 0;
     let totalUpdated = 0;
     let totalUnchanged = 0;
@@ -165,6 +187,7 @@ export async function buildApplyResult(
       ok: true,
       dryRun: false,
       applied: true,
+      scope,
       totals: {
         created: totalCreated,
         updated: totalUpdated,
@@ -208,6 +231,11 @@ function emitApplyProse(
 ): void {
   // Load summary header is built fresh from RESOURCES — it's a UX nicety
   // for the prose path, not part of the structured contract.
+  if (result.scope) {
+    console.log(
+      `Scoped to --kind ${result.scope.join(", ")}. Other kinds were not scanned (their state on the server is untouched and unreported).`,
+    );
+  }
   if (result.dryRun) {
     if (result.plan.totalOps === 0) {
       console.log("Nothing to do.");
@@ -261,6 +289,31 @@ function planToJson(
     byResource.push({ resource: resourceName, create, update, unchanged, orphans });
   }
   return { totalOps, byResource };
+}
+
+/**
+ * Resolve `--kind` names to registry modules, preserving RESOURCES' topological
+ * order (so dependencies still execute before dependents). Empty selection =
+ * every kind. An unknown kind is a `stage: "args"` error, mirroring
+ * `pull --kind`.
+ */
+export function resolveActiveResources(
+  kinds: string[],
+): { ok: true; value: ReadonlyArray<ResourceModule<unknown, unknown>> } | ApplyErr {
+  if (kinds.length === 0) return { ok: true, value: RESOURCES };
+  const byName = new Map(RESOURCES.map((r) => [r.name, r]));
+  const wanted = new Set(kinds);
+  const unknown = kinds.filter((k) => !byName.has(k));
+  if (unknown.length > 0) {
+    return {
+      ok: false,
+      stage: "args",
+      error: `--kind "${unknown.join(", ")}" is not a known resource. Known: ${[...byName.keys()].join(", ")}.`,
+    };
+  }
+  // Iterate RESOURCES (topo order), keep those requested — dedupes and orders.
+  const value = RESOURCES.filter((r) => wanted.has(r.name));
+  return { ok: true, value };
 }
 
 function describeLoadFailure(failure: LoadFailure): string {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -5,6 +5,13 @@ export type ApplyArgs = {
   prune: boolean;
   dir: string;
   json: boolean;
+  /**
+   * Restrict the run to these resource kinds. Empty = every kind. Mirrors
+   * `pull --kind`. Scopes load / validate / diff / plan / execute / prune —
+   * critically, `--prune` only considers orphans of the named kinds, so a
+   * scoped prune can't touch managed rows of kinds you didn't name.
+   */
+  kinds: string[];
   host?: string;
   project?: string;
 };
@@ -67,6 +74,7 @@ function parseApply(argv: string[]): ApplyArgs {
     prune: false,
     dir: "posthog",
     json: false,
+    kinds: [],
   };
 
   for (let i = 1; i < argv.length; i++) {
@@ -78,6 +86,16 @@ function parseApply(argv: string[]): ApplyArgs {
       case "--prune":
         args.prune = true;
         break;
+      case "--kind": {
+        const value = expectValue(argv, ++i, flag);
+        // Validity of each kind is checked at runtime against the registry —
+        // the CLI doesn't carry a hard-coded list.
+        args.kinds = value
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        break;
+      }
       case "--verbose":
       case "-v":
         args.verbose = true;
@@ -240,6 +258,13 @@ Apply flags:
                        touches resources tagged iac:dashboards:* /
                        iac:insights:* — hand-built resources are never
                        considered.
+  --kind <list>        Comma-separated list of resource kinds to apply
+                       (e.g. dashboards, feature-flags). Omit to apply every
+                       kind. Scopes the whole run — load, plan, execute, and
+                       prune. With --prune, ONLY orphans of the named kinds
+                       are deleted; managed rows of other kinds are not even
+                       scanned. Kinds you scope to should include any kinds
+                       they reference (deps run in dependency order).
 
 Pull flags:
   --kind <list>        Comma-separated list of resource kinds to pull

--- a/src/cli/pull.integration.test.ts
+++ b/src/cli/pull.integration.test.ts
@@ -30,6 +30,7 @@ function applyArgs(dir: string): ApplyArgs {
     verbose: false,
     prune: false,
     json: true,
+    kinds: [],
   };
 }
 

--- a/src/cli/result.ts
+++ b/src/cli/result.ts
@@ -18,6 +18,13 @@ export type ApplyOkDryRun = {
   ok: true;
   dryRun: true;
   applied: false;
+  /**
+   * When `--kind` scoped the run, the list of kinds that were scanned;
+   * `null` means every kind was in scope. Kinds NOT in this list were not
+   * scanned at all — their absence from `byResource` is not "0 changes",
+   * it is "not looked at".
+   */
+  scope: string[] | null;
   plan: {
     totalOps: number;
     byResource: Array<{
@@ -34,6 +41,8 @@ export type ApplyOkApplied = {
   ok: true;
   dryRun: false;
   applied: true;
+  /** Kinds scanned when `--kind` scoped the run; `null` means all kinds. */
+  scope: string[] | null;
   totals: {
     created: number;
     updated: number;
@@ -51,7 +60,7 @@ export type ApplyOkApplied = {
 export type ApplyErr = {
   ok: false;
   /** Where in the pipeline the error occurred. */
-  stage: "config" | "load" | "validate" | "fetch" | "apply";
+  stage: "config" | "args" | "load" | "validate" | "fetch" | "apply";
   /** Short human-readable error message. Suitable for `error: …` prose output. */
   error: string;
   /** Validation issues, populated when stage === "validate". */


### PR DESCRIPTION
Adds `apply --kind <list>`, mirroring `pull --kind`. This is the infrastructure item that closes the scoped-prune safety gap identified during the resource campaign.

## Problem
`apply --prune` lists **every** collection kind and deletes any managed (iac-tagged) row not backed by a spec in the directory. On a shared project, an unscoped `--prune` from a partial directory would delete managed rows of kinds you never intended to manage from there. On dev project 806 an unscoped prune preview currently reports **518 orphans across 12 kinds (487 of them insights)** — none of which a directory managing only, say, feature-flags should touch.

## Change
`apply --kind dashboards,feature-flags` restricts the whole run — load → validate → diff → plan → execute → **prune** — to the named kinds, in dependency (topological) order. Other kinds are not even fetched.

- Unknown kind → fast `stage: "args"` error listing valid kinds (mirrors `pull --kind`).
- Plan output reflects scope honestly: a `scope: string[]` field (`null` when unscoped), and only scanned kinds appear in `byResource`. Out-of-scope kinds are **absent, not "0 orphans"** — they weren't looked at. Prose output leads with an explicit `Scoped to --kind …; other kinds were not scanned` line.
- Bonus fix: the dry-run short-circuit no longer hides orphans — `apply --prune --dry-run` now scans even when zero specs are declared (previously an empty dir returned an empty plan, concealing the orphans a prune preview exists to surface).

## Verification (live, project 806)
- `apply --kind feature-flags --prune --dry-run` → `scope: ["feature-flags"]`, plan contains **only** feature-flags. Unscoped run on the same dir → `scope: null`, all 12 kinds, 518 orphans. Clean contrast.
- Real `apply --kind feature-flags --prune` → pruned managed orphans of feature-flags only; declared rows survived; **insights and every other kind untouched** (never entered the plan). Seeded/cleaned up disposable rows.
- Unit tests: kind resolver (topo ordering, dedup, unknown-kind error) + `--kind` arg parsing.

## Notes
- **Independent of the codegen stack** — pure CLI/driver change, no generated-client dependency — so this targets `main` directly (not `pl/spec-migration`).
- Until this merges, unscoped `--prune` stays unsafe on shared projects.
- `pnpm lint` shows **4 pre-existing errors on `main`** (`typed-posthog.ts`, `resources/types.ts`, unused imports in two files) that are already fixed on the codegen/spec-migration lint commit — not introduced here; my changed source lints clean. Flagging so CI red is attributed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)