### PR TITLE
feat(hog-flow): SDK factory + pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Alpha — do not use in production.**
 > This is pre-MVP software (`0.1.0-alpha.0`). The CLI, the on-disk file format, the SDK surface, and the tag-based identity model are all subject to breaking changes without notice. Use it on throwaway projects or in a sandbox while we stabilize.
 
-Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
+Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, experiment saved metrics, and hog flows (campaigns) in TypeScript, then sync them to a PostHog project with one command.
 
 ## Why
 
@@ -51,6 +51,7 @@ export default dashboard({
    - `event_definition:read`, `event_definition:write` (also covers property groups)
    - `experiment:read`, `experiment:write` (also covers experiment holdouts)
    - `experiment_saved_metric:read`, `experiment_saved_metric:write`
+   - `hog_flow:read`, `hog_flow:write`
 
    Then add it (and your numeric project ID) to a `.env` (or `.envrc`) file:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -62,7 +62,7 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 | Resource              | PostHog API                                  | posthog-definitions | Notes                          |
 | --------------------- | -------------------------------------------- | ------------------- | ------------------------------ |
 | Hog functions         | ✅ `environments/{id}/hog_functions`         | ❌                  | Destinations / transformations |
-| Hog flows             | ✅ `environments/{id}/hog_flows`             | ❌                  | Campaign builder               |
+| Hog flows             | ✅ `environments/{id}/hog_flows`             | ✅                  | Identity via `iac:hog-flows:<key>` marker in `description`. Action/edge graph round-tripped verbatim (author-defined node ids); status draft/active/archived. Full matrix refresh tracked in #78. |
 | Messaging templates   | ✅ `environments/{id}/messaging_templates`   | ❌                  |                                |
 | Messaging categories  | ✅ `environments/{id}/messaging_categories`  | ❌                  |                                |
 | Messaging preferences | ✅ `environments/{id}/messaging_preferences` | ❌                  |                                |

--- a/examples/posthog/hog-flows/trial-ending-reminder.ts
+++ b/examples/posthog/hog-flows/trial-ending-reminder.ts
@@ -1,0 +1,40 @@
+// A second, even simpler campaign: fire when a trial is about to end, branch on
+// whether the account has added a payment method, and exit. Shows a
+// conditional_branch node and a `branch` edge (index 0 matches
+// config.conditions[0]); the no-match path falls through the `continue` edge.
+import { hogFlow } from "@posthog/definitions";
+
+export default hogFlow({
+  key: "trial-ending-reminder",
+  name: "Trial ending reminder",
+  description: "Catch trials with no card on file before they lapse.",
+  actions: [
+    {
+      id: "trigger",
+      type: "trigger",
+      name: "Trial ending soon",
+      config: {
+        type: "event",
+        filters: { events: [{ id: "trial_ending_soon", name: "trial_ending_soon", type: "events" }] },
+      },
+    },
+    {
+      id: "has_card",
+      type: "conditional_branch",
+      name: "Has payment method?",
+      config: {
+        conditions: [
+          { filters: { properties: [{ key: "has_payment_method", value: ["true"], operator: "exact", type: "person" }] } },
+        ],
+      },
+    },
+    { id: "exit", type: "exit", name: "Exit", config: { reason: "done" } },
+  ],
+  edges: [
+    { from: "trigger", to: "has_card", type: "continue" },
+    // Matched condition[0] → already has a card, just exit.
+    { from: "has_card", to: "exit", type: "branch", index: 0 },
+    // No match → (in a fuller flow, send the reminder here) → exit.
+    { from: "has_card", to: "exit", type: "continue" },
+  ],
+});

--- a/examples/posthog/hog-flows/welcome-series.ts
+++ b/examples/posthog/hog-flows/welcome-series.ts
@@ -1,0 +1,43 @@
+// A campaign (hog flow) is an event-triggered graph of action nodes wired by
+// edges. This one fires when a workspace activates, waits a day, then hands off
+// to a destination that sends a welcome email. Action `id`s are author-chosen
+// and referenced by the edges; `type: "trigger"` and `type: "exit"` bookend
+// every flow. The whole graph round-trips verbatim.
+import { hogFlow } from "@posthog/definitions";
+
+export default hogFlow({
+  key: "welcome-series",
+  name: "Welcome series",
+  description: "Nudge freshly-activated workspaces one day in.",
+  status: "draft",
+  exitCondition: "exit_only_at_end",
+  actions: [
+    {
+      id: "trigger",
+      type: "trigger",
+      name: "Workspace activated",
+      config: {
+        type: "event",
+        filters: {
+          events: [{ id: "workspace_activated", name: "workspace_activated", type: "events" }],
+        },
+      },
+    },
+    {
+      id: "wait_a_day",
+      type: "delay",
+      name: "Wait 1 day",
+      config: { delay_duration: "1d" },
+    },
+    {
+      id: "exit",
+      type: "exit",
+      name: "Exit",
+      config: { reason: "completed" },
+    },
+  ],
+  edges: [
+    { from: "trigger", to: "wait_a_day", type: "continue" },
+    { from: "wait_a_day", to: "exit", type: "continue" },
+  ],
+});

--- a/openapi-filter.yaml
+++ b/openapi-filter.yaml
@@ -86,6 +86,12 @@ inverseOperationIds:
   - actions_partial_update
   - actions_destroy
 
+  - hog_flows_list
+  - hog_flows_create
+  - hog_flows_retrieve
+  - hog_flows_partial_update
+  - hog_flows_destroy
+
 unusedComponents:
   - schemas
   - parameters

--- a/scripts/smoke-cleanup.ts
+++ b/scripts/smoke-cleanup.ts
@@ -82,6 +82,9 @@ import {
   pruneAction,
 } from "../src/resources/action/pipeline.js";
 
+import { listManagedHogFlows } from "../src/resources/hog-flow/client.js";
+import { hogFlowKeyFromServer, pruneHogFlow } from "../src/resources/hog-flow/pipeline.js";
+
 import type { ClientConfig } from "../src/client/config.js";
 
 type Args = {
@@ -96,6 +99,7 @@ type Args = {
   "property-group"?: string;
   cohort?: string;
   endpoint?: string;
+  "hog-flow"?: string;
 };
 
 const ARG_KEYS: Array<keyof Args> = [
@@ -110,6 +114,7 @@ const ARG_KEYS: Array<keyof Args> = [
   "property-group",
   "cohort",
   "endpoint",
+  "hog-flow",
 ];
 
 function parseArgs(argv: string[]): Args {
@@ -268,6 +273,16 @@ async function main(): Promise<void> {
       listManagedEndpoints,
       (row) => endpointKeyFromServer(row),
       (c, row) => pruneEndpoint(c, row),
+    );
+  }
+  if (args["hog-flow"]) {
+    await deleteByKey(
+      "hog-flow",
+      args["hog-flow"],
+      config,
+      listManagedHogFlows,
+      (row) => hogFlowKeyFromServer(row),
+      (c, row) => pruneHogFlow(c, row),
     );
   }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -63,6 +63,7 @@ SAVED_METRIC_KEY="smoke-metric-${STAMP}"
 EXPERIMENT_KEY="smoke-experiment-${STAMP}"
 COHORT_KEY="smoke-cohort-${STAMP}"
 ENDPOINT_KEY="smoke-endpoint-${STAMP}"
+HOG_FLOW_KEY="smoke-hogflow-${STAMP}"
 
 # Names that round-trip cleanly through pull's slug-from-name. We use the
 # event-definition `name` as both the spec key AND the on-the-wire event
@@ -71,7 +72,7 @@ EVENT_NAME="${EVENT_DEFINITION_KEY}"
 
 # Resource kinds we'll seed and pull. Used both in --kind for pull and in
 # the no-op assertion's filter (we don't want unrelated kinds dirtying it).
-SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints"
+SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints,hog-flows"
 
 cleanup() {
   echo
@@ -88,6 +89,7 @@ cleanup() {
     "--property-group=${PROPERTY_GROUP_KEY}" \
     "--cohort=${COHORT_KEY}" \
     "--endpoint=${ENDPOINT_KEY}" \
+    "--hog-flow=${HOG_FLOW_KEY}" \
     || echo "smoke: cleanup hit an error (continuing)"
   echo "smoke: removing workdir $WORK_DIR"
   rm -rf "$WORK_DIR"
@@ -153,7 +155,8 @@ mkdir -p \
   "$SEED_DIR/experiment-saved-metrics" \
   "$SEED_DIR/experiments" \
   "$SEED_DIR/cohorts" \
-  "$SEED_DIR/endpoints"
+  "$SEED_DIR/endpoints" \
+  "$SEED_DIR/hog-flows"
 
 # Insight — referenced by the dashboard tile below.
 cat > "$SEED_DIR/insights/smoke-insight.ts" <<EOF
@@ -306,6 +309,21 @@ export default endpoint({
   key: "${ENDPOINT_KEY}",
   name: "${ENDPOINT_KEY}",
   query: { kind: "HogQLQuery", query: "select 1 as smoke" },
+});
+EOF
+
+# Hog flow — independent. Minimal trigger -> exit campaign.
+cat > "$SEED_DIR/hog-flows/smoke-hogflow.ts" <<EOF
+import { hogFlow } from "@posthog/definitions";
+export default hogFlow({
+  key: "${HOG_FLOW_KEY}",
+  name: "${HOG_FLOW_KEY}",
+  description: "Smoke fixture hog flow",
+  actions: [
+    { id: "trigger", type: "trigger", name: "Trigger", config: { type: "event", filters: { events: [{ id: "\$pageview", name: "\$pageview", type: "events" }] } } },
+    { id: "exit", type: "exit", name: "Exit", config: { reason: "done" } },
+  ],
+  edges: [{ from: "trigger", to: "exit", type: "continue" }],
 });
 EOF
 

--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -543,6 +543,38 @@ export interface paths {
         patch: operations["feature_flags_partial_update"];
         trace?: never;
     };
+    "/api/projects/{project_id}/hog_flows/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["hog_flows_list"];
+        put?: never;
+        post: operations["hog_flows_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/hog_flows/{id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["hog_flows_retrieve"];
+        put?: never;
+        post?: never;
+        delete: operations["hog_flows_destroy"];
+        options?: never;
+        head?: never;
+        patch: operations["hog_flows_partial_update"];
+        trace?: never;
+    };
     "/api/projects/{project_id}/insights/": {
         parameters: {
             query?: never;
@@ -4743,6 +4775,14 @@ export interface components {
             operator: components["schemas"]["ExistenceOperatorEnum"];
         };
         /**
+         * @description * `exit_on_conversion` - Conversion
+         *     * `exit_on_trigger_not_matched` - Trigger Not Matched
+         *     * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+         *     * `exit_only_at_end` - Only At End
+         * @enum {string}
+         */
+        ExitConditionEnum: "exit_on_conversion" | "exit_on_trigger_not_matched" | "exit_on_trigger_not_matched_or_conversion" | "exit_only_at_end";
+        /**
          * @description Full experiment representation for the detail, create, and update endpoints.
          *
          *     Extends the shared read-side fields in ``ExperimentBaseSerializer`` with the metric
@@ -8120,6 +8160,263 @@ export interface components {
          * @enum {string}
          */
         HeatmapSortOrder: "asc" | "desc";
+        /** @description Mixin for serializers to add user access control fields */
+        HogFlow: {
+            /** Format: uuid */
+            readonly id: string;
+            /** @description Workflow name. */
+            name?: string | null;
+            /**
+             * @description Optional description.
+             * @default
+             */
+            description: string;
+            readonly version: number;
+            /**
+             * @description draft (no execution), active (live), archived (disabled).
+             *
+             *     * `draft` - Draft
+             *     * `active` - Active
+             *     * `archived` - Archived
+             */
+            status?: components["schemas"]["HogFlowStatusEnum"];
+            /** Format: date-time */
+            readonly created_at: string;
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at: string;
+            readonly trigger: unknown;
+            /** @description Optional dedup/throttle on an already-matched trigger: {hash: <HogQL template>, ttl: <seconds, 60-94608000>, threshold?: <int>}. Without threshold: fire once per hash, then suppress repeats within ttl (hash '{person.id}' = once per person per ttl). With threshold N: fire once per N matches of the same hash — a sampler, the 1st then every Nth. Throttles an already-qualifying trigger; it doesn't decide who enters. Server compiles bytecode from hash; omit to disable. */
+            trigger_masking?: components["schemas"]["HogFlowMasking"] | null;
+            /** @description Conversion goal. filters: ARRAY of property conditions [{key, value, operator, type: event|person|group}]; events: event-based goals [{filters: {events: [...]}}]; window_minutes: minutes after entry. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
+            conversion?: components["schemas"]["HogFlowConversion"] | null;
+            /**
+             * @description exit_only_at_end: only at exit node (default). exit_on_conversion: also on conversion (needs 'conversion'; silent no-op otherwise). exit_on_trigger_not_matched: also when trigger filter stops matching. exit_on_trigger_not_matched_or_conversion: both (needs 'conversion').
+             *
+             *     * `exit_on_conversion` - Conversion
+             *     * `exit_on_trigger_not_matched` - Trigger Not Matched
+             *     * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+             *     * `exit_only_at_end` - Only At End
+             */
+            exit_condition?: components["schemas"]["ExitConditionEnum"];
+            /** @description Graph edges: [{from, to, type: 'continue'|'branch', index?}]. 'continue' = fall-through (sequential, or no-match path of conditional_branch). 'branch' requires 'index': matches config.conditions[index] on conditional_branch / wait_until_condition. Every non-exit action needs a reachable next action ('No next action found' otherwise). */
+            edges?: components["schemas"]["HogFlowEdge"][];
+            /** @description Ordered action nodes. Exactly one type='trigger' required. Typically one type='exit' too. */
+            actions: components["schemas"]["HogFlowAction"][];
+            readonly abort_action: string | null;
+            /** @description Workflow vars (key, type, default). Total <5KB. */
+            variables?: {
+                [key: string]: string;
+            }[];
+            readonly billable_action_types: unknown;
+            /** @description Recurring schedules attached to this workflow (read-only here; manage via the schedules sub-resource). A batch/schedule workflow only fires when it's active AND has an active schedule. Empty for non-scheduled workflows. */
+            readonly schedules: components["schemas"]["HogFlowSchedule"][];
+            /** @description The effective access level the user has for this object */
+            readonly user_access_level: string | null;
+            /** @description Staged content changes awaiting publish — a full snapshot of the workflow's actions, edges and settings. Null when there's nothing staged. Test it with a use_draft test run, then promote it with the publish endpoint or throw it away with discard_draft. */
+            readonly draft: unknown;
+            /**
+             * Format: date-time
+             * @description When the draft was last written; null when there's no staged draft. Pass this to publish (and as base_updated_at on further draft edits) so a concurrent editor's changes aren't clobbered — a mismatch returns 409.
+             */
+            readonly draft_updated_at: string | null;
+            /** @description Skip-forward map for deleted steps: {deleted_action_id: next surviving action_id}. Maintained automatically when a live graph edit deletes actions, so in-flight runs parked on a deleted step continue at its surviving successor instead of exiting. Null when no live deletions have occurred. */
+            readonly action_redirects: {
+                [key: string]: string;
+            } | null;
+        };
+        HogFlowAction: {
+            /** @description Unique node ID within the workflow. */
+            id: string;
+            /** @description Display name. */
+            name: string;
+            /**
+             * @description Optional description.
+             * @default
+             */
+            description: string;
+            /**
+             * @description On failure: continue (skip the action and proceed) or abort (stop the run).
+             *
+             *     * `continue` - continue
+             *     * `abort` - abort
+             */
+            on_error?: components["schemas"]["OnErrorEnum"] | components["schemas"]["NullEnum"];
+            /** @description Created at (epoch ms). Frontend-managed. */
+            created_at?: number;
+            /** @description Updated at (epoch ms). Frontend-managed. */
+            updated_at?: number;
+            /** @description Property filters gating this action. */
+            filters?: components["schemas"]["HogFunctionFilters"] | null;
+            /** @description trigger | function | function_email | function_sms | delay | conditional_branch | wait_until_condition | wait_until_time_window | random_cohort_branch | exit. */
+            type: string;
+            /** @description Type-specific config keyed by action type. trigger: {type: event|webhook|manual|batch|schedule|tracking_pixel, filters?}. filters shape: {events: [{id, name, type:'events', properties:[<cond>]}], properties:[<cond>], actions:[...], filter_test_accounts:<bool>}. <cond>: {key, value, operator, type: event|person|group}. function*: {template_id, inputs: {<key>: {value: <str>}}}. Wrap values in {value:...} to enable hog templating ({person.x}, {event.x}); flat strings won't interpolate. Dictionary input values are template strings too — write booleans/numbers as single-expression templates ('{true}', '{42}'), which evaluate to the typed value. delay: {delay_duration: '<number><unit>'} where unit is m|h|d. Fractions OK ('0.5m'=30s; seconds unsupported). Per-unit max m<=60, h<=24, d<=30; values above are SILENTLY CLAMPED. Max 30d. conditional_branch: {conditions: [{filters}, ...]}. Index N matches the 'branch' edge with index:N. wait_until_condition: {condition: {filters}, events?: [{filters: {events: [{id, name, type: 'events'}], actions?: [...]}, name?}], max_wait_duration: <duration>} (same rules as delay). Continues when condition.filters match OR any events entry fires; each events entry must target at least one event or action. On resolution (a condition match or any events entry firing) it advances via the 'branch' edge with index:0; the max_wait_duration timeout falls through the 'continue' edge. exit: {reason}. */
+            config: {
+                [key: string]: unknown;
+            } | {
+                /** @description Property-based wait condition; continues when the person matches. A condition with no property filters is ignored — the wait then relies on 'events' and the max_wait_duration timeout. */
+                condition?: {
+                    /** @description Property conditions, e.g. {properties: [{key, value, operator, type}]}. */
+                    filters?: components["schemas"]["HogFunctionFilters"] | null;
+                    /** @description Optional display name. */
+                    name?: string;
+                };
+                /** @description Events to wait for: continues when ANY entry fires (OR'd with 'condition'). Each entry: {filters: {events: [{id, name, type: 'events'}], actions?: [...]}, name?}. */
+                events?: {
+                    /** @description Event/action filters; the workflow wakes when a matching event fires. Must target at least one event or action (entries targeting neither are dropped). */
+                    filters?: components["schemas"]["HogFunctionFilters"] | null;
+                    /** @description Optional display name. */
+                    name?: string;
+                }[];
+                /** @description '<number><unit>' with unit m|h|d, e.g. '30m' (same rules as delay). */
+                max_wait_duration: string;
+            };
+            /** @description Output variable for downstream actions: {key, result_path?, spread?, label?} or a list of those. */
+            output_variable?: unknown;
+        };
+        HogFlowConversion: {
+            /** @description Property-based conversion conditions, as an ARRAY of property filters: [{key, value, operator, type: event|person|group}, ...]. Event-based goals do NOT go here — put them in 'events'. Empty array = any event within the window converts. */
+            filters?: {
+                [key: string]: unknown;
+            }[];
+            /** @description Event-based conversion goals: [{filters: {events: [{id, name, type: 'events'}], ...}}]. */
+            events?: components["schemas"]["HogFlowConversionEvent"][];
+            /** @description Conversion window in minutes after a person enters the workflow. null = no explicit window. */
+            window_minutes?: number | null;
+            /** @description Compiled server-side from 'filters'. Do not set; ignored if sent. */
+            bytecode?: unknown;
+        };
+        HogFlowConversionEvent: {
+            /** @description Event/action filters for this conversion event, same shape as trigger filters: {events: [{id, name, type: 'events', properties?: [<cond>]}], actions?: [...], properties?: [<cond>]}. bytecode is compiled server-side. */
+            filters: components["schemas"]["HogFunctionFilters"];
+        };
+        HogFlowEdge: {
+            /** @description Target action id. */
+            to: string;
+            /**
+             * @description continue: fall-through (sequential or the no-match path of conditional_branch). branch: requires 'index' matching config.conditions[index].
+             *
+             *     * `continue` - continue
+             *     * `branch` - branch
+             */
+            type: components["schemas"]["HogFlowEdgeTypeEnum"];
+            /** @description Required for type='branch'. conditional_branch: index into config.conditions[index]. wait_until_condition: use index:0 — it advances via the index:0 branch edge when it resolves (a condition match or an events entry firing). */
+            index?: number;
+            /** @description Source action id. */
+            from: string;
+        };
+        /**
+         * @description * `continue` - continue
+         *     * `branch` - branch
+         * @enum {string}
+         */
+        HogFlowEdgeTypeEnum: "continue" | "branch";
+        HogFlowMasking: {
+            /** @description Seconds (60 to ~94M / 3y) to suppress repeat firings of the same hash. */
+            ttl?: number | null;
+            /** @description Fire once per N matches of the same hash within ttl — a sampler: N=3 fires on the 1st, 4th, 7th… match. Omit to fire on the first match, then suppress repeats within ttl. */
+            threshold?: number | null;
+            /** @description HogQL template defining the dedup/grouping key, e.g. '{person.id}' (once per person) within ttl. */
+            hash: string;
+            /** @description Auto-compiled from hash. Do not set. */
+            bytecode?: unknown;
+        };
+        /** @description Mixin for serializers to add user access control fields */
+        HogFlowMinimal: {
+            /** Format: uuid */
+            readonly id: string;
+            readonly name: string | null;
+            readonly description: string;
+            readonly version: number;
+            readonly status: components["schemas"]["HogFlowStatusEnum"];
+            /** Format: date-time */
+            readonly created_at: string;
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at: string;
+            readonly trigger: unknown;
+            readonly trigger_masking: unknown;
+            readonly conversion: unknown;
+            readonly exit_condition: components["schemas"]["ExitConditionEnum"];
+            readonly edges: unknown;
+            readonly actions: unknown;
+            readonly abort_action: string | null;
+            readonly variables: unknown;
+            readonly billable_action_types: unknown;
+            /** @description The effective access level the user has for this object */
+            readonly user_access_level: string | null;
+        };
+        HogFlowSchedule: {
+            /** Format: uuid */
+            readonly id: string;
+            /** @description iCalendar RRULE string (e.g. 'FREQ=DAILY;INTERVAL=1'). Must produce occurrences at most once per hour. */
+            rrule: string;
+            /**
+             * Format: date-time
+             * @description ISO 8601 datetime the schedule starts from.
+             */
+            starts_at: string;
+            /** @description IANA timezone for interpreting the RRULE (default 'UTC'). */
+            timezone?: string;
+            /** @description Variable value overrides merged with the workflow defaults on each run. */
+            variables?: unknown;
+            /**
+             * @description active, paused, or completed (set once the RRULE's COUNT/UNTIL is exhausted).
+             *
+             *     * `active` - Active
+             *     * `paused` - Paused
+             *     * `completed` - Completed
+             */
+            readonly status: components["schemas"]["HogFlowScheduleStatusEnum"];
+            /**
+             * Format: date-time
+             * @description Next scheduled fire time, computed by the scheduler.
+             */
+            readonly next_run_at: string | null;
+            /** Format: date-time */
+            readonly created_at: string;
+            /** Format: date-time */
+            readonly updated_at: string;
+        };
+        /**
+         * @description * `active` - Active
+         *     * `paused` - Paused
+         *     * `completed` - Completed
+         * @enum {string}
+         */
+        HogFlowScheduleStatusEnum: "active" | "paused" | "completed";
+        /**
+         * @description * `draft` - Draft
+         *     * `active` - Active
+         *     * `archived` - Archived
+         * @enum {string}
+         */
+        HogFlowStatusEnum: "draft" | "active" | "archived";
+        HogFunctionFilters: {
+            /** @default events */
+            source: components["schemas"]["HogFunctionFiltersSourceEnum"];
+            actions?: {
+                [key: string]: unknown;
+            }[];
+            events?: {
+                [key: string]: unknown;
+            }[];
+            data_warehouse?: {
+                [key: string]: unknown;
+            }[];
+            properties?: {
+                [key: string]: unknown;
+            }[];
+            filter_test_accounts?: boolean;
+            bytecode_error?: string;
+        };
+        /**
+         * @description * `events` - events
+         *     * `person-updates` - person-updates
+         *     * `data-warehouse-table` - data-warehouse-table
+         * @enum {string}
+         */
+        HogFunctionFiltersSourceEnum: "events" | "person-updates" | "data-warehouse-table";
         /** HogQLFilter */
         HogQLFilter: {
             /**
@@ -10118,6 +10415,12 @@ export interface components {
          */
         NumericPropertyFilterOperatorEnum: "exact" | "is_not" | "gt" | "lt" | "gte" | "lte";
         /**
+         * @description * `continue` - continue
+         *     * `abort` - abort
+         * @enum {string}
+         */
+        OnErrorEnum: "continue" | "abort";
+        /**
          * OrderDirection2
          * @enum {string}
          */
@@ -10271,6 +10574,21 @@ export interface components {
              */
             previous?: string | null;
             results: components["schemas"]["FeatureFlag"][];
+        };
+        PaginatedHogFlowMinimalList: {
+            /** @example 123 */
+            count: number;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=400&limit=100
+             */
+            next?: string | null;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=200&limit=100
+             */
+            previous?: string | null;
+            results: components["schemas"]["HogFlowMinimal"][];
         };
         PaginatedInsightList: {
             /** @example 123 */
@@ -10611,6 +10929,71 @@ export interface components {
              *     * `device_id` - Device ID
              */
             bucketing_identifier?: components["schemas"]["BucketingIdentifierEnum"] | components["schemas"]["NullEnum"];
+        };
+        /** @description Mixin for serializers to add user access control fields */
+        PatchedHogFlow: {
+            /** Format: uuid */
+            readonly id?: string;
+            /** @description Workflow name. */
+            name?: string | null;
+            /**
+             * @description Optional description.
+             * @default
+             */
+            description: string;
+            readonly version?: number;
+            /**
+             * @description draft (no execution), active (live), archived (disabled).
+             *
+             *     * `draft` - Draft
+             *     * `active` - Active
+             *     * `archived` - Archived
+             */
+            status?: components["schemas"]["HogFlowStatusEnum"];
+            /** Format: date-time */
+            readonly created_at?: string;
+            readonly created_by?: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at?: string;
+            readonly trigger?: unknown;
+            /** @description Optional dedup/throttle on an already-matched trigger: {hash: <HogQL template>, ttl: <seconds, 60-94608000>, threshold?: <int>}. Without threshold: fire once per hash, then suppress repeats within ttl (hash '{person.id}' = once per person per ttl). With threshold N: fire once per N matches of the same hash — a sampler, the 1st then every Nth. Throttles an already-qualifying trigger; it doesn't decide who enters. Server compiles bytecode from hash; omit to disable. */
+            trigger_masking?: components["schemas"]["HogFlowMasking"] | null;
+            /** @description Conversion goal. filters: ARRAY of property conditions [{key, value, operator, type: event|person|group}]; events: event-based goals [{filters: {events: [...]}}]; window_minutes: minutes after entry. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
+            conversion?: components["schemas"]["HogFlowConversion"] | null;
+            /**
+             * @description exit_only_at_end: only at exit node (default). exit_on_conversion: also on conversion (needs 'conversion'; silent no-op otherwise). exit_on_trigger_not_matched: also when trigger filter stops matching. exit_on_trigger_not_matched_or_conversion: both (needs 'conversion').
+             *
+             *     * `exit_on_conversion` - Conversion
+             *     * `exit_on_trigger_not_matched` - Trigger Not Matched
+             *     * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+             *     * `exit_only_at_end` - Only At End
+             */
+            exit_condition?: components["schemas"]["ExitConditionEnum"];
+            /** @description Graph edges: [{from, to, type: 'continue'|'branch', index?}]. 'continue' = fall-through (sequential, or no-match path of conditional_branch). 'branch' requires 'index': matches config.conditions[index] on conditional_branch / wait_until_condition. Every non-exit action needs a reachable next action ('No next action found' otherwise). */
+            edges?: components["schemas"]["HogFlowEdge"][];
+            /** @description Ordered action nodes. Exactly one type='trigger' required. Typically one type='exit' too. */
+            actions?: components["schemas"]["HogFlowAction"][];
+            readonly abort_action?: string | null;
+            /** @description Workflow vars (key, type, default). Total <5KB. */
+            variables?: {
+                [key: string]: string;
+            }[];
+            readonly billable_action_types?: unknown;
+            /** @description Recurring schedules attached to this workflow (read-only here; manage via the schedules sub-resource). A batch/schedule workflow only fires when it's active AND has an active schedule. Empty for non-scheduled workflows. */
+            readonly schedules?: components["schemas"]["HogFlowSchedule"][];
+            /** @description The effective access level the user has for this object */
+            readonly user_access_level?: string | null;
+            /** @description Staged content changes awaiting publish — a full snapshot of the workflow's actions, edges and settings. Null when there's nothing staged. Test it with a use_draft test run, then promote it with the publish endpoint or throw it away with discard_draft. */
+            readonly draft?: unknown;
+            /**
+             * Format: date-time
+             * @description When the draft was last written; null when there's no staged draft. Pass this to publish (and as base_updated_at on further draft edits) so a concurrent editor's changes aren't clobbered — a mismatch returns 409.
+             */
+            readonly draft_updated_at?: string | null;
+            /** @description Skip-forward map for deleted steps: {deleted_action_id: next surviving action_id}. Maintained automatically when a live graph edit deletes actions, so in-flight runs parked on a deleted step continue at its surviving successor instead of exiting. Null when no live deletions have occurred. */
+            readonly action_redirects?: {
+                [key: string]: string;
+            } | null;
         };
         /** @description Simplified serializer to speed response times when loading large amounts of objects. */
         PatchedInsight: {
@@ -20254,6 +20637,148 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FeatureFlag"];
+                };
+            };
+        };
+    };
+    hog_flows_list: {
+        parameters: {
+            query?: {
+                created_at?: string;
+                created_by?: number;
+                id?: string;
+                /** @description Number of results to return per page. */
+                limit?: number;
+                /** @description The initial index from which to return the results. */
+                offset?: number;
+                /**
+                 * @description * `draft` - Draft
+                 *     * `active` - Active
+                 *     * `archived` - Archived
+                 */
+                status?: "active" | "archived" | "draft";
+                updated_at?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedHogFlowMinimalList"];
+                };
+            };
+        };
+    };
+    hog_flows_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["HogFlow"];
+                "application/x-www-form-urlencoded": components["schemas"]["HogFlow"];
+                "multipart/form-data": components["schemas"]["HogFlow"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HogFlow"];
+                };
+            };
+        };
+    };
+    hog_flows_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this hog flow. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HogFlow"];
+                };
+            };
+        };
+    };
+    hog_flows_destroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this hog flow. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    hog_flows_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this hog flow. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedHogFlow"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedHogFlow"];
+                "multipart/form-data": components["schemas"]["PatchedHogFlow"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HogFlow"];
                 };
             };
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,5 +75,14 @@ export type {
 export { projectSettings } from "./resources/project-settings/index.js";
 export type { ProjectSettings } from "./resources/project-settings/index.js";
 
+export { hogFlow } from "./resources/hog-flow/index.js";
+export type {
+  HogFlow,
+  HogFlowStatus,
+  HogFlowExitCondition,
+  HogFlowAction,
+  HogFlowEdge,
+} from "./resources/hog-flow/index.js";
+
 export { createTypedPostHog } from "./client/typed-posthog.js";
 export type { TypedPostHog, CaptureCapableClient } from "./client/typed-posthog.js";

--- a/src/resources/hog-flow/client.test.ts
+++ b/src/resources/hog-flow/client.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { ServerHogFlowSchema } from "./client.js";
+
+// Shape hand-derived from a real GET
+// /api/environments/{id}/hog_flows/{id}/ response (project 806).
+const realFlow = {
+  id: "019f90ec-db26-0000-f7fe-30b8ff4c002a",
+  name: "Welcome series",
+  description: "Onboarding drip\n\n<!-- iac:hog-flows:welcome iac:hash:abcd1234 -->",
+  status: "draft",
+  exit_condition: "exit_only_at_end",
+  version: 1,
+  actions: [
+    { id: "trigger_node", type: "trigger", name: "Trigger", config: { type: "event", filters: {} } },
+    { id: "exit_node", type: "exit", name: "Exit", config: { reason: "done" } },
+  ],
+  edges: [{ from: "trigger_node", to: "exit_node", type: "continue" }],
+  variables: [],
+  created_at: "2026-07-23T00:00:00Z",
+};
+
+describe("ServerHogFlowSchema", () => {
+  it("parses a real hog flow payload", () => {
+    const parsed = ServerHogFlowSchema.parse(realFlow);
+    expect(parsed.id).toBe("019f90ec-db26-0000-f7fe-30b8ff4c002a");
+    expect(parsed.status).toBe("draft");
+    expect(parsed.actions).toHaveLength(2);
+    expect(parsed.edges?.[0]).toMatchObject({ from: "trigger_node", to: "exit_node" });
+  });
+
+  it("throws on an unknown status", () => {
+    expect(() => ServerHogFlowSchema.parse({ ...realFlow, status: "paused" })).toThrow();
+  });
+
+  it("throws when id is missing", () => {
+    const { id: _omit, ...withoutId } = realFlow;
+    void _omit;
+    expect(() => ServerHogFlowSchema.parse(withoutId)).toThrow();
+  });
+});

--- a/src/resources/hog-flow/client.ts
+++ b/src/resources/hog-flow/client.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+import type { ClientConfig } from "../../client/config.js";
+import type { components } from "../../generated/api.js";
+import { createApiClient, followPagination, type Paginated } from "../../client/typed.js";
+
+const MANAGED_DESCRIPTION_PREFIX = "<!-- iac:hog-flows:";
+
+export const ServerHogFlowSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().nullable().optional(),
+    description: z.string().nullable().default(""),
+    status: z.enum(["draft", "active", "archived"]).nullable().optional(),
+    exit_condition: z.string().nullable().optional(),
+    actions: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
+    edges: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
+    trigger_masking: z.record(z.string(), z.unknown()).nullable().optional(),
+    conversion: z.record(z.string(), z.unknown()).nullable().optional(),
+    variables: z.array(z.unknown()).nullable().optional(),
+  })
+  .loose();
+
+export type ServerHogFlow = z.infer<typeof ServerHogFlowSchema>;
+
+export type HogFlowCreate = {
+  name: string;
+  description: string;
+  status?: string;
+  exit_condition?: string;
+  actions: unknown[];
+  edges: unknown[];
+  trigger_masking?: Record<string, unknown>;
+  conversion?: Record<string, unknown>;
+  variables?: unknown[];
+};
+
+export type HogFlowUpdate = Partial<HogFlowCreate>;
+
+type HogFlowBody = components["schemas"]["HogFlow"];
+type PatchedHogFlowBody = components["schemas"]["PatchedHogFlow"];
+type GeneratedPaginatedList = components["schemas"]["PaginatedHogFlowMinimalList"];
+
+function paginatedFrom(raw: GeneratedPaginatedList): Paginated<unknown> {
+  return {
+    count: raw.count,
+    next: raw.next ?? null,
+    previous: raw.previous ?? null,
+    results: raw.results ?? [],
+  };
+}
+
+export async function listHogFlows(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFlow[]> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/hog_flows/", {
+    params: { path: { project_id: config.projectId }, query: { limit: 100 } },
+  });
+  const firstPage = paginatedFrom(data!);
+  const allRaw = await followPagination<unknown>(config, firstPage, { verbose: options.verbose });
+  return allRaw.map((row) => ServerHogFlowSchema.parse(row));
+}
+
+export async function listManagedHogFlows(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFlow[]> {
+  const all = await listHogFlows(config, options);
+  return all.filter((row) => (row.description ?? "").includes(MANAGED_DESCRIPTION_PREFIX));
+}
+
+export async function getHogFlow(
+  config: ClientConfig,
+  id: string,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFlow> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/hog_flows/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+  });
+  return ServerHogFlowSchema.parse(data);
+}
+
+export async function createHogFlow(
+  config: ClientConfig,
+  payload: HogFlowCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFlow> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.POST("/api/projects/{project_id}/hog_flows/", {
+    params: { path: { project_id: config.projectId } },
+    body: payload as unknown as HogFlowBody,
+  });
+  return ServerHogFlowSchema.parse(data);
+}
+
+export async function updateHogFlow(
+  config: ClientConfig,
+  id: string,
+  payload: HogFlowUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerHogFlow> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.PATCH("/api/projects/{project_id}/hog_flows/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+    body: payload as unknown as PatchedHogFlowBody,
+  });
+  return ServerHogFlowSchema.parse(data);
+}
+
+/** Hog flows support a real DELETE (204). */
+export async function deleteHogFlow(
+  config: ClientConfig,
+  id: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  await api.DELETE("/api/projects/{project_id}/hog_flows/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+  });
+}

--- a/src/resources/hog-flow/codegen.ts
+++ b/src/resources/hog-flow/codegen.ts
@@ -1,0 +1,76 @@
+import type { ClientConfig } from "../../client/config.js";
+import { renderObject, renderRawLiteral, stringLiteral } from "../../pull/render.js";
+import { slugify } from "../../pull/slug.js";
+import type { PullRenderContext, RenderedFile } from "../../pull/types.js";
+import { type ServerHogFlow, updateHogFlow } from "./client.js";
+import { stripMarker } from "./pipeline.js";
+import type { HogFlow } from "./sdk.js";
+
+const MARKER_PREFIX = "iac:hog-flows:";
+const HASH_MARKER_PREFIX = "iac:hash:";
+
+export function pullFilter(server: ServerHogFlow): { kept: true } | { kept: false; reason: string } {
+  if ((server as { deleted?: boolean }).deleted) return { kept: false, reason: "deleted" };
+  return { kept: true };
+}
+
+export function pullLabel(server: ServerHogFlow): { primary: string; secondary?: string } {
+  return { primary: server.name ?? server.id, secondary: `[${server.status ?? "draft"}]` };
+}
+
+export function serverIdOf(server: ServerHogFlow): string {
+  return server.id;
+}
+
+function cleanAction(action: Record<string, unknown>): Record<string, unknown> {
+  const { created_at: _c, updated_at: _u, ...rest } = action;
+  void _c;
+  void _u;
+  return rest;
+}
+
+export function renderToFile(
+  server: ServerHogFlow,
+  ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const baseSlug = slugify(server.name ?? "") || `hog-flow-${server.id}`;
+  const slug = ctx.uniqueSlug(baseSlug);
+
+  const fields: Record<string, string> = {
+    key: stringLiteral(slug),
+    name: stringLiteral(server.name ?? ""),
+  };
+  const userDescription = stripMarker(server.description);
+  if (userDescription) fields.description = stringLiteral(userDescription);
+  if (server.status && server.status !== "draft") fields.status = stringLiteral(server.status);
+  if (server.exit_condition && server.exit_condition !== "exit_only_at_end") {
+    fields.exitCondition = stringLiteral(server.exit_condition);
+  }
+  fields.actions = renderRawLiteral((server.actions ?? []).map(cleanAction), 2);
+  fields.edges = renderRawLiteral(server.edges ?? [], 2);
+  if (server.trigger_masking != null) fields.triggerMasking = renderRawLiteral(server.trigger_masking, 2);
+  if (server.conversion != null) fields.conversion = renderRawLiteral(server.conversion, 2);
+  if (server.variables != null) fields.variables = renderRawLiteral(server.variables, 2);
+
+  const contents = [
+    `import { hogFlow } from "@posthog/definitions";`,
+    "",
+    `export default hogFlow(${renderObject(fields, 2)});`,
+    "",
+  ].join("\n");
+
+  return { filename: `${slug}.ts`, contents, specKey: slug };
+}
+
+export async function tagOnServer(
+  config: ClientConfig,
+  server: ServerHogFlow,
+  spec: HogFlow,
+  hash: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const userDescription = stripMarker(server.description);
+  const marker = `<!-- ${MARKER_PREFIX}${spec.key} ${HASH_MARKER_PREFIX}${hash} -->`;
+  const newDescription = userDescription ? `${userDescription}\n\n${marker}` : marker;
+  await updateHogFlow(config, server.id, { description: newDescription }, options);
+}

--- a/src/resources/hog-flow/index.ts
+++ b/src/resources/hog-flow/index.ts
@@ -1,0 +1,55 @@
+import type { ApplyContext, CollectionResourceModule } from "../types.js";
+import type { HogFlow } from "./sdk.js";
+import {
+  displayHogFlow,
+  displayHogFlowFromServer,
+  HOG_FLOW_IDENTITY_PREFIX,
+  hogFlowHash,
+  hogFlowHashFromServer,
+  hogFlowKeyFromServer,
+  looksLikeHogFlow,
+  pruneHogFlow,
+  runHogFlowOp,
+  validateHogFlows,
+} from "./pipeline.js";
+import { getHogFlow, listHogFlows, listManagedHogFlows, type ServerHogFlow } from "./client.js";
+import { pullFilter, pullLabel, renderToFile, serverIdOf, tagOnServer } from "./codegen.js";
+
+export { hogFlow } from "./sdk.js";
+export type {
+  HogFlow,
+  HogFlowStatus,
+  HogFlowExitCondition,
+  HogFlowAction,
+  HogFlowEdge,
+} from "./sdk.js";
+
+export const hogFlowResource: CollectionResourceModule<HogFlow, ServerHogFlow> = {
+  kind: "collection",
+  name: "hog-flows",
+  displayName: "hog flow",
+  identityPrefix: HOG_FLOW_IDENTITY_PREFIX,
+
+  isSpec: looksLikeHogFlow,
+  specKey: (spec) => spec.key,
+
+  list: listManagedHogFlows,
+  keyFromServer: (server) => hogFlowKeyFromServer(server),
+  hashFromServer: (server) => hogFlowHashFromServer(server),
+
+  hash: hogFlowHash,
+  validate: (specs) => validateHogFlows(specs),
+  executeOp: runHogFlowOp,
+  prune: pruneHogFlow,
+
+  displaySpec: (spec, _ctx: ApplyContext) => displayHogFlow(spec),
+  displayServer: (server, _ctx: ApplyContext) => displayHogFlowFromServer(server),
+
+  listAll: listHogFlows,
+  getById: (config, id, options) => getHogFlow(config, String(id), options),
+  pullFilter,
+  pullLabel,
+  serverIdOf,
+  renderToFile,
+  tagOnServer,
+};

--- a/src/resources/hog-flow/pipeline.test.ts
+++ b/src/resources/hog-flow/pipeline.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { diff } from "../../apply/diff.js";
+import type { DesiredState } from "../types.js";
+import type { HogFlow } from "./sdk.js";
+import type { ServerHogFlow } from "./client.js";
+import { hogFlowHash, validateHogFlows } from "./pipeline.js";
+
+function spec(key: string, overrides: Partial<HogFlow> = {}): HogFlow {
+  return {
+    key,
+    name: `Flow ${key}`,
+    actions: [
+      { id: "t", type: "trigger", name: "Trigger", config: { type: "event", filters: {} } },
+      { id: "x", type: "exit", name: "Exit", config: { reason: "done" } },
+    ],
+    edges: [{ from: "t", to: "x", type: "continue" }],
+    ...overrides,
+  };
+}
+
+function serverRow(id: string, key: string, hash: string): ServerHogFlow {
+  return {
+    id,
+    name: `Flow ${key}`,
+    description: `<!-- iac:hog-flows:${key} iac:hash:${hash} -->`,
+    status: "draft",
+    actions: [{ id: "t", type: "trigger" }],
+    edges: [],
+  };
+}
+
+function desiredFor(specs: HogFlow[]): DesiredState {
+  const state: DesiredState = new Map();
+  state.set(
+    "hog-flows",
+    specs.map((spec) => ({ path: "<test>", spec })),
+  );
+  return state;
+}
+
+function currentFor(rows: ServerHogFlow[]): Map<string, unknown[]> {
+  return new Map<string, unknown[]>([["hog-flows", rows]]);
+}
+
+describe("hog-flow pipeline", () => {
+  it("emits create when desired has no matching server row", () => {
+    const slice = diff(desiredFor([spec("welcome")]), currentFor([])).get("hog-flows")!;
+    expect(slice.ops[0]!.kind).toBe("create");
+  });
+
+  it("emits unchanged when server hash matches", () => {
+    const desired = spec("welcome");
+    const op = diff(
+      desiredFor([desired]),
+      currentFor([serverRow("u1", "welcome", hogFlowHash(desired))]),
+    ).get("hog-flows")!.ops[0]!;
+    expect(op.kind).toBe("unchanged");
+  });
+
+  it("emits update when server hash differs", () => {
+    const op = diff(
+      desiredFor([spec("welcome")]),
+      currentFor([serverRow("u1", "welcome", "stale00000000")]),
+    ).get("hog-flows")!.ops[0]!;
+    expect(op.kind).toBe("update");
+  });
+
+  it("hash ignores server-set action created_at/updated_at", () => {
+    const clean = spec("welcome");
+    const withStamps = spec("welcome", {
+      actions: clean.actions.map((a) => ({ ...a, created_at: 123, updated_at: 456 })),
+    });
+    expect(hogFlowHash(clean)).toBe(hogFlowHash(withStamps));
+  });
+
+  it("hash changes when the graph changes", () => {
+    const a = spec("welcome");
+    const b = spec("welcome", { edges: [{ from: "t", to: "x", type: "branch", index: 0 }] });
+    expect(hogFlowHash(a)).not.toBe(hogFlowHash(b));
+  });
+
+  it("classifies a server-only managed flow as an orphan", () => {
+    const slice = diff(desiredFor([]), currentFor([serverRow("gh", "ghost", "any")])).get(
+      "hog-flows",
+    )!;
+    expect(slice.orphans.length).toBe(1);
+  });
+
+  it("safety invariant: ignores server rows without the identity marker", () => {
+    const handBuilt: ServerHogFlow = {
+      id: "hb",
+      name: "Hand-built",
+      description: "a campaign someone built in the UI",
+      status: "active",
+      actions: [{ id: "t", type: "trigger" }],
+      edges: [],
+    };
+    const slice = diff(desiredFor([]), currentFor([handBuilt])).get("hog-flows")!;
+    expect(slice.ops.length).toBe(0);
+    expect(slice.orphans.length).toBe(0);
+  });
+});
+
+describe("hog-flow validation", () => {
+  it("requires exactly one trigger action", () => {
+    const issues = validateHogFlows([
+      spec("two", {
+        actions: [
+          { id: "t1", type: "trigger", config: {} },
+          { id: "t2", type: "trigger", config: {} },
+        ],
+        edges: [],
+      }),
+    ]);
+    expect(issues.some((m) => m.includes("exactly one action with type \"trigger\""))).toBeTruthy();
+  });
+
+  it("rejects an edge referencing an unknown action id", () => {
+    const issues = validateHogFlows([
+      spec("bad", { edges: [{ from: "t", to: "nope", type: "continue" }] }),
+    ]);
+    expect(issues.some((m) => m.includes('"to" does not reference'))).toBeTruthy();
+  });
+
+  it("rejects duplicate action ids", () => {
+    const issues = validateHogFlows([
+      spec("dupids", {
+        actions: [
+          { id: "t", type: "trigger", config: {} },
+          { id: "t", type: "exit", config: {} },
+        ],
+        edges: [],
+      }),
+    ]);
+    expect(issues.some((m) => m.includes("duplicate action id"))).toBeTruthy();
+  });
+
+  it("accepts a minimal valid spec", () => {
+    expect(validateHogFlows([spec("ok")])).toEqual([]);
+  });
+});

--- a/src/resources/hog-flow/pipeline.ts
+++ b/src/resources/hog-flow/pipeline.ts
@@ -1,0 +1,252 @@
+import type { ClientConfig } from "../../client/config.js";
+import { ApiError } from "../../client/typed.js";
+import { specHash } from "../../apply/hash.js";
+import { displayJson, obj, scalar, type DisplayValue } from "../../apply/display.js";
+import { SafetyViolationError } from "../../apply/errors.js";
+import { getResourceKind, type ApplyContext, type ResourceOp } from "../types.js";
+import type { HogFlow, HogFlowAction } from "./sdk.js";
+import {
+  createHogFlow,
+  deleteHogFlow,
+  getHogFlow,
+  type HogFlowCreate,
+  type ServerHogFlow,
+  updateHogFlow,
+} from "./client.js";
+
+/**
+ * Hog flows have no `tags` field. Identity sits in a trailing HTML-comment
+ * marker on `description` (surveys / endpoints pattern).
+ */
+export const HOG_FLOW_IDENTITY_PREFIX = "iac:hog-flows:";
+
+const MARKER_REGEX = /\n*<!--\s*iac:hog-flows:(\S+)\s+iac:hash:(\S+)\s*-->\s*$/;
+const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+type ParsedMarker = { userDescription: string; key: string; hash: string };
+
+function parseMarker(description: string | null | undefined): ParsedMarker | undefined {
+  if (!description) return undefined;
+  const match = description.match(MARKER_REGEX);
+  if (!match || match.index === undefined) return undefined;
+  return {
+    userDescription: description.slice(0, match.index).replace(/\s+$/, ""),
+    key: match[1]!,
+    hash: match[2]!,
+  };
+}
+
+function withMarker(userDescription: string | undefined, key: string, hash: string): string {
+  const trailer = `<!-- iac:hog-flows:${key} iac:hash:${hash} -->`;
+  const trimmed = (userDescription ?? "").replace(/\s+$/, "");
+  return trimmed ? `${trimmed}\n\n${trailer}` : trailer;
+}
+
+export function stripMarker(description: string | null | undefined): string | null {
+  if (!description) return null;
+  const parsed = parseMarker(description);
+  return parsed ? parsed.userDescription || null : description;
+}
+
+export function hogFlowKeyFromServer(server: ServerHogFlow): string | undefined {
+  return parseMarker(server.description)?.key;
+}
+
+export function hogFlowHashFromServer(server: ServerHogFlow): string | undefined {
+  return parseMarker(server.description)?.hash;
+}
+
+/**
+ * Strip server-set bookkeeping (`created_at` / `updated_at`) off each action so
+ * they never enter the hash or a re-sent payload. The action `id` is
+ * author-controlled — kept — and edges reference it, so ordering of `actions`
+ * and `edges` is preserved (not sorted): the graph is meaningful and stable as
+ * authored.
+ */
+function cleanAction(action: HogFlowAction): Record<string, unknown> {
+  const { created_at: _c, updated_at: _u, ...rest } = action as Record<string, unknown>;
+  void _c;
+  void _u;
+  return rest;
+}
+
+function specForHash(spec: HogFlow): unknown {
+  return {
+    key: spec.key,
+    name: spec.name,
+    description: spec.description ?? "",
+    status: spec.status ?? "draft",
+    exit_condition: spec.exitCondition ?? "exit_only_at_end",
+    actions: (spec.actions ?? []).map(cleanAction),
+    edges: spec.edges ?? [],
+    trigger_masking: spec.triggerMasking ?? null,
+    conversion: spec.conversion ?? null,
+    variables: spec.variables ?? null,
+  };
+}
+
+export function hogFlowHash(spec: HogFlow): string {
+  return specHash(specForHash(spec));
+}
+
+function buildPayload(spec: HogFlow, hash: string): HogFlowCreate {
+  const payload: HogFlowCreate = {
+    name: spec.name,
+    description: withMarker(spec.description, spec.key, hash),
+    status: spec.status ?? "draft",
+    exit_condition: spec.exitCondition ?? "exit_only_at_end",
+    actions: (spec.actions ?? []).map(cleanAction),
+    edges: spec.edges ?? [],
+  };
+  if (spec.triggerMasking !== undefined) payload.trigger_masking = spec.triggerMasking;
+  if (spec.conversion !== undefined) payload.conversion = spec.conversion;
+  if (spec.variables !== undefined) payload.variables = spec.variables;
+  return payload;
+}
+
+export function looksLikeHogFlow(value: unknown): value is HogFlow {
+  return getResourceKind(value) === "hog-flow";
+}
+
+function actionType(action: HogFlowAction): string | undefined {
+  const t = (action as { type?: unknown }).type;
+  return typeof t === "string" ? t : undefined;
+}
+
+function actionId(action: HogFlowAction): string | undefined {
+  const id = (action as { id?: unknown }).id;
+  return typeof id === "string" ? id : undefined;
+}
+
+export function validateHogFlows(specs: HogFlow[]): string[] {
+  const issues: string[] = [];
+  const seenKeys = new Set<string>();
+  const seenNames = new Set<string>();
+
+  for (const spec of specs) {
+    if (!spec.key) {
+      issues.push("hog-flow.key is required");
+      continue;
+    }
+    if (!KEY_PATTERN.test(spec.key)) {
+      issues.push(`hog flow "${spec.key}" key must match ${KEY_PATTERN.source}`);
+    }
+    if (seenKeys.has(spec.key)) issues.push(`Duplicate hog flow key "${spec.key}"`);
+    seenKeys.add(spec.key);
+
+    if (!spec.name || spec.name.trim() === "") {
+      issues.push(`hog flow "${spec.key}" name is required`);
+    } else if (seenNames.has(spec.name)) {
+      issues.push(`Duplicate hog flow name "${spec.name}"`);
+    } else {
+      seenNames.add(spec.name);
+    }
+
+    const actions = spec.actions ?? [];
+    if (actions.length === 0) {
+      issues.push(`hog flow "${spec.key}" must have at least one action`);
+      continue;
+    }
+    const ids = new Set<string>();
+    let triggerCount = 0;
+    for (const [i, action] of actions.entries()) {
+      const id = actionId(action);
+      if (!id) {
+        issues.push(`hog flow "${spec.key}" action[${i}] is missing an "id"`);
+      } else {
+        if (ids.has(id)) issues.push(`hog flow "${spec.key}" has duplicate action id "${id}"`);
+        ids.add(id);
+      }
+      if (!actionType(action)) issues.push(`hog flow "${spec.key}" action[${i}] is missing a "type"`);
+      if (actionType(action) === "trigger") triggerCount++;
+    }
+    if (triggerCount !== 1) {
+      issues.push(
+        `hog flow "${spec.key}" must have exactly one action with type "trigger" (found ${triggerCount})`,
+      );
+    }
+
+    for (const [i, edge] of (spec.edges ?? []).entries()) {
+      const from = (edge as { from?: unknown }).from;
+      const to = (edge as { to?: unknown }).to;
+      if (typeof from !== "string" || !ids.has(from)) {
+        issues.push(`hog flow "${spec.key}" edge[${i}] "from" does not reference a known action id`);
+      }
+      if (typeof to !== "string" || !ids.has(to)) {
+        issues.push(`hog flow "${spec.key}" edge[${i}] "to" does not reference a known action id`);
+      }
+    }
+  }
+  return issues;
+}
+
+async function assertManaged(
+  config: ClientConfig,
+  id: string,
+  key: string,
+  options: { verbose?: boolean },
+): Promise<void> {
+  const current = await getHogFlow(config, id, options);
+  if (hogFlowKeyFromServer(current) !== key) {
+    throw new SafetyViolationError("hog-flow", id, key);
+  }
+}
+
+export async function runHogFlowOp(
+  config: ClientConfig,
+  op: ResourceOp<HogFlow, ServerHogFlow>,
+  _ctx: ApplyContext,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+
+  const hash = hogFlowHash(op.spec);
+
+  if (op.kind === "create") {
+    await createHogFlow(config, buildPayload(op.spec, hash), options);
+    return;
+  }
+
+  await assertManaged(config, op.server.id, op.spec.key, options);
+  await updateHogFlow(config, op.server.id, buildPayload(op.spec, hash), options);
+}
+
+export async function pruneHogFlow(
+  config: ClientConfig,
+  orphan: ServerHogFlow,
+  options: { verbose?: boolean } = {},
+): Promise<boolean> {
+  const key = hogFlowKeyFromServer(orphan) ?? `id:${orphan.id}`;
+  try {
+    await assertManaged(config, orphan.id, key, options);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return false;
+    throw err;
+  }
+  await deleteHogFlow(config, orphan.id, options);
+  return true;
+}
+
+export function displayHogFlow(spec: HogFlow): DisplayValue {
+  return obj([
+    ["key", scalar(spec.key)],
+    ["name", scalar(spec.name)],
+    ["description", scalar(spec.description ?? null)],
+    ["status", scalar(spec.status ?? "draft")],
+    ["exit_condition", scalar(spec.exitCondition ?? "exit_only_at_end")],
+    ["actions", displayJson((spec.actions ?? []).map(cleanAction))],
+    ["edges", displayJson(spec.edges ?? [])],
+  ]);
+}
+
+export function displayHogFlowFromServer(server: ServerHogFlow): DisplayValue {
+  return obj([
+    ["key", scalar(hogFlowKeyFromServer(server) ?? null)],
+    ["name", scalar(server.name ?? "")],
+    ["description", scalar(stripMarker(server.description))],
+    ["status", scalar(server.status ?? "draft")],
+    ["exit_condition", scalar(server.exit_condition ?? "exit_only_at_end")],
+    ["actions", displayJson((server.actions ?? []).map((a) => cleanAction(a as HogFlowAction)))],
+    ["edges", displayJson(server.edges ?? [])],
+  ]);
+}

--- a/src/resources/hog-flow/sdk.ts
+++ b/src/resources/hog-flow/sdk.ts
@@ -1,0 +1,49 @@
+import { markResourceKind } from "../types.js";
+
+export type HogFlowStatus = "draft" | "active" | "archived";
+
+export type HogFlowExitCondition =
+  | "exit_on_conversion"
+  | "exit_on_trigger_not_matched"
+  | "exit_on_trigger_not_matched_or_conversion"
+  | "exit_only_at_end";
+
+/**
+ * A node in the flow graph — passthrough. Shape (per the API):
+ * `{ id, type, name?, config, filters?, on_error?, output_variable? }`.
+ * `id` is author-chosen and referenced by edges. `type` is one of trigger /
+ * exit / delay / conditional_branch / wait_until_condition / function* / …;
+ * `config` is type-specific. Round-tripped verbatim and canonically hashed —
+ * posthog-definitions does not enumerate every action type.
+ */
+export type HogFlowAction = Record<string, unknown>;
+
+/**
+ * A graph edge — passthrough: `{ from, to, type: "continue" | "branch",
+ * index? }`. `from`/`to` are action ids; `branch` edges carry an `index`.
+ */
+export type HogFlowEdge = Record<string, unknown>;
+
+export type HogFlow = {
+  key: string;
+  name: string;
+  description?: string;
+  /** draft (default) / active / archived. */
+  status?: HogFlowStatus;
+  /** When the person leaves the flow. Defaults to `exit_only_at_end`. */
+  exitCondition?: HogFlowExitCondition;
+  /**
+   * Ordered action nodes. Exactly one `type: "trigger"` is required; an
+   * `type: "exit"` node is typical. Author-defined `id`s wire the graph.
+   */
+  actions: HogFlowAction[];
+  /** Graph edges connecting action ids. */
+  edges: HogFlowEdge[];
+  triggerMasking?: Record<string, unknown>;
+  conversion?: Record<string, unknown>;
+  variables?: unknown[];
+};
+
+export function hogFlow(spec: HogFlow): HogFlow {
+  return markResourceKind(spec, "hog-flow");
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -12,6 +12,7 @@ import { experimentHoldoutResource } from "./experiment-holdout/index.js";
 import { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
+import { hogFlowResource } from "./hog-flow/index.js";
 
 /**
  * Source-of-truth registry. Listed in stable, human-readable order — the
@@ -31,6 +32,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
   insightResource as ResourceModule<unknown, unknown>,
   projectSettingsResource as ResourceModule<unknown, unknown>,
   propertyGroupResource as ResourceModule<unknown, unknown>,
+  hogFlowResource as ResourceModule<unknown, unknown>,
 ];
 
 /**
@@ -53,6 +55,7 @@ export { experimentHoldoutResource } from "./experiment-holdout/index.js";
 export { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 export { experimentResource } from "./experiment/index.js";
 export { projectSettingsResource } from "./project-settings/index.js";
+export { hogFlowResource } from "./hog-flow/index.js";
 export type {
   ResourceModule,
   CollectionResourceModule,

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -16,6 +16,7 @@ import { experimentSavedMetricResource } from "./experiment-saved-metric/index.j
 import { featureFlagResource } from "./feature-flag/index.js";
 import { insightResource } from "./insight/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
+import { hogFlowResource } from "./hog-flow/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
 
 describe("topoOrder", () => {
@@ -185,6 +186,7 @@ describe("RESOURCES (real registry)", () => {
         insightResource,
         projectSettingsResource,
         propertyGroupResource,
+        hogFlowResource,
       ].map((r) => r.name),
     );
     expect(new Set(RESOURCES.map((r) => r.name))).toEqual(expected);


### PR DESCRIPTION
Adds **hog flows** (campaigns) as a managed resource. Sixth resource in the API-parity campaign.

## Identity
Description marker (no `tags`) — `iac:hog-flows:<key>`.

## The graph
A flow is an author-defined graph:
- **`actions`** — nodes with **author-chosen `id`s** (exactly one `type: "trigger"`, typically one `type: "exit"`), each with a type-specific `config`.
- **`edges`** — `{from, to, type: "continue" | "branch", index?}` referencing action ids.

The graph round-trips **verbatim** as a passthrough structure. Validation enforces trigger cardinality, unique action ids, and that every edge references a known node.

## Canonicalisation / hashing
- **Node ids are author-controlled** — there are no server-generated ids to exclude (the coordinator's concern was preemptive; it doesn't arise here).
- Action order and edge order are **preserved** (not sorted) — the graph is meaningful and stable as authored.
- Server-set action `created_at`/`updated_at` are **stripped** from the hash and re-sent payload; the server also compiles `config.filters` to bytecode on read. None of it matters for no-op, since identity + hash live in the description marker (verified: a flow with server bytecode re-applies as a clean no-op).

## Not mid-migration
The flow-builder API is stable and richly documented — the top-level read-only `trigger` field is a derived view; the writable model is `actions` + `edges`. (Unlike the dashboard-tiles situation, nothing here is silently dropped.)

## Live verification (project 806)
create → no-op re-apply (hash projection correct) → edit → single update (graph preserved) → orphan left alone → hand-built flow (no marker) untouched → kind-scoped prune deletes managed only. Delete is a real DELETE (204). All rows cleaned up.

## Notes
- `status` is declarative (draft / active / archived). Scope: `hog_flow:read` / `hog_flow:write`.
- Gates green (`typecheck`, `typecheck:examples`, `test` — 305 pass, `lint`). Smoke wiring verified in isolation; full `smoke.sh` stays red on the pre-existing `actions` pull gap (lands on `pl/pull-actions`).

---

Stacks on #81 (base `pl/spec-migration`) — codegen only compiles there. Retarget to `main` when #81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)