### PR TITLE
feat(hog-function): SDK factory + pipeline + secrets convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Alpha — do not use in production.**
 > This is pre-MVP software (`0.1.0-alpha.0`). The CLI, the on-disk file format, the SDK surface, and the tag-based identity model are all subject to breaking changes without notice. Use it on throwaway projects or in a sandbox while we stabilize.
 
-Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
+Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, experiment saved metrics, and hog functions (destinations / transformations) in TypeScript, then sync them to a PostHog project with one command.
 
 ## Why
 
@@ -51,6 +51,7 @@ export default dashboard({
    - `event_definition:read`, `event_definition:write` (also covers property groups)
    - `experiment:read`, `experiment:write` (also covers experiment holdouts)
    - `experiment_saved_metric:read`, `experiment_saved_metric:write`
+   - `hog_function:read`, `hog_function:write`
 
    Then add it (and your numeric project ID) to a `.env` (or `.envrc`) file:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -61,7 +61,7 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 
 | Resource              | PostHog API                                  | posthog-definitions | Notes                          |
 | --------------------- | -------------------------------------------- | ------------------- | ------------------------------ |
-| Hog functions         | ✅ `environments/{id}/hog_functions`         | ❌                  | Destinations / transformations |
+| Hog functions         | ✅ `environments/{id}/hog_functions`         | ✅                  | Identity via `iac:hog-functions:<key>` marker in `description`. Template-based (destinations / transformations). Secret inputs come from env-var references (`secret("VAR")`) — never stored in files, excluded from the hash, sent on create, re-sent only on explicit rotation. Full matrix refresh tracked in #78. |
 | Hog flows             | ✅ `environments/{id}/hog_flows`             | ❌                  | Campaign builder               |
 | Messaging templates   | ✅ `environments/{id}/messaging_templates`   | ❌                  |                                |
 | Messaging categories  | ✅ `environments/{id}/messaging_categories`  | ❌                  |                                |

--- a/examples/posthog/hog-functions/activecampaign-destination.ts
+++ b/examples/posthog/hog-functions/activecampaign-destination.ts
@@ -1,0 +1,30 @@
+// A real-time destination built from a marketplace template: forward activated
+// accounts to ActiveCampaign. This is the flagship example for the secrets
+// convention — the API key never appears in the file. `secret("ENV_VAR")` reads
+// the value from the environment at apply time; it is excluded from the hash
+// and, once set, is never re-sent on update (so a masked read-back can't cause
+// a perpetual diff). To rotate it, bump the `rotate` token.
+import { hogFunction, secret } from "@posthog/definitions";
+
+export default hogFunction({
+  key: "activecampaign-sync",
+  type: "destination",
+  name: "ActiveCampaign — sync activated accounts",
+  description: "Push activated workspaces to ActiveCampaign for lifecycle email.",
+  templateId: "template-activecampaign",
+  enabled: true,
+  inputs: {
+    accountName: "acme-inc",
+    apiKey: secret("ACTIVECAMPAIGN_API_KEY"),
+    // To rotate later: secret("ACTIVECAMPAIGN_API_KEY", { rotate: "2026-q3" })
+    email: "{person.properties.email}",
+    firstName: "{person.properties.first_name}",
+    lastName: "{person.properties.last_name}",
+    phone: "{person.properties.phone}",
+    attributes: {},
+  },
+  filters: {
+    source: "events",
+    events: [{ id: "workspace_activated", name: "workspace_activated", type: "events", order: 0 }],
+  },
+});

--- a/examples/posthog/hog-functions/geoip-transformation.ts
+++ b/examples/posthog/hog-functions/geoip-transformation.ts
@@ -1,0 +1,14 @@
+// A transformation runs inline on the ingestion pipeline, enriching every event
+// before it lands. This one is the stock GeoIP transformation — no inputs, no
+// secrets — enabled for the whole project. Transformations of the same type run
+// in the order they're created.
+import { hogFunction } from "@posthog/definitions";
+
+export default hogFunction({
+  key: "geoip",
+  type: "transformation",
+  name: "GeoIP enrichment",
+  description: "Adds city / country properties to every event from the client IP.",
+  templateId: "template-geoip",
+  enabled: true,
+});

--- a/openapi-filter.yaml
+++ b/openapi-filter.yaml
@@ -86,6 +86,11 @@ inverseOperationIds:
   - actions_partial_update
   - actions_destroy
 
+  - hog_functions_list
+  - hog_functions_create
+  - hog_functions_retrieve
+  - hog_functions_partial_update
+
 unusedComponents:
   - schemas
   - parameters

--- a/scripts/smoke-cleanup.ts
+++ b/scripts/smoke-cleanup.ts
@@ -82,6 +82,12 @@ import {
   pruneAction,
 } from "../src/resources/action/pipeline.js";
 
+import { listManagedHogFunctions } from "../src/resources/hog-function/client.js";
+import {
+  hogFunctionKeyFromServer,
+  pruneHogFunction,
+} from "../src/resources/hog-function/pipeline.js";
+
 import type { ClientConfig } from "../src/client/config.js";
 
 type Args = {
@@ -96,6 +102,7 @@ type Args = {
   "property-group"?: string;
   cohort?: string;
   endpoint?: string;
+  "hog-function"?: string;
 };
 
 const ARG_KEYS: Array<keyof Args> = [
@@ -110,6 +117,7 @@ const ARG_KEYS: Array<keyof Args> = [
   "property-group",
   "cohort",
   "endpoint",
+  "hog-function",
 ];
 
 function parseArgs(argv: string[]): Args {
@@ -268,6 +276,16 @@ async function main(): Promise<void> {
       listManagedEndpoints,
       (row) => endpointKeyFromServer(row),
       (c, row) => pruneEndpoint(c, row),
+    );
+  }
+  if (args["hog-function"]) {
+    await deleteByKey(
+      "hog-function",
+      args["hog-function"],
+      config,
+      listManagedHogFunctions,
+      (row) => hogFunctionKeyFromServer(row),
+      (c, row) => pruneHogFunction(c, row),
     );
   }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -63,6 +63,7 @@ SAVED_METRIC_KEY="smoke-metric-${STAMP}"
 EXPERIMENT_KEY="smoke-experiment-${STAMP}"
 COHORT_KEY="smoke-cohort-${STAMP}"
 ENDPOINT_KEY="smoke-endpoint-${STAMP}"
+HOG_FUNCTION_KEY="smoke-hogfn-${STAMP}"
 
 # Names that round-trip cleanly through pull's slug-from-name. We use the
 # event-definition `name` as both the spec key AND the on-the-wire event
@@ -71,7 +72,7 @@ EVENT_NAME="${EVENT_DEFINITION_KEY}"
 
 # Resource kinds we'll seed and pull. Used both in --kind for pull and in
 # the no-op assertion's filter (we don't want unrelated kinds dirtying it).
-SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints"
+SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints,hog-functions"
 
 cleanup() {
   echo
@@ -88,6 +89,7 @@ cleanup() {
     "--property-group=${PROPERTY_GROUP_KEY}" \
     "--cohort=${COHORT_KEY}" \
     "--endpoint=${ENDPOINT_KEY}" \
+    "--hog-function=${HOG_FUNCTION_KEY}" \
     || echo "smoke: cleanup hit an error (continuing)"
   echo "smoke: removing workdir $WORK_DIR"
   rm -rf "$WORK_DIR"
@@ -153,7 +155,8 @@ mkdir -p \
   "$SEED_DIR/experiment-saved-metrics" \
   "$SEED_DIR/experiments" \
   "$SEED_DIR/cohorts" \
-  "$SEED_DIR/endpoints"
+  "$SEED_DIR/endpoints" \
+  "$SEED_DIR/hog-functions"
 
 # Insight — referenced by the dashboard tile below.
 cat > "$SEED_DIR/insights/smoke-insight.ts" <<EOF
@@ -306,6 +309,20 @@ export default endpoint({
   key: "${ENDPOINT_KEY}",
   name: "${ENDPOINT_KEY}",
   query: { kind: "HogQLQuery", query: "select 1 as smoke" },
+});
+EOF
+
+# Hog function — independent. A no-secret transformation (GeoIP template) so
+# the smoke needs no env vars.
+cat > "$SEED_DIR/hog-functions/smoke-hogfn.ts" <<EOF
+import { hogFunction } from "@posthog/definitions";
+export default hogFunction({
+  key: "${HOG_FUNCTION_KEY}",
+  type: "transformation",
+  name: "${HOG_FUNCTION_KEY}",
+  description: "Smoke fixture hog function",
+  templateId: "template-geoip",
+  enabled: false,
 });
 EOF
 

--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -543,6 +543,38 @@ export interface paths {
         patch: operations["feature_flags_partial_update"];
         trace?: never;
     };
+    "/api/projects/{project_id}/hog_functions/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["hog_functions_list"];
+        put?: never;
+        post: operations["hog_functions_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/hog_functions/{id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["hog_functions_retrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["hog_functions_partial_update"];
+        trace?: never;
+    };
     "/api/projects/{project_id}/insights/": {
         parameters: {
             query?: never;
@@ -8120,6 +8152,196 @@ export interface components {
          * @enum {string}
          */
         HeatmapSortOrder: "asc" | "desc";
+        HogFunction: {
+            /** Format: uuid */
+            readonly id: string;
+            /**
+             * @description Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
+             *
+             *     * `destination` - Destination
+             *     * `site_destination` - Site Destination
+             *     * `internal_destination` - Internal Destination
+             *     * `source_webhook` - Source Webhook
+             *     * `warehouse_source_webhook` - Warehouse Source Webhook
+             *     * `site_app` - Site App
+             *     * `transformation` - Transformation
+             */
+            type?: components["schemas"]["HogFunctionTypeEnum"] | components["schemas"]["NullEnum"];
+            /** @description Display name for the function. */
+            name?: string | null;
+            /** @description Human-readable description of what this function does. */
+            description?: string;
+            /** Format: date-time */
+            readonly created_at: string;
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at: string;
+            /** @description Whether the function is active and processing events. */
+            enabled?: boolean;
+            /** @description Soft-delete flag. Set to true to archive the function. */
+            deleted?: boolean;
+            /** @description Source code. Hog language for most types; TypeScript for site_destination and site_app. */
+            hog?: string;
+            readonly bytecode: unknown;
+            readonly transpiled: string | null;
+            /** @description Schema defining the configurable input parameters for this function. */
+            inputs_schema?: components["schemas"]["InputsSchemaItem"][];
+            /** @description Values for each input defined in inputs_schema. */
+            inputs?: {
+                [key: string]: components["schemas"]["InputsItem"];
+            };
+            /** @description Event filters that control which events trigger this function. */
+            filters?: components["schemas"]["HogFunctionFilters"];
+            /** @description PII masking configuration with TTL, threshold, and hash expression. */
+            masking?: components["schemas"]["HogFunctionMasking"] | null;
+            /** @description Event-to-destination field mappings. Only for destination and site_destination types. */
+            mappings?: components["schemas"]["Mappings"][] | null;
+            /** @description URL for the function's icon displayed in the UI. */
+            icon_url?: string | null;
+            readonly template: components["schemas"]["HogFunctionTemplate"];
+            /** @description ID of the template to create this function from. */
+            template_id?: string | null;
+            readonly status: components["schemas"]["HogFunctionStatus"] | null;
+            /** @description Execution priority for transformations. Lower values run first. */
+            execution_order?: number | null;
+            /** create in folder */
+            _create_in_folder?: string;
+            /** Format: uuid */
+            readonly batch_export_id: string | null;
+            /** @description How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match, returned only when no exact match exists). Null when the list is not filtered by `search`. */
+            readonly search_match_type: components["schemas"]["SearchMatchTypeEnum"] | components["schemas"]["NullEnum"];
+        };
+        HogFunctionFilters: {
+            /** @default events */
+            source: components["schemas"]["HogFunctionFiltersSourceEnum"];
+            actions?: {
+                [key: string]: unknown;
+            }[];
+            events?: {
+                [key: string]: unknown;
+            }[];
+            data_warehouse?: {
+                [key: string]: unknown;
+            }[];
+            properties?: {
+                [key: string]: unknown;
+            }[];
+            filter_test_accounts?: boolean;
+            bytecode_error?: string;
+        };
+        /**
+         * @description * `events` - events
+         *     * `person-updates` - person-updates
+         *     * `data-warehouse-table` - data-warehouse-table
+         * @enum {string}
+         */
+        HogFunctionFiltersSourceEnum: "events" | "person-updates" | "data-warehouse-table";
+        HogFunctionMappingTemplate: {
+            /** @description Name of this mapping template. */
+            name: string;
+            /** @description Whether this mapping is enabled by default. */
+            include_by_default?: boolean | null;
+            /** @description Whether this mapping should match all events by default, hiding the event filter UI. */
+            use_all_events_by_default?: boolean | null;
+            /** @description Event filters specific to this mapping. */
+            filters?: unknown;
+            /** @description Input values specific to this mapping. */
+            inputs?: unknown;
+            /** @description Additional input schema fields specific to this mapping. */
+            inputs_schema?: unknown;
+        };
+        HogFunctionMasking: {
+            /** @description Time-to-live in seconds for the masking cache (60–86400). */
+            ttl: number;
+            /** @description Optional threshold count before masking applies. */
+            threshold?: number | null;
+            /** @description Hog expression used to compute the masking hash. */
+            hash: string;
+            /** @description Compiled bytecode for the hash expression. Auto-generated. */
+            bytecode?: unknown;
+        };
+        HogFunctionMinimal: {
+            /** Format: uuid */
+            readonly id: string;
+            readonly type: string | null;
+            readonly name: string | null;
+            readonly description: string;
+            /** Format: date-time */
+            readonly created_at: string;
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at: string;
+            readonly enabled: boolean;
+            readonly hog: string;
+            readonly filters: unknown;
+            readonly icon_url: string | null;
+            readonly template: components["schemas"]["HogFunctionTemplate"];
+            readonly status: components["schemas"]["HogFunctionStatus"] | null;
+            readonly execution_order: number | null;
+            /** @description How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match, returned only when no exact match exists). Null when the list is not filtered by `search`. */
+            readonly search_match_type: components["schemas"]["SearchMatchTypeEnum"] | components["schemas"]["NullEnum"];
+        };
+        HogFunctionStatus: {
+            state: components["schemas"]["HogFunctionStatusStateEnum"];
+            tokens: number;
+        };
+        /**
+         * @description * `0` - 0
+         *     * `1` - 1
+         *     * `2` - 2
+         *     * `3` - 3
+         *     * `11` - 11
+         *     * `12` - 12
+         * @enum {integer}
+         */
+        HogFunctionStatusStateEnum: 0 | 1 | 2 | 3 | 11 | 12;
+        HogFunctionTemplate: {
+            /** @description Unique template identifier (e.g. 'template-slack'). */
+            id: string;
+            /** @description Display name of the template. */
+            name: string;
+            /** @description What this template does. */
+            description?: string | null;
+            /** @description Source code of the template. */
+            code: string;
+            /** @description Programming language: 'hog' or 'javascript'. */
+            code_language?: string;
+            /** @description Schema defining configurable inputs for functions created from this template. */
+            inputs_schema: unknown;
+            /** @description Function type this template creates. */
+            type: string;
+            /** @description Lifecycle status: alpha, beta, stable, deprecated, or hidden. */
+            status?: string;
+            /** @description Category tags for organizing templates. */
+            category?: unknown;
+            /** @description Whether available on free plans. */
+            free?: boolean;
+            /** @description URL for the template's icon. */
+            icon_url?: string | null;
+            /** @description Default event filters. */
+            filters?: unknown;
+            /** @description Default PII masking configuration. */
+            masking?: unknown;
+            /** @description Pre-defined mapping configurations for destination templates. */
+            mapping_templates?: components["schemas"]["HogFunctionMappingTemplate"][] | null;
+        };
+        /**
+         * @description * `hog` - hog
+         *     * `liquid` - liquid
+         * @enum {string}
+         */
+        HogFunctionTemplatingEnum: "hog" | "liquid";
+        /**
+         * @description * `destination` - Destination
+         *     * `site_destination` - Site Destination
+         *     * `internal_destination` - Internal Destination
+         *     * `source_webhook` - Source Webhook
+         *     * `warehouse_source_webhook` - Warehouse Source Webhook
+         *     * `site_app` - Site App
+         *     * `transformation` - Transformation
+         * @enum {string}
+         */
+        HogFunctionTypeEnum: "destination" | "site_destination" | "internal_destination" | "source_webhook" | "warehouse_source_webhook" | "site_app" | "transformation";
         /** HogQLFilter */
         HogQLFilter: {
             /**
@@ -8597,6 +8819,55 @@ export interface components {
          * @enum {string}
          */
         InlineCohortCalculation: "off" | "auto" | "always";
+        InputsItem: {
+            templating?: components["schemas"]["HogFunctionTemplatingEnum"];
+            readonly bytecode: unknown[];
+            readonly order: number;
+            readonly transpiled: unknown;
+        };
+        InputsSchemaItem: {
+            type: components["schemas"]["InputsSchemaItemTypeEnum"];
+            key: string;
+            label?: string;
+            choices?: {
+                [key: string]: unknown;
+            }[];
+            searchable?: boolean;
+            /** @default false */
+            required: boolean;
+            /** @default false */
+            secret: boolean;
+            /** @default false */
+            hidden: boolean;
+            description?: string;
+            integration?: string;
+            integration_key?: string;
+            requires_field?: string;
+            integration_field?: string;
+            requiredScopes?: string;
+            templating?: boolean | ("hog" | "liquid");
+        };
+        /**
+         * @description * `string` - string
+         *     * `number` - number
+         *     * `boolean` - boolean
+         *     * `dictionary` - dictionary
+         *     * `choice` - choice
+         *     * `json` - json
+         *     * `integration` - integration
+         *     * `integration_multi` - integration_multi
+         *     * `integration_field` - integration_field
+         *     * `email` - email
+         *     * `native_email` - native_email
+         *     * `posthog_assignee` - posthog_assignee
+         *     * `posthog_ticket_tags` - posthog_ticket_tags
+         *     * `posthog_business_hours` - posthog_business_hours
+         *     * `non_failure_status_codes` - non_failure_status_codes
+         *     * `customer_analytics_account_properties` - customer_analytics_account_properties
+         *     * `customer_analytics_account_relationships` - customer_analytics_account_relationships
+         * @enum {string}
+         */
+        InputsSchemaItemTypeEnum: "string" | "number" | "boolean" | "dictionary" | "choice" | "json" | "integration" | "integration_multi" | "integration_field" | "email" | "native_email" | "posthog_assignee" | "posthog_ticket_tags" | "posthog_business_hours" | "non_failure_status_codes" | "customer_analytics_account_properties" | "customer_analytics_account_relationships";
         /** @description Simplified serializer to speed response times when loading large amounts of objects. */
         Insight: {
             readonly id: number;
@@ -9356,6 +9627,14 @@ export interface components {
          * @enum {string}
          */
         ManualMetricType: "funnel" | "mean_count" | "mean_sum_or_avg";
+        Mappings: {
+            name?: string;
+            inputs_schema?: components["schemas"]["InputsSchemaItem"][];
+            inputs?: {
+                [key: string]: components["schemas"]["InputsItem"];
+            };
+            filters?: components["schemas"]["HogFunctionFilters"];
+        };
         /** MarketingAnalyticsAggregatedQuery */
         MarketingAnalyticsAggregatedQuery: {
             /**
@@ -10272,6 +10551,21 @@ export interface components {
             previous?: string | null;
             results: components["schemas"]["FeatureFlag"][];
         };
+        PaginatedHogFunctionMinimalList: {
+            /** @example 123 */
+            count: number;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=400&limit=100
+             */
+            next?: string | null;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=200&limit=100
+             */
+            previous?: string | null;
+            results: components["schemas"]["HogFunctionMinimal"][];
+        };
         PaginatedInsightList: {
             /** @example 123 */
             count: number;
@@ -10611,6 +10905,65 @@ export interface components {
              *     * `device_id` - Device ID
              */
             bucketing_identifier?: components["schemas"]["BucketingIdentifierEnum"] | components["schemas"]["NullEnum"];
+        };
+        PatchedHogFunction: {
+            /** Format: uuid */
+            readonly id?: string;
+            /**
+             * @description Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
+             *
+             *     * `destination` - Destination
+             *     * `site_destination` - Site Destination
+             *     * `internal_destination` - Internal Destination
+             *     * `source_webhook` - Source Webhook
+             *     * `warehouse_source_webhook` - Warehouse Source Webhook
+             *     * `site_app` - Site App
+             *     * `transformation` - Transformation
+             */
+            type?: components["schemas"]["HogFunctionTypeEnum"] | components["schemas"]["NullEnum"];
+            /** @description Display name for the function. */
+            name?: string | null;
+            /** @description Human-readable description of what this function does. */
+            description?: string;
+            /** Format: date-time */
+            readonly created_at?: string;
+            readonly created_by?: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at?: string;
+            /** @description Whether the function is active and processing events. */
+            enabled?: boolean;
+            /** @description Soft-delete flag. Set to true to archive the function. */
+            deleted?: boolean;
+            /** @description Source code. Hog language for most types; TypeScript for site_destination and site_app. */
+            hog?: string;
+            readonly bytecode?: unknown;
+            readonly transpiled?: string | null;
+            /** @description Schema defining the configurable input parameters for this function. */
+            inputs_schema?: components["schemas"]["InputsSchemaItem"][];
+            /** @description Values for each input defined in inputs_schema. */
+            inputs?: {
+                [key: string]: components["schemas"]["InputsItem"];
+            };
+            /** @description Event filters that control which events trigger this function. */
+            filters?: components["schemas"]["HogFunctionFilters"];
+            /** @description PII masking configuration with TTL, threshold, and hash expression. */
+            masking?: components["schemas"]["HogFunctionMasking"] | null;
+            /** @description Event-to-destination field mappings. Only for destination and site_destination types. */
+            mappings?: components["schemas"]["Mappings"][] | null;
+            /** @description URL for the function's icon displayed in the UI. */
+            icon_url?: string | null;
+            readonly template?: components["schemas"]["HogFunctionTemplate"];
+            /** @description ID of the template to create this function from. */
+            template_id?: string | null;
+            readonly status?: components["schemas"]["HogFunctionStatus"] | null;
+            /** @description Execution priority for transformations. Lower values run first. */
+            execution_order?: number | null;
+            /** create in folder */
+            _create_in_folder?: string;
+            /** Format: uuid */
+            readonly batch_export_id?: string | null;
+            /** @description How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match, returned only when no exact match exists). Null when the list is not filtered by `search`. */
+            readonly search_match_type?: components["schemas"]["SearchMatchTypeEnum"] | components["schemas"]["NullEnum"];
         };
         /** @description Simplified serializer to speed response times when loading large amounts of objects. */
         PatchedInsight: {
@@ -20254,6 +20607,122 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FeatureFlag"];
+                };
+            };
+        };
+    };
+    hog_functions_list: {
+        parameters: {
+            query?: {
+                created_at?: string;
+                created_by?: number;
+                enabled?: boolean;
+                id?: string;
+                /** @description Number of results to return per page. */
+                limit?: number;
+                /** @description The initial index from which to return the results. */
+                offset?: number;
+                /** @description Multiple values may be separated by commas. */
+                type?: string[];
+                updated_at?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedHogFunctionMinimalList"];
+                };
+            };
+        };
+    };
+    hog_functions_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["HogFunction"];
+                "application/x-www-form-urlencoded": components["schemas"]["HogFunction"];
+                "multipart/form-data": components["schemas"]["HogFunction"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HogFunction"];
+                };
+            };
+        };
+    };
+    hog_functions_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this hog function. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HogFunction"];
+                };
+            };
+        };
+    };
+    hog_functions_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this hog function. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedHogFunction"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedHogFunction"];
+                "multipart/form-data": components["schemas"]["PatchedHogFunction"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HogFunction"];
                 };
             };
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,5 +75,13 @@ export type {
 export { projectSettings } from "./resources/project-settings/index.js";
 export type { ProjectSettings } from "./resources/project-settings/index.js";
 
+export { hogFunction, secret } from "./resources/hog-function/index.js";
+export type {
+  HogFunction,
+  HogFunctionType,
+  HogFunctionInputValue,
+  SecretInput,
+} from "./resources/hog-function/index.js";
+
 export { createTypedPostHog } from "./client/typed-posthog.js";
 export type { TypedPostHog, CaptureCapableClient } from "./client/typed-posthog.js";

--- a/src/resources/hog-function/client.test.ts
+++ b/src/resources/hog-function/client.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { ServerHogFunctionSchema } from "./client.js";
+
+// Shape hand-derived from a real GET
+// /api/projects/{id}/hog_functions/{id}/ response (project 806). Note the
+// secret input reads back masked as `{ secret: true }`, and non-secret inputs
+// carry server-computed bytecode/order alongside their value.
+const realFn = {
+  id: "019f90da-df91-0000-6fbc-c7ff8167d1fd",
+  type: "destination",
+  name: "ActiveCampaign sync",
+  description: "Sync users\n\n<!-- iac:hog-functions:ac iac:hash:abcd1234 -->",
+  enabled: false,
+  deleted: false,
+  inputs: {
+    accountName: { value: "acme", bytecode: ["_H", 1, 32, "acme"], order: 0 },
+    apiKey: { secret: true },
+  },
+  filters: { source: "events" },
+  template: { id: "template-activecampaign", type: "destination" },
+  template_id: null,
+  bytecode: ["_H", 1],
+  status: { state: 0, tokens: 0 },
+};
+
+describe("ServerHogFunctionSchema", () => {
+  it("parses a real hog function payload", () => {
+    const parsed = ServerHogFunctionSchema.parse(realFn);
+    expect(parsed.id).toBe("019f90da-df91-0000-6fbc-c7ff8167d1fd");
+    expect(parsed.type).toBe("destination");
+    expect(parsed.template?.id).toBe("template-activecampaign");
+    expect(parsed.inputs?.apiKey).toEqual({ secret: true });
+  });
+
+  it("parses the minimal list shape (no inputs)", () => {
+    const { inputs: _omit, ...minimal } = realFn;
+    void _omit;
+    const parsed = ServerHogFunctionSchema.parse(minimal);
+    expect(parsed.inputs).toBeUndefined();
+    expect(parsed.description).toContain("iac:hog-functions:ac");
+  });
+
+  it("throws when id is missing", () => {
+    const { id: _omit, ...withoutId } = realFn;
+    void _omit;
+    expect(() => ServerHogFunctionSchema.parse(withoutId)).toThrow();
+  });
+});

--- a/src/resources/hog-function/client.ts
+++ b/src/resources/hog-function/client.ts
@@ -1,0 +1,139 @@
+import { z } from "zod";
+import type { ClientConfig } from "../../client/config.js";
+import type { components } from "../../generated/api.js";
+import { createApiClient, followPagination, type Paginated } from "../../client/typed.js";
+
+const MANAGED_DESCRIPTION_PREFIX = "<!-- iac:hog-functions:";
+
+export const ServerHogFunctionSchema = z
+  .object({
+    id: z.string(),
+    type: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    description: z.string().nullable().default(""),
+    enabled: z.boolean().nullable().optional(),
+    deleted: z.boolean().nullable().optional(),
+    // Present on the full retrieve, absent on the minimal list. Passthrough:
+    // each value is `{ value, bytecode, order }` or `{ secret: true }`.
+    inputs: z.record(z.string(), z.record(z.string(), z.unknown())).nullable().optional(),
+    filters: z.record(z.string(), z.unknown()).nullable().optional(),
+    // Read-only snapshot of the source template — `template.id` lets us detect
+    // templateId drift on update.
+    template: z
+      .object({ id: z.string().nullable().optional() })
+      .loose()
+      .nullable()
+      .optional(),
+    template_id: z.string().nullable().optional(),
+  })
+  .loose();
+
+export type ServerHogFunction = z.infer<typeof ServerHogFunctionSchema>;
+
+export type HogFunctionInputWire = { value: unknown } | { secret: true };
+
+export type HogFunctionCreate = {
+  type: string;
+  name: string;
+  description: string;
+  template_id: string;
+  enabled?: boolean;
+  inputs?: Record<string, HogFunctionInputWire>;
+  filters?: Record<string, unknown>;
+};
+
+export type HogFunctionUpdate = {
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  inputs?: Record<string, HogFunctionInputWire>;
+  filters?: Record<string, unknown>;
+  deleted?: boolean;
+};
+
+type HogFunctionBody = components["schemas"]["HogFunction"];
+type PatchedHogFunctionBody = components["schemas"]["PatchedHogFunction"];
+type GeneratedPaginatedList = components["schemas"]["PaginatedHogFunctionMinimalList"];
+
+function paginatedFrom(raw: GeneratedPaginatedList): Paginated<unknown> {
+  return {
+    count: raw.count,
+    next: raw.next ?? null,
+    previous: raw.previous ?? null,
+    results: raw.results ?? [],
+  };
+}
+
+/** Unfiltered list (minimal shape — has description, no inputs); used by pull. */
+export async function listHogFunctions(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFunction[]> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/hog_functions/", {
+    params: { path: { project_id: config.projectId }, query: { limit: 100 } },
+  });
+  const firstPage = paginatedFrom(data!);
+  const allRaw = await followPagination<unknown>(config, firstPage, { verbose: options.verbose });
+  return allRaw.map((row) => ServerHogFunctionSchema.parse(row));
+}
+
+export async function listManagedHogFunctions(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFunction[]> {
+  const all = await listHogFunctions(config, options);
+  return all.filter((row) => (row.description ?? "").includes(MANAGED_DESCRIPTION_PREFIX));
+}
+
+/** Full retrieve (includes inputs + template). */
+export async function getHogFunction(
+  config: ClientConfig,
+  id: string,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFunction> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/hog_functions/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+  });
+  return ServerHogFunctionSchema.parse(data);
+}
+
+export async function createHogFunction(
+  config: ClientConfig,
+  payload: HogFunctionCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFunction> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.POST("/api/projects/{project_id}/hog_functions/", {
+    params: { path: { project_id: config.projectId } },
+    body: payload as unknown as HogFunctionBody,
+  });
+  return ServerHogFunctionSchema.parse(data);
+}
+
+export async function updateHogFunction(
+  config: ClientConfig,
+  id: string,
+  payload: HogFunctionUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFunction> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.PATCH("/api/projects/{project_id}/hog_functions/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+    body: payload as unknown as PatchedHogFunctionBody,
+  });
+  return ServerHogFunctionSchema.parse(data);
+}
+
+/**
+ * Delete a hog function. The DELETE verb is 403; functions soft-delete via
+ * PATCH { deleted: true }.
+ */
+export async function deleteHogFunction(
+  config: ClientConfig,
+  id: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  await updateHogFunction(config, id, { deleted: true }, options);
+}

--- a/src/resources/hog-function/codegen.ts
+++ b/src/resources/hog-function/codegen.ts
@@ -1,0 +1,96 @@
+import type { ClientConfig } from "../../client/config.js";
+import { renderObject, renderRawLiteral, stringLiteral } from "../../pull/render.js";
+import { slugify } from "../../pull/slug.js";
+import type { PullRenderContext, RenderedFile } from "../../pull/types.js";
+import { getHogFunction, type ServerHogFunction, updateHogFunction } from "./client.js";
+import { stripMarker } from "./pipeline.js";
+import type { HogFunction } from "./sdk.js";
+
+const MARKER_PREFIX = "iac:hog-functions:";
+const HASH_MARKER_PREFIX = "iac:hash:";
+
+export function pullFilter(
+  server: ServerHogFunction,
+): { kept: true } | { kept: false; reason: string } {
+  if (server.deleted) return { kept: false, reason: "deleted" };
+  // Only template-based functions are representable — custom raw-hog functions
+  // aren't managed by this resource.
+  if (!server.template?.id) return { kept: false, reason: "no source template (custom hog)" };
+  return { kept: true };
+}
+
+export function pullLabel(server: ServerHogFunction): { primary: string; secondary?: string } {
+  return { primary: server.name ?? server.id, secondary: `[${server.type ?? "?"}]` };
+}
+
+export function serverIdOf(server: ServerHogFunction): string {
+  return server.id;
+}
+
+/** The list is minimal (no inputs); retrieve the full row before rendering. */
+export async function hydrateForPull(
+  config: ClientConfig,
+  server: ServerHogFunction,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFunction> {
+  return getHogFunction(config, server.id, options);
+}
+
+export function renderToFile(
+  server: ServerHogFunction,
+  ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const baseSlug = slugify(server.name ?? "") || `hog-function-${server.id}`;
+  const slug = ctx.uniqueSlug(baseSlug);
+
+  const fields: Record<string, string> = {
+    key: stringLiteral(slug),
+    type: stringLiteral(server.type ?? "destination"),
+    name: stringLiteral(server.name ?? ""),
+  };
+  const userDescription = stripMarker(server.description);
+  if (userDescription) fields.description = stringLiteral(userDescription);
+  fields.templateId = stringLiteral(server.template?.id ?? "");
+  if (server.enabled === false) fields.enabled = "false";
+
+  let usesSecret = false;
+  const inputEntries = Object.entries(server.inputs ?? {});
+  if (inputEntries.length > 0) {
+    const inputFields: Record<string, string> = {};
+    for (const [key, item] of inputEntries) {
+      if ((item as { secret?: boolean }).secret) {
+        usesSecret = true;
+        // The value is masked on read — we can't recover it. Emit a placeholder
+        // env reference the operator must fill in.
+        inputFields[key] = `secret(${stringLiteral(`REPLACE_ME_${key.toUpperCase()}`)})`;
+        ctx.warn(
+          `hog function "${server.name}" input "${key}" is a secret — its value is masked on read. Set the env var and edit the placeholder in ${slug}.ts.`,
+        );
+      } else {
+        inputFields[key] = renderRawLiteral((item as { value?: unknown }).value, 4);
+      }
+    }
+    fields.inputs = renderObject(inputFields, 4);
+  }
+  if (server.filters != null) fields.filters = renderRawLiteral(server.filters, 2);
+
+  const imports = usesSecret
+    ? `import { hogFunction, secret } from "@posthog/definitions";`
+    : `import { hogFunction } from "@posthog/definitions";`;
+  const contents = [imports, "", `export default hogFunction(${renderObject(fields, 2)});`, ""].join("\n");
+
+  return { filename: `${slug}.ts`, contents, specKey: slug };
+}
+
+export async function tagOnServer(
+  config: ClientConfig,
+  server: ServerHogFunction,
+  spec: HogFunction,
+  hash: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const userDescription = stripMarker(server.description);
+  const marker = `<!-- ${MARKER_PREFIX}${spec.key} ${HASH_MARKER_PREFIX}${hash} -->`;
+  const newDescription = userDescription ? `${userDescription}\n\n${marker}` : marker;
+  await updateHogFunction(config, server.id, { description: newDescription }, options);
+}

--- a/src/resources/hog-function/index.ts
+++ b/src/resources/hog-function/index.ts
@@ -1,0 +1,62 @@
+import type { ApplyContext, CollectionResourceModule } from "../types.js";
+import type { HogFunction } from "./sdk.js";
+import {
+  displayHogFunction,
+  displayHogFunctionFromServer,
+  HOG_FUNCTION_IDENTITY_PREFIX,
+  hogFunctionHash,
+  hogFunctionHashFromServer,
+  hogFunctionKeyFromServer,
+  looksLikeHogFunction,
+  pruneHogFunction,
+  runHogFunctionOp,
+  validateHogFunctions,
+} from "./pipeline.js";
+import {
+  getHogFunction,
+  listHogFunctions,
+  listManagedHogFunctions,
+  type ServerHogFunction,
+} from "./client.js";
+import {
+  hydrateForPull,
+  pullFilter,
+  pullLabel,
+  renderToFile,
+  serverIdOf,
+  tagOnServer,
+} from "./codegen.js";
+
+export { hogFunction, secret } from "./sdk.js";
+export type { HogFunction, HogFunctionType, HogFunctionInputValue, SecretInput } from "./sdk.js";
+
+export const hogFunctionResource: CollectionResourceModule<HogFunction, ServerHogFunction> = {
+  kind: "collection",
+  name: "hog-functions",
+  displayName: "hog function",
+  identityPrefix: HOG_FUNCTION_IDENTITY_PREFIX,
+
+  isSpec: looksLikeHogFunction,
+  specKey: (spec) => spec.key,
+
+  list: listManagedHogFunctions,
+  keyFromServer: (server) => hogFunctionKeyFromServer(server),
+  hashFromServer: (server) => hogFunctionHashFromServer(server),
+
+  hash: hogFunctionHash,
+  validate: (specs) => validateHogFunctions(specs),
+  executeOp: runHogFunctionOp,
+  prune: pruneHogFunction,
+
+  displaySpec: (spec, _ctx: ApplyContext) => displayHogFunction(spec),
+  displayServer: (server, _ctx: ApplyContext) => displayHogFunctionFromServer(server),
+
+  listAll: listHogFunctions,
+  getById: (config, id, options) => getHogFunction(config, String(id), options),
+  hydrateForPull,
+  pullFilter,
+  pullLabel,
+  serverIdOf,
+  renderToFile,
+  tagOnServer,
+};

--- a/src/resources/hog-function/pipeline.test.ts
+++ b/src/resources/hog-function/pipeline.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { diff } from "../../apply/diff.js";
+import type { DesiredState } from "../types.js";
+import { type HogFunction, secret } from "./sdk.js";
+import type { ServerHogFunction } from "./client.js";
+import { hogFunctionHash, validateHogFunctions } from "./pipeline.js";
+
+function spec(key: string, overrides: Partial<HogFunction> = {}): HogFunction {
+  return {
+    key,
+    type: "destination",
+    name: `Fn ${key}`,
+    templateId: "template-activecampaign",
+    inputs: { accountName: "acme" },
+    ...overrides,
+  };
+}
+
+function serverRow(
+  id: string,
+  key: string,
+  hash: string,
+  extraDescription = "",
+): ServerHogFunction {
+  const marker = `<!-- iac:hog-functions:${key} iac:hash:${hash} -->`;
+  return {
+    id,
+    type: "destination",
+    name: `Fn ${key}`,
+    description: extraDescription ? `${extraDescription}\n\n${marker}` : marker,
+    enabled: true,
+    template: { id: "template-activecampaign" },
+  };
+}
+
+function desiredFor(specs: HogFunction[]): DesiredState {
+  const state: DesiredState = new Map();
+  state.set(
+    "hog-functions",
+    specs.map((spec) => ({ path: "<test>", spec })),
+  );
+  return state;
+}
+
+function currentFor(rows: ServerHogFunction[]): Map<string, unknown[]> {
+  return new Map<string, unknown[]>([["hog-functions", rows]]);
+}
+
+describe("hog-function pipeline", () => {
+  it("emits create when desired has no matching server row", () => {
+    const slice = diff(desiredFor([spec("ac")]), currentFor([])).get("hog-functions")!;
+    expect(slice.ops.length).toBe(1);
+    expect(slice.ops[0]!.kind).toBe("create");
+  });
+
+  it("emits unchanged when server hash matches", () => {
+    const desired = spec("ac");
+    const server = serverRow("u1", "ac", hogFunctionHash(desired));
+    const op = diff(desiredFor([desired]), currentFor([server])).get("hog-functions")!.ops[0]!;
+    expect(op.kind).toBe("unchanged");
+  });
+
+  it("emits update when server hash differs", () => {
+    const desired = spec("ac");
+    const server = serverRow("u1", "ac", "stalehash00000000");
+    const op = diff(desiredFor([desired]), currentFor([server])).get("hog-functions")!.ops[0]!;
+    expect(op.kind).toBe("update");
+  });
+
+  it("classifies a server-only managed function as an orphan", () => {
+    const server = serverRow("gh", "ghost", "any");
+    const slice = diff(desiredFor([]), currentFor([server])).get("hog-functions")!;
+    expect(slice.orphans.length).toBe(1);
+  });
+
+  it("safety invariant: ignores server rows without the identity marker", () => {
+    const handBuilt: ServerHogFunction = {
+      id: "hb",
+      type: "transformation",
+      name: "GeoIP",
+      description: "Adds geoip data",
+      enabled: true,
+      template: { id: "template-geoip" },
+    };
+    const slice = diff(desiredFor([]), currentFor([handBuilt])).get("hog-functions")!;
+    expect(slice.ops.length).toBe(0);
+    expect(slice.orphans.length).toBe(0);
+  });
+});
+
+describe("hog-function secret hashing", () => {
+  it("never depends on the secret's env VALUE — only its declaration", () => {
+    const a = spec("ac", { inputs: { apiKey: secret("MY_KEY") } });
+    process.env.MY_KEY = "value-one";
+    const h1 = hogFunctionHash(a);
+    process.env.MY_KEY = "value-two";
+    const h2 = hogFunctionHash(a);
+    delete process.env.MY_KEY;
+    expect(h1).toBe(h2);
+  });
+
+  it("changes when a rotate token is bumped (rotation is a declared change)", () => {
+    const noRotate = spec("ac", { inputs: { apiKey: secret("MY_KEY") } });
+    const rotated = spec("ac", { inputs: { apiKey: secret("MY_KEY", { rotate: "v2" }) } });
+    expect(hogFunctionHash(noRotate)).not.toBe(hogFunctionHash(rotated));
+  });
+
+  it("changes when the secret points at a different env var", () => {
+    const a = spec("ac", { inputs: { apiKey: secret("KEY_A") } });
+    const b = spec("ac", { inputs: { apiKey: secret("KEY_B") } });
+    expect(hogFunctionHash(a)).not.toBe(hogFunctionHash(b));
+  });
+
+  it("changes when a plain input changes", () => {
+    expect(hogFunctionHash(spec("ac", { inputs: { accountName: "acme" } }))).not.toBe(
+      hogFunctionHash(spec("ac", { inputs: { accountName: "globex" } })),
+    );
+  });
+
+  it("changes when templateId changes", () => {
+    expect(hogFunctionHash(spec("ac", { templateId: "template-a" }))).not.toBe(
+      hogFunctionHash(spec("ac", { templateId: "template-b" })),
+    );
+  });
+});
+
+describe("hog-function validation", () => {
+  it("requires a templateId", () => {
+    const issues = validateHogFunctions([spec("ok", { templateId: "" })]);
+    expect(issues.some((m) => m.includes("templateId"))).toBeTruthy();
+  });
+
+  it("rejects an unknown type", () => {
+    const issues = validateHogFunctions([spec("ok", { type: "banana" as HogFunction["type"] })]);
+    expect(issues.some((m) => m.includes("unknown type"))).toBeTruthy();
+  });
+
+  it("rejects duplicate keys", () => {
+    const issues = validateHogFunctions([spec("dup"), spec("dup")]);
+    expect(issues.some((m) => m.includes("Duplicate"))).toBeTruthy();
+  });
+
+  it("accepts a minimal valid spec", () => {
+    expect(validateHogFunctions([spec("ok")])).toEqual([]);
+  });
+});

--- a/src/resources/hog-function/pipeline.ts
+++ b/src/resources/hog-function/pipeline.ts
@@ -1,0 +1,307 @@
+import type { ClientConfig } from "../../client/config.js";
+import { ApiError } from "../../client/typed.js";
+import { specHash } from "../../apply/hash.js";
+import { displayJson, obj, scalar, type DisplayValue } from "../../apply/display.js";
+import { SafetyViolationError } from "../../apply/errors.js";
+import { getResourceKind, type ApplyContext, type ResourceOp } from "../types.js";
+import { type HogFunction, type HogFunctionInputValue, isSecretInput } from "./sdk.js";
+import {
+  createHogFunction,
+  deleteHogFunction,
+  getHogFunction,
+  type HogFunctionCreate,
+  type HogFunctionInputWire,
+  type HogFunctionUpdate,
+  type ServerHogFunction,
+  updateHogFunction,
+} from "./client.js";
+
+/**
+ * Hog functions have no `tags` field. Identity sits in a trailing HTML-comment
+ * marker on `description` (surveys / endpoints pattern).
+ */
+export const HOG_FUNCTION_IDENTITY_PREFIX = "iac:hog-functions:";
+
+const MARKER_REGEX = /\n*<!--\s*iac:hog-functions:(\S+)\s+iac:hash:(\S+)\s*-->\s*$/;
+const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+type ParsedMarker = { userDescription: string; key: string; hash: string };
+
+function parseMarker(description: string | null | undefined): ParsedMarker | undefined {
+  if (!description) return undefined;
+  const match = description.match(MARKER_REGEX);
+  if (!match || match.index === undefined) return undefined;
+  return {
+    userDescription: description.slice(0, match.index).replace(/\s+$/, ""),
+    key: match[1]!,
+    hash: match[2]!,
+  };
+}
+
+function withMarker(userDescription: string | undefined, key: string, hash: string): string {
+  const trailer = `<!-- iac:hog-functions:${key} iac:hash:${hash} -->`;
+  const trimmed = (userDescription ?? "").replace(/\s+$/, "");
+  return trimmed ? `${trimmed}\n\n${trailer}` : trailer;
+}
+
+export function stripMarker(description: string | null | undefined): string | null {
+  if (!description) return null;
+  const parsed = parseMarker(description);
+  return parsed ? parsed.userDescription || null : description;
+}
+
+export function hogFunctionKeyFromServer(server: ServerHogFunction): string | undefined {
+  return parseMarker(server.description)?.key;
+}
+
+export function hogFunctionHashFromServer(server: ServerHogFunction): string | undefined {
+  return parseMarker(server.description)?.hash;
+}
+
+/**
+ * Canonical projection for hashing. Secret values are NEVER included — only the
+ * env var name and the optional rotate token — so the masked read-back can
+ * never produce a spurious diff, and secrets never touch the definition hash.
+ */
+function inputsForHash(inputs: Record<string, HogFunctionInputValue> | undefined): unknown {
+  if (!inputs) return {};
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(inputs)) {
+    out[key] = isSecretInput(value)
+      ? { __secret_env: value.env, rotate: value.rotate ?? null }
+      : value;
+  }
+  return out;
+}
+
+function specForHash(spec: HogFunction): unknown {
+  return {
+    key: spec.key,
+    type: spec.type,
+    name: spec.name,
+    description: spec.description ?? "",
+    templateId: spec.templateId,
+    enabled: spec.enabled ?? true,
+    inputs: inputsForHash(spec.inputs),
+    filters: spec.filters ?? null,
+  };
+}
+
+export function hogFunctionHash(spec: HogFunction): string {
+  return specHash(specForHash(spec));
+}
+
+function resolveSecret(env: string, specKey: string, inputKey: string): string {
+  const value = process.env[env];
+  if (value === undefined || value === "") {
+    throw new Error(
+      `hog function "${specKey}" secret input "${inputKey}" reads env var "${env}", but it is not set. Export it before applying (secrets are never stored in definition files).`,
+    );
+  }
+  return value;
+}
+
+function buildCreatePayload(spec: HogFunction, hash: string): HogFunctionCreate {
+  const payload: HogFunctionCreate = {
+    type: spec.type,
+    name: spec.name,
+    description: withMarker(spec.description, spec.key, hash),
+    template_id: spec.templateId,
+    enabled: spec.enabled ?? true,
+  };
+  const inputs = buildInputs(spec, { includeSecrets: "all" });
+  if (Object.keys(inputs).length > 0) payload.inputs = inputs;
+  if (spec.filters !== undefined) payload.filters = spec.filters;
+  return payload;
+}
+
+function buildUpdatePayload(spec: HogFunction, hash: string): HogFunctionUpdate {
+  const payload: HogFunctionUpdate = {
+    name: spec.name,
+    description: withMarker(spec.description, spec.key, hash),
+    enabled: spec.enabled ?? true,
+  };
+  // On update, only secrets flagged for rotation are re-sent; all others are
+  // omitted so the server keeps the stored value.
+  const inputs = buildInputs(spec, { includeSecrets: "rotating" });
+  if (Object.keys(inputs).length > 0) payload.inputs = inputs;
+  if (spec.filters !== undefined) payload.filters = spec.filters;
+  return payload;
+}
+
+/**
+ * Build the wire `inputs` map. `includeSecrets: "all"` sends every secret
+ * (create); `"rotating"` sends only secrets with a `rotate` token, omitting the
+ * rest so the server preserves them (update).
+ */
+function buildInputs(
+  spec: HogFunction,
+  opts: { includeSecrets: "all" | "rotating" },
+): Record<string, HogFunctionInputWire> {
+  const out: Record<string, HogFunctionInputWire> = {};
+  for (const [key, value] of Object.entries(spec.inputs ?? {})) {
+    if (isSecretInput(value)) {
+      const send = opts.includeSecrets === "all" || value.rotate !== undefined;
+      if (send) out[key] = { value: resolveSecret(value.env, spec.key, key) };
+      // else: omit — preserves the existing secret value on the server.
+    } else {
+      out[key] = { value };
+    }
+  }
+  return out;
+}
+
+export function looksLikeHogFunction(value: unknown): value is HogFunction {
+  return getResourceKind(value) === "hog-function";
+}
+
+const KNOWN_TYPES = new Set([
+  "destination",
+  "transformation",
+  "site_destination",
+  "internal_destination",
+  "site_app",
+  "source_webhook",
+  "warehouse_source_webhook",
+]);
+
+export function validateHogFunctions(specs: HogFunction[]): string[] {
+  const issues: string[] = [];
+  const seenKeys = new Set<string>();
+  const seenNames = new Set<string>();
+
+  for (const spec of specs) {
+    if (!spec.key) {
+      issues.push("hog-function.key is required");
+      continue;
+    }
+    if (!KEY_PATTERN.test(spec.key)) {
+      issues.push(`hog function "${spec.key}" key must match ${KEY_PATTERN.source}`);
+    }
+    if (seenKeys.has(spec.key)) issues.push(`Duplicate hog function key "${spec.key}"`);
+    seenKeys.add(spec.key);
+
+    if (!spec.name || spec.name.trim() === "") {
+      issues.push(`hog function "${spec.key}" name is required`);
+    } else if (seenNames.has(spec.name)) {
+      issues.push(`Duplicate hog function name "${spec.name}"`);
+    } else {
+      seenNames.add(spec.name);
+    }
+
+    if (!spec.type) {
+      issues.push(`hog function "${spec.key}" type is required`);
+    } else if (!KNOWN_TYPES.has(spec.type)) {
+      issues.push(`hog function "${spec.key}" has unknown type "${spec.type}"`);
+    }
+
+    if (!spec.templateId) {
+      issues.push(
+        `hog function "${spec.key}" requires a templateId (e.g. "template-activecampaign") — only template-based functions are managed`,
+      );
+    }
+  }
+  return issues;
+}
+
+/** Refetch (full) and confirm the marker key still matches. Returns the row so
+ * callers can inspect server-side fields like the source template. */
+async function assertManaged(
+  config: ClientConfig,
+  id: string,
+  key: string,
+  options: { verbose?: boolean },
+): Promise<ServerHogFunction> {
+  const current = await getHogFunction(config, id, options);
+  if (hogFunctionKeyFromServer(current) !== key) {
+    throw new SafetyViolationError("hog-function", id, key);
+  }
+  return current;
+}
+
+export async function runHogFunctionOp(
+  config: ClientConfig,
+  op: ResourceOp<HogFunction, ServerHogFunction>,
+  _ctx: ApplyContext,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+
+  const hash = hogFunctionHash(op.spec);
+
+  if (op.kind === "create") {
+    await createHogFunction(config, buildCreatePayload(op.spec, hash), options);
+    return;
+  }
+
+  const current = await assertManaged(config, op.server.id, op.spec.key, options);
+  // The template's code is inlined at create time; template_id is write-only
+  // and reads back null, but `template.id` echoes the source. If the spec now
+  // names a different template, an in-place update would silently keep the old
+  // code — refuse rather than diverge.
+  const serverTemplateId = current.template?.id ?? null;
+  if (serverTemplateId && serverTemplateId !== op.spec.templateId) {
+    throw new Error(
+      `hog function "${op.spec.key}" changed templateId from "${serverTemplateId}" to "${op.spec.templateId}". The template's code is inlined at create time and cannot be swapped in place — delete the function and re-apply to recreate it.`,
+    );
+  }
+  await updateHogFunction(config, op.server.id, buildUpdatePayload(op.spec, hash), options);
+}
+
+export async function pruneHogFunction(
+  config: ClientConfig,
+  orphan: ServerHogFunction,
+  options: { verbose?: boolean } = {},
+): Promise<boolean> {
+  const key = hogFunctionKeyFromServer(orphan) ?? `id:${orphan.id}`;
+  try {
+    await assertManaged(config, orphan.id, key, options);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return false;
+    throw err;
+  }
+  await deleteHogFunction(config, orphan.id, options);
+  return true;
+}
+
+/** Render inputs for display: plain values shown; secrets redacted to their
+ * env var reference (never the value). */
+function displayInputs(inputs: Record<string, HogFunctionInputValue> | undefined): DisplayValue {
+  const shown: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(inputs ?? {})) {
+    shown[key] = isSecretInput(value) ? `secret(env:${value.env})` : value;
+  }
+  return displayJson(shown);
+}
+
+export function displayHogFunction(spec: HogFunction): DisplayValue {
+  return obj([
+    ["key", scalar(spec.key)],
+    ["type", scalar(spec.type)],
+    ["name", scalar(spec.name)],
+    ["description", scalar(spec.description ?? null)],
+    ["templateId", scalar(spec.templateId)],
+    ["enabled", scalar(spec.enabled ?? true)],
+    ["inputs", displayInputs(spec.inputs)],
+    ["filters", displayJson(spec.filters ?? null)],
+  ]);
+}
+
+export function displayHogFunctionFromServer(server: ServerHogFunction): DisplayValue {
+  // Server input values carry bytecode/order and secrets read back masked;
+  // show just the keys (with secret ones flagged) to keep update diffs legible.
+  const shown: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(server.inputs ?? {})) {
+    shown[key] = (item as { secret?: boolean }).secret ? "secret(masked)" : (item as { value?: unknown }).value;
+  }
+  return obj([
+    ["key", scalar(hogFunctionKeyFromServer(server) ?? null)],
+    ["type", scalar(server.type ?? null)],
+    ["name", scalar(server.name ?? "")],
+    ["description", scalar(stripMarker(server.description))],
+    ["templateId", scalar(server.template?.id ?? null)],
+    ["enabled", scalar(server.enabled ?? true)],
+    ["inputs", displayJson(shown)],
+    ["filters", displayJson(server.filters ?? null)],
+  ]);
+}

--- a/src/resources/hog-function/sdk.ts
+++ b/src/resources/hog-function/sdk.ts
@@ -1,0 +1,88 @@
+import { markResourceKind } from "../types.js";
+
+/**
+ * The kinds of hog function. `destination` and `transformation` are the common
+ * IaC targets; the rest are supported as pass-through `type` values.
+ */
+export type HogFunctionType =
+  | "destination"
+  | "transformation"
+  | "site_destination"
+  | "internal_destination"
+  | "site_app"
+  | "source_webhook"
+  | "warehouse_source_webhook";
+
+/**
+ * A secret input value, sourced from an environment variable at apply time.
+ *
+ * Secret handling — the campaign's secrets convention, established here:
+ *  - The definition file stores only the env var NAME, never the value. The
+ *    value is read from `process.env` when the function is created (or rotated)
+ *    and is never written to disk or into the hash.
+ *  - PostHog masks secret inputs on read (`{ secret: true }`), so on update the
+ *    secret is left untouched by default — omitting it preserves the stored
+ *    value. That keeps a masked read-back from ever showing up as a diff.
+ *  - To rotate, set `rotate` to a new token (any string — a date, a version).
+ *    The token is part of the hash, so bumping it triggers an update that
+ *    re-reads `process.env[env]` and sends the fresh value.
+ */
+export type SecretInput = {
+  readonly __hogSecret: true;
+  readonly env: string;
+  readonly rotate?: string;
+};
+
+/**
+ * Declare a secret input backed by an environment variable. Optionally pass a
+ * `rotate` token; change it to force the secret to be re-sent from the
+ * environment on the next apply.
+ */
+export function secret(env: string, opts?: { rotate?: string }): SecretInput {
+  return { __hogSecret: true, env, ...(opts?.rotate ? { rotate: opts.rotate } : {}) };
+}
+
+export function isSecretInput(value: unknown): value is SecretInput {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __hogSecret?: unknown }).__hogSecret === true
+  );
+}
+
+/** A plain (non-secret) input literal, or a secret reference. */
+export type HogFunctionInputValue =
+  | string
+  | number
+  | boolean
+  | null
+  | Record<string, unknown>
+  | unknown[]
+  | SecretInput;
+
+export type HogFunction = {
+  key: string;
+  type: HogFunctionType;
+  name: string;
+  description?: string;
+  /**
+   * The template to build this function from (e.g. "template-activecampaign",
+   * "template-geoip"). The template's code and input schema are inlined into a
+   * standalone function at create time; changing `templateId` afterwards is not
+   * supported (delete and recreate — apply errors rather than silently keeping
+   * the old code).
+   */
+  templateId: string;
+  enabled?: boolean;
+  /**
+   * Values for the template's inputs, keyed by input name. Plain literals for
+   * ordinary fields; `secret("ENV_VAR")` for secret fields.
+   */
+  inputs?: Record<string, HogFunctionInputValue>;
+  /** Event filters controlling which events trigger the function. */
+  filters?: Record<string, unknown>;
+};
+
+export function hogFunction(spec: HogFunction): HogFunction {
+  return markResourceKind(spec, "hog-function");
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -12,6 +12,7 @@ import { experimentHoldoutResource } from "./experiment-holdout/index.js";
 import { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
+import { hogFunctionResource } from "./hog-function/index.js";
 
 /**
  * Source-of-truth registry. Listed in stable, human-readable order — the
@@ -31,6 +32,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
   insightResource as ResourceModule<unknown, unknown>,
   projectSettingsResource as ResourceModule<unknown, unknown>,
   propertyGroupResource as ResourceModule<unknown, unknown>,
+  hogFunctionResource as ResourceModule<unknown, unknown>,
 ];
 
 /**
@@ -53,6 +55,7 @@ export { experimentHoldoutResource } from "./experiment-holdout/index.js";
 export { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 export { experimentResource } from "./experiment/index.js";
 export { projectSettingsResource } from "./project-settings/index.js";
+export { hogFunctionResource } from "./hog-function/index.js";
 export type {
   ResourceModule,
   CollectionResourceModule,

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -16,6 +16,7 @@ import { experimentSavedMetricResource } from "./experiment-saved-metric/index.j
 import { featureFlagResource } from "./feature-flag/index.js";
 import { insightResource } from "./insight/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
+import { hogFunctionResource } from "./hog-function/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
 
 describe("topoOrder", () => {
@@ -185,6 +186,7 @@ describe("RESOURCES (real registry)", () => {
         insightResource,
         projectSettingsResource,
         propertyGroupResource,
+        hogFunctionResource,
       ].map((r) => r.name),
     );
     expect(new Set(RESOURCES.map((r) => r.name))).toEqual(expected);


### PR DESCRIPTION
Adds **hog functions** (destinations / transformations) as a managed resource, and establishes the campaign's **secrets convention**.

## Identity
Description marker (no `tags`) — `iac:hog-functions:<key>`.

## Templates
Template-based. `templateId` seeds a **standalone** function — the template's hog code + `inputs_schema` are inlined at create time. `template_id` is write-only (reads back `null`), but `template.id` echoes the source, so templateId drift is detectable. Changing `templateId` on an existing function would silently keep the old code, so apply **errors** and tells the operator to recreate — no silent divergence.

## Secrets convention (new; established here for the campaign)
Secret inputs (PostHog masks them on read as `{secret: true}`) are handled via **env-var references**:

```ts
inputs: { apiKey: secret("ACTIVECAMPAIGN_API_KEY") }
```

- The value is read from `process.env` at create/rotation time and is **never** written to a definition file.
- **Excluded from the hash** — only the env var name and an optional `rotate` token are hashed. This is what keeps the masked read-back from ever surfacing as a perpetual diff.
- **Sent on create.** On update, secrets are **omitted** (the server preserves the stored value) unless the input carries a `rotate` token (part of the hash) — bump it to force a re-send from the environment.

## Live verification (project 806, field by field)
- create → no-op re-apply (hash projection correct; secret value causes no drift)
- edit a plain input → single update, **secret preserved** (still masked, not clobbered)
- rotation via a bumped `rotate` token → update re-sends the secret from env
- **templateId drift → errors loudly** (no silent divergence)
- orphan left alone → hand-built function (no marker) untouched → kind-scoped prune deletes managed only
- Delete is soft-delete via PATCH `{deleted:true}` (the DELETE verb is 403)

## Scope / notes
- **Template-based functions only** (custom raw-hog deferred). Validation requires a `templateId`.
- Pull renders a `secret("REPLACE_ME_*")` placeholder + warning for masked secret inputs (values can't be recovered on read). Uses `hydrateForPull` since the list endpoint is a minimal shape without inputs.
- Scope: `hog_function:read` / `hog_function:write`.
- Gates green (`typecheck`, `typecheck:examples`, `test` — 308 pass, `lint`). Smoke wiring verified in isolation; full `smoke.sh` stays red on the pre-existing `actions` pull gap (lands on `pl/pull-actions`).

---

Stacks on #81 (base `pl/spec-migration`) — codegen only compiles there. Retarget to `main` when #81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)