### PR TITLE
feat(messaging-template): SDK factory + pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Alpha — do not use in production.**
 > This is pre-MVP software (`0.1.0-alpha.0`). The CLI, the on-disk file format, the SDK surface, and the tag-based identity model are all subject to breaking changes without notice. Use it on throwaway projects or in a sandbox while we stabilize.
 
-Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
+Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, experiment saved metrics, and messaging templates in TypeScript, then sync them to a PostHog project with one command.
 
 ## Why
 
@@ -51,6 +51,7 @@ export default dashboard({
    - `event_definition:read`, `event_definition:write` (also covers property groups)
    - `experiment:read`, `experiment:write` (also covers experiment holdouts)
    - `experiment_saved_metric:read`, `experiment_saved_metric:write`
+   - `hog_flow:read`, `hog_flow:write` (also covers messaging templates)
 
    Then add it (and your numeric project ID) to a `.env` (or `.envrc`) file:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -63,7 +63,7 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 | --------------------- | -------------------------------------------- | ------------------- | ------------------------------ |
 | Hog functions         | ✅ `environments/{id}/hog_functions`         | ❌                  | Destinations / transformations |
 | Hog flows             | ✅ `environments/{id}/hog_flows`             | ❌                  | Campaign builder               |
-| Messaging templates   | ✅ `environments/{id}/messaging_templates`   | ❌                  |                                |
+| Messaging templates   | ✅ `environments/{id}/messaging_templates`   | ✅                  | Identity via `iac:messaging-templates:<key>` marker in `description`. Email content (subject/text/html/design) round-tripped as a passthrough bag. `message_category` is a raw uuid passthrough (categories not managed). Full matrix refresh tracked in #78. |
 | Messaging categories  | ✅ `environments/{id}/messaging_categories`  | ❌                  |                                |
 | Messaging preferences | ✅ `environments/{id}/messaging_preferences` | ❌                  |                                |
 | Links                 | ✅ `projects/{id}/links`                     | ❌                  | Short-link service             |

--- a/examples/posthog/messaging-templates/trial-ending-email.ts
+++ b/examples/posthog/messaging-templates/trial-ending-email.ts
@@ -1,0 +1,13 @@
+// A second template — the "your trial ends soon" nudge. A minimal template
+// can skip the visual `design` tree entirely and just ship subject + html.
+import { messageTemplate } from "@posthog/definitions";
+
+export default messageTemplate({
+  key: "trial-ending-email",
+  name: "Trial ending soon",
+  description: "Reminder a few days before a trial lapses.",
+  email: {
+    subject: "Your Acme trial ends in 3 days",
+    html: "<p>Add a payment method to keep your workspace, {{ person.properties.first_name }}.</p>",
+  },
+});

--- a/examples/posthog/messaging-templates/welcome-email.ts
+++ b/examples/posthog/messaging-templates/welcome-email.ts
@@ -1,0 +1,21 @@
+// A reusable email template the campaigns team drops into onboarding flows.
+// `email` is the content bag — `subject`/`text`/`html` are Liquid-templated
+// (tags like {{ person.name }} pass through verbatim), and `design` is the
+// visual-editor document. The whole thing round-trips as one blob; templating
+// is always "liquid".
+import { messageTemplate } from "@posthog/definitions";
+
+export default messageTemplate({
+  key: "welcome-email",
+  name: "Welcome email",
+  description: "Sent to new workspaces on day zero.",
+  email: {
+    subject: "Welcome to Acme, {{ person.properties.first_name }}!",
+    text: "Thanks for signing up. Here's how to get started…",
+    html: "<h1>Welcome!</h1><p>Thanks for signing up, {{ person.properties.first_name }}.</p>",
+    design: {
+      // The visual editor stores its own tree here; kept as an opaque bag.
+      body: { rows: [] },
+    },
+  },
+});

--- a/openapi-filter.yaml
+++ b/openapi-filter.yaml
@@ -86,6 +86,11 @@ inverseOperationIds:
   - actions_partial_update
   - actions_destroy
 
+  - messaging_templates_list
+  - messaging_templates_create
+  - messaging_templates_retrieve
+  - messaging_templates_partial_update
+
 unusedComponents:
   - schemas
   - parameters

--- a/scripts/smoke-cleanup.ts
+++ b/scripts/smoke-cleanup.ts
@@ -82,6 +82,12 @@ import {
   pruneAction,
 } from "../src/resources/action/pipeline.js";
 
+import { listManagedMessageTemplates } from "../src/resources/messaging-template/client.js";
+import {
+  messageTemplateKeyFromServer,
+  pruneMessageTemplate,
+} from "../src/resources/messaging-template/pipeline.js";
+
 import type { ClientConfig } from "../src/client/config.js";
 
 type Args = {
@@ -96,6 +102,7 @@ type Args = {
   "property-group"?: string;
   cohort?: string;
   endpoint?: string;
+  "messaging-template"?: string;
 };
 
 const ARG_KEYS: Array<keyof Args> = [
@@ -110,6 +117,7 @@ const ARG_KEYS: Array<keyof Args> = [
   "property-group",
   "cohort",
   "endpoint",
+  "messaging-template",
 ];
 
 function parseArgs(argv: string[]): Args {
@@ -268,6 +276,16 @@ async function main(): Promise<void> {
       listManagedEndpoints,
       (row) => endpointKeyFromServer(row),
       (c, row) => pruneEndpoint(c, row),
+    );
+  }
+  if (args["messaging-template"]) {
+    await deleteByKey(
+      "messaging-template",
+      args["messaging-template"],
+      config,
+      listManagedMessageTemplates,
+      (row) => messageTemplateKeyFromServer(row),
+      (c, row) => pruneMessageTemplate(c, row),
     );
   }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -63,6 +63,7 @@ SAVED_METRIC_KEY="smoke-metric-${STAMP}"
 EXPERIMENT_KEY="smoke-experiment-${STAMP}"
 COHORT_KEY="smoke-cohort-${STAMP}"
 ENDPOINT_KEY="smoke-endpoint-${STAMP}"
+MESSAGING_TEMPLATE_KEY="smoke-msgtmpl-${STAMP}"
 
 # Names that round-trip cleanly through pull's slug-from-name. We use the
 # event-definition `name` as both the spec key AND the on-the-wire event
@@ -71,7 +72,7 @@ EVENT_NAME="${EVENT_DEFINITION_KEY}"
 
 # Resource kinds we'll seed and pull. Used both in --kind for pull and in
 # the no-op assertion's filter (we don't want unrelated kinds dirtying it).
-SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints"
+SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints,messaging-templates"
 
 cleanup() {
   echo
@@ -88,6 +89,7 @@ cleanup() {
     "--property-group=${PROPERTY_GROUP_KEY}" \
     "--cohort=${COHORT_KEY}" \
     "--endpoint=${ENDPOINT_KEY}" \
+    "--messaging-template=${MESSAGING_TEMPLATE_KEY}" \
     || echo "smoke: cleanup hit an error (continuing)"
   echo "smoke: removing workdir $WORK_DIR"
   rm -rf "$WORK_DIR"
@@ -153,7 +155,8 @@ mkdir -p \
   "$SEED_DIR/experiment-saved-metrics" \
   "$SEED_DIR/experiments" \
   "$SEED_DIR/cohorts" \
-  "$SEED_DIR/endpoints"
+  "$SEED_DIR/endpoints" \
+  "$SEED_DIR/messaging-templates"
 
 # Insight — referenced by the dashboard tile below.
 cat > "$SEED_DIR/insights/smoke-insight.ts" <<EOF
@@ -306,6 +309,17 @@ export default endpoint({
   key: "${ENDPOINT_KEY}",
   name: "${ENDPOINT_KEY}",
   query: { kind: "HogQLQuery", query: "select 1 as smoke" },
+});
+EOF
+
+# Messaging template — independent. Minimal email.
+cat > "$SEED_DIR/messaging-templates/smoke-msgtmpl.ts" <<EOF
+import { messageTemplate } from "@posthog/definitions";
+export default messageTemplate({
+  key: "${MESSAGING_TEMPLATE_KEY}",
+  name: "${MESSAGING_TEMPLATE_KEY}",
+  description: "Smoke fixture messaging template",
+  email: { subject: "Smoke {{ person.name }}", html: "<p>smoke</p>" },
 });
 EOF
 

--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -616,6 +616,38 @@ export interface paths {
         patch: operations["insights_partial_update"];
         trace?: never;
     };
+    "/api/projects/{project_id}/messaging_templates/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["messaging_templates_list"];
+        put?: never;
+        post: operations["messaging_templates_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/messaging_templates/{id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["messaging_templates_retrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["messaging_templates_partial_update"];
+        trace?: never;
+    };
     "/api/projects/{project_id}/schema_property_groups/": {
         parameters: {
             query?: never;
@@ -3302,6 +3334,31 @@ export interface components {
              * @default null
              */
             value: (string | number | boolean)[] | string | number | boolean | null;
+        };
+        EmailTemplate: {
+            /** @description Email subject line. Supports Liquid templating. Required for email-type templates. */
+            subject?: string;
+            /** @description Plain-text fallback body for clients that can't render the email. */
+            text?: string;
+            /** @description Rendered email body — derived from the design at save time. The visual editor's save path supplies it directly; omit it otherwise. */
+            html?: string;
+            /** @description Design JSON for PostHog's visual email editor — the authoring surface and source of truth. The server renders the sent email from it, and it opens as editable blocks in the editor. Full schema in the designing-email-templates skill. */
+            design?: {
+                /** @description Highest htmlID suffix per element type, e.g. {"u_row": 1, "u_content_text": 2}. */
+                counters?: Record<string, never>;
+                /** @description Design schema version, e.g. 16. */
+                schemaVersion: number;
+                body: {
+                    /** @description Any unique string. */
+                    id?: string;
+                    /** @description Rows of {id, cells, columns[{id, contents[{id, type, values}], values}], values}. */
+                    rows: Record<string, never>[];
+                    headers?: Record<string, never>[];
+                    footers?: Record<string, never>[];
+                    /** @description Body-level settings: backgroundColor, contentWidth ('600px'), fontFamily, textColor. */
+                    values?: Record<string, never>;
+                };
+            };
         };
         /** EmptyPropertyFilter */
         EmptyPropertyFilter: {
@@ -9787,6 +9844,46 @@ export interface components {
          * @enum {string}
          */
         MeanRetentionCalculation: "simple" | "weighted" | "none";
+        MessageTemplate: {
+            /** Format: uuid */
+            readonly id: string;
+            /** @description Human-readable template name shown in the library. */
+            name: string;
+            /** @description What the template is for and when to use it. */
+            description?: string;
+            /** Format: date-time */
+            readonly created_at: string;
+            /** Format: date-time */
+            readonly updated_at: string;
+            /** @description Template content keyed by channel. Replaced as a whole on update, not merged. */
+            content?: components["schemas"]["MessageTemplateContent"];
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** @description Message channel of the template. Currently 'email'. */
+            type?: string;
+            /**
+             * Format: uuid
+             * @description Message category ID to file the template under. Must belong to the same project.
+             */
+            message_category?: string | null;
+            /** @description Soft-delete flag. Set true to remove the template from the library. */
+            deleted?: boolean;
+        };
+        MessageTemplateContent: {
+            /**
+             * @description Templating language for the email content. Always 'liquid' — Liquid tags pass through verbatim.
+             *
+             *     * `liquid` - liquid
+             * @default liquid
+             */
+            templating: components["schemas"]["MessageTemplateContentTemplatingEnum"];
+            /** @description Email message content. Replaced as a whole on update — send the complete object. */
+            email?: components["schemas"]["EmailTemplate"] | null;
+        };
+        /**
+         * @description * `liquid` - liquid
+         * @enum {string}
+         */
+        MessageTemplateContentTemplatingEnum: "liquid";
         /** MetricPropertyFilter */
         MetricPropertyFilter: {
             /** Key */
@@ -10287,6 +10384,21 @@ export interface components {
             previous?: string | null;
             results: components["schemas"]["Insight"][];
         };
+        PaginatedMessageTemplateList: {
+            /** @example 123 */
+            count: number;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=400&limit=100
+             */
+            next?: string | null;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=200&limit=100
+             */
+            previous?: string | null;
+            results: components["schemas"]["MessageTemplate"][];
+        };
         PaginatedSchemaPropertyGroupList: {
             /** @example 123 */
             count: number;
@@ -10691,6 +10803,30 @@ export interface components {
             readonly last_viewed_at?: string | null;
             /** @description How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match, returned only when no exact match exists). Null when the list is not filtered by `search`. */
             readonly search_match_type?: components["schemas"]["SearchMatchTypeEnum"] | components["schemas"]["NullEnum"];
+        };
+        PatchedMessageTemplate: {
+            /** Format: uuid */
+            readonly id?: string;
+            /** @description Human-readable template name shown in the library. */
+            name?: string;
+            /** @description What the template is for and when to use it. */
+            description?: string;
+            /** Format: date-time */
+            readonly created_at?: string;
+            /** Format: date-time */
+            readonly updated_at?: string;
+            /** @description Template content keyed by channel. Replaced as a whole on update, not merged. */
+            content?: components["schemas"]["MessageTemplateContent"];
+            readonly created_by?: components["schemas"]["UserBasic"];
+            /** @description Message channel of the template. Currently 'email'. */
+            type?: string;
+            /**
+             * Format: uuid
+             * @description Message category ID to file the template under. Must belong to the same project.
+             */
+            message_category?: string | null;
+            /** @description Soft-delete flag. Set true to remove the template from the library. */
+            deleted?: boolean;
         };
         /**
          * @description OpenAPI-only PATCH body for dashboards (agents/MCP).
@@ -20498,6 +20634,115 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["Insight"];
                     "text/csv": components["schemas"]["Insight"];
+                };
+            };
+        };
+    };
+    messaging_templates_list: {
+        parameters: {
+            query?: {
+                /** @description Number of results to return per page. */
+                limit?: number;
+                /** @description The initial index from which to return the results. */
+                offset?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedMessageTemplateList"];
+                };
+            };
+        };
+    };
+    messaging_templates_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MessageTemplate"];
+                "application/x-www-form-urlencoded": components["schemas"]["MessageTemplate"];
+                "multipart/form-data": components["schemas"]["MessageTemplate"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageTemplate"];
+                };
+            };
+        };
+    };
+    messaging_templates_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this message template. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageTemplate"];
+                };
+            };
+        };
+    };
+    messaging_templates_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this message template. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedMessageTemplate"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedMessageTemplate"];
+                "multipart/form-data": components["schemas"]["PatchedMessageTemplate"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageTemplate"];
                 };
             };
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,5 +75,12 @@ export type {
 export { projectSettings } from "./resources/project-settings/index.js";
 export type { ProjectSettings } from "./resources/project-settings/index.js";
 
+export { messageTemplate } from "./resources/messaging-template/index.js";
+export type {
+  MessageTemplate,
+  MessageTemplateType,
+  EmailContent,
+} from "./resources/messaging-template/index.js";
+
 export { createTypedPostHog } from "./client/typed-posthog.js";
 export type { TypedPostHog, CaptureCapableClient } from "./client/typed-posthog.js";

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -12,6 +12,7 @@ import { experimentHoldoutResource } from "./experiment-holdout/index.js";
 import { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
+import { messagingTemplateResource } from "./messaging-template/index.js";
 
 /**
  * Source-of-truth registry. Listed in stable, human-readable order — the
@@ -31,6 +32,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
   insightResource as ResourceModule<unknown, unknown>,
   projectSettingsResource as ResourceModule<unknown, unknown>,
   propertyGroupResource as ResourceModule<unknown, unknown>,
+  messagingTemplateResource as ResourceModule<unknown, unknown>,
 ];
 
 /**
@@ -53,6 +55,7 @@ export { experimentHoldoutResource } from "./experiment-holdout/index.js";
 export { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 export { experimentResource } from "./experiment/index.js";
 export { projectSettingsResource } from "./project-settings/index.js";
+export { messagingTemplateResource } from "./messaging-template/index.js";
 export type {
   ResourceModule,
   CollectionResourceModule,

--- a/src/resources/messaging-template/client.test.ts
+++ b/src/resources/messaging-template/client.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { ServerMessageTemplateSchema } from "./client.js";
+
+// Shape hand-derived from a real GET
+// /api/environments/{id}/messaging_templates/{id}/ response (project 806).
+const realTemplate = {
+  id: "019f90f8-1f1b-0000-747d-7d0d6b714f5f",
+  name: "Welcome email",
+  description: "Onboarding\n\n<!-- iac:messaging-templates:welcome iac:hash:abcd1234 -->",
+  type: "email",
+  message_category: null,
+  content: {
+    templating: "liquid",
+    email: {
+      subject: "Welcome {{ person.name }}",
+      text: "Hi there",
+      html: "<p>Hi there</p>",
+      design: { body: { rows: [] } },
+    },
+  },
+  deleted: false,
+  created_at: "2026-07-23T00:00:00Z",
+  created_by: { id: 1, uuid: "u", distinct_id: "d" },
+};
+
+describe("ServerMessageTemplateSchema", () => {
+  it("parses a real messaging template payload", () => {
+    const parsed = ServerMessageTemplateSchema.parse(realTemplate);
+    expect(parsed.id).toBe("019f90f8-1f1b-0000-747d-7d0d6b714f5f");
+    expect(parsed.type).toBe("email");
+    expect(parsed.content?.email).toMatchObject({ subject: "Welcome {{ person.name }}" });
+  });
+
+  it("parses when message_category carries a uuid", () => {
+    const parsed = ServerMessageTemplateSchema.parse({
+      ...realTemplate,
+      message_category: "019f0000-0000-0000-0000-000000000000",
+    });
+    expect(parsed.message_category).toBe("019f0000-0000-0000-0000-000000000000");
+  });
+
+  it("throws when name is missing", () => {
+    const { name: _omit, ...withoutName } = realTemplate;
+    void _omit;
+    expect(() => ServerMessageTemplateSchema.parse(withoutName)).toThrow();
+  });
+});

--- a/src/resources/messaging-template/client.ts
+++ b/src/resources/messaging-template/client.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+import type { ClientConfig } from "../../client/config.js";
+import type { components } from "../../generated/api.js";
+import { createApiClient, followPagination, type Paginated } from "../../client/typed.js";
+
+const MANAGED_DESCRIPTION_PREFIX = "<!-- iac:messaging-templates:";
+
+export const ServerMessageTemplateSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().nullable().default(""),
+    type: z.string().nullable().optional(),
+    message_category: z.string().nullable().optional(),
+    content: z
+      .object({
+        templating: z.string().nullable().optional(),
+        email: z.record(z.string(), z.unknown()).nullable().optional(),
+      })
+      .loose()
+      .nullable()
+      .optional(),
+    deleted: z.boolean().nullable().optional(),
+  })
+  .loose();
+
+export type ServerMessageTemplate = z.infer<typeof ServerMessageTemplateSchema>;
+
+export type MessageTemplateCreate = {
+  name: string;
+  description: string;
+  type: string;
+  content: { templating: string; email: Record<string, unknown> };
+  message_category?: string | null;
+};
+
+export type MessageTemplateUpdate = Partial<MessageTemplateCreate> & { deleted?: boolean };
+
+type MessageTemplateBody = components["schemas"]["MessageTemplate"];
+type PatchedMessageTemplateBody = components["schemas"]["PatchedMessageTemplate"];
+type GeneratedPaginatedList = components["schemas"]["PaginatedMessageTemplateList"];
+
+function paginatedFrom(raw: GeneratedPaginatedList): Paginated<unknown> {
+  return {
+    count: raw.count,
+    next: raw.next ?? null,
+    previous: raw.previous ?? null,
+    results: raw.results ?? [],
+  };
+}
+
+export async function listMessageTemplates(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerMessageTemplate[]> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/messaging_templates/", {
+    params: { path: { project_id: config.projectId }, query: { limit: 100 } },
+  });
+  const firstPage = paginatedFrom(data!);
+  const allRaw = await followPagination<unknown>(config, firstPage, { verbose: options.verbose });
+  return allRaw.map((row) => ServerMessageTemplateSchema.parse(row));
+}
+
+export async function listManagedMessageTemplates(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerMessageTemplate[]> {
+  const all = await listMessageTemplates(config, options);
+  return all.filter((row) => (row.description ?? "").includes(MANAGED_DESCRIPTION_PREFIX));
+}
+
+export async function getMessageTemplate(
+  config: ClientConfig,
+  id: string,
+  options: { verbose?: boolean } = {},
+): Promise<ServerMessageTemplate> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/messaging_templates/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+  });
+  return ServerMessageTemplateSchema.parse(data);
+}
+
+export async function createMessageTemplate(
+  config: ClientConfig,
+  payload: MessageTemplateCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerMessageTemplate> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.POST("/api/projects/{project_id}/messaging_templates/", {
+    params: { path: { project_id: config.projectId } },
+    body: payload as unknown as MessageTemplateBody,
+  });
+  return ServerMessageTemplateSchema.parse(data);
+}
+
+export async function updateMessageTemplate(
+  config: ClientConfig,
+  id: string,
+  payload: MessageTemplateUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerMessageTemplate> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.PATCH("/api/projects/{project_id}/messaging_templates/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+    body: payload as unknown as PatchedMessageTemplateBody,
+  });
+  return ServerMessageTemplateSchema.parse(data);
+}
+
+/**
+ * Delete a template. The DELETE verb is 405; templates soft-delete via
+ * PATCH { deleted: true }.
+ */
+export async function deleteMessageTemplate(
+  config: ClientConfig,
+  id: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  await updateMessageTemplate(config, id, { deleted: true }, options);
+}

--- a/src/resources/messaging-template/codegen.ts
+++ b/src/resources/messaging-template/codegen.ts
@@ -1,0 +1,67 @@
+import type { ClientConfig } from "../../client/config.js";
+import { renderObject, renderRawLiteral, stringLiteral } from "../../pull/render.js";
+import { slugify } from "../../pull/slug.js";
+import type { PullRenderContext, RenderedFile } from "../../pull/types.js";
+import { type ServerMessageTemplate, updateMessageTemplate } from "./client.js";
+import { stripMarker } from "./pipeline.js";
+import type { MessageTemplate } from "./sdk.js";
+
+const MARKER_PREFIX = "iac:messaging-templates:";
+const HASH_MARKER_PREFIX = "iac:hash:";
+
+export function pullFilter(
+  server: ServerMessageTemplate,
+): { kept: true } | { kept: false; reason: string } {
+  if (server.deleted) return { kept: false, reason: "deleted" };
+  return { kept: true };
+}
+
+export function pullLabel(server: ServerMessageTemplate): { primary: string; secondary?: string } {
+  return { primary: server.name, secondary: `[${server.type ?? "email"}]` };
+}
+
+export function serverIdOf(server: ServerMessageTemplate): string {
+  return server.id;
+}
+
+export function renderToFile(
+  server: ServerMessageTemplate,
+  ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const baseSlug = slugify(server.name) || `messaging-template-${server.id}`;
+  const slug = ctx.uniqueSlug(baseSlug);
+
+  const fields: Record<string, string> = {
+    key: stringLiteral(slug),
+    name: stringLiteral(server.name),
+  };
+  const userDescription = stripMarker(server.description);
+  if (userDescription) fields.description = stringLiteral(userDescription);
+  fields.email = renderRawLiteral(server.content?.email ?? {}, 2);
+  if (server.content?.templating && server.content.templating !== "liquid") {
+    fields.templating = stringLiteral(server.content.templating);
+  }
+  if (server.message_category) fields.messageCategory = stringLiteral(server.message_category);
+
+  const contents = [
+    `import { messageTemplate } from "@posthog/definitions";`,
+    "",
+    `export default messageTemplate(${renderObject(fields, 2)});`,
+    "",
+  ].join("\n");
+
+  return { filename: `${slug}.ts`, contents, specKey: slug };
+}
+
+export async function tagOnServer(
+  config: ClientConfig,
+  server: ServerMessageTemplate,
+  spec: MessageTemplate,
+  hash: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const userDescription = stripMarker(server.description);
+  const marker = `<!-- ${MARKER_PREFIX}${spec.key} ${HASH_MARKER_PREFIX}${hash} -->`;
+  const newDescription = userDescription ? `${userDescription}\n\n${marker}` : marker;
+  await updateMessageTemplate(config, server.id, { description: newDescription }, options);
+}

--- a/src/resources/messaging-template/index.ts
+++ b/src/resources/messaging-template/index.ts
@@ -1,0 +1,57 @@
+import type { ApplyContext, CollectionResourceModule } from "../types.js";
+import type { MessageTemplate } from "./sdk.js";
+import {
+  displayMessageTemplate,
+  displayMessageTemplateFromServer,
+  MESSAGING_TEMPLATE_IDENTITY_PREFIX,
+  messageTemplateHash,
+  messageTemplateHashFromServer,
+  messageTemplateKeyFromServer,
+  looksLikeMessageTemplate,
+  pruneMessageTemplate,
+  runMessageTemplateOp,
+  validateMessageTemplates,
+} from "./pipeline.js";
+import {
+  getMessageTemplate,
+  listManagedMessageTemplates,
+  listMessageTemplates,
+  type ServerMessageTemplate,
+} from "./client.js";
+import { pullFilter, pullLabel, renderToFile, serverIdOf, tagOnServer } from "./codegen.js";
+
+export { messageTemplate } from "./sdk.js";
+export type { MessageTemplate, MessageTemplateType, EmailContent } from "./sdk.js";
+
+export const messagingTemplateResource: CollectionResourceModule<
+  MessageTemplate,
+  ServerMessageTemplate
+> = {
+  kind: "collection",
+  name: "messaging-templates",
+  displayName: "messaging template",
+  identityPrefix: MESSAGING_TEMPLATE_IDENTITY_PREFIX,
+
+  isSpec: looksLikeMessageTemplate,
+  specKey: (spec) => spec.key,
+
+  list: listManagedMessageTemplates,
+  keyFromServer: (server) => messageTemplateKeyFromServer(server),
+  hashFromServer: (server) => messageTemplateHashFromServer(server),
+
+  hash: messageTemplateHash,
+  validate: (specs) => validateMessageTemplates(specs),
+  executeOp: runMessageTemplateOp,
+  prune: pruneMessageTemplate,
+
+  displaySpec: (spec, _ctx: ApplyContext) => displayMessageTemplate(spec),
+  displayServer: (server, _ctx: ApplyContext) => displayMessageTemplateFromServer(server),
+
+  listAll: listMessageTemplates,
+  getById: (config, id, options) => getMessageTemplate(config, String(id), options),
+  pullFilter,
+  pullLabel,
+  serverIdOf,
+  renderToFile,
+  tagOnServer,
+};

--- a/src/resources/messaging-template/pipeline.test.ts
+++ b/src/resources/messaging-template/pipeline.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { diff } from "../../apply/diff.js";
+import type { DesiredState } from "../types.js";
+import type { MessageTemplate } from "./sdk.js";
+import type { ServerMessageTemplate } from "./client.js";
+import { messageTemplateHash, validateMessageTemplates } from "./pipeline.js";
+
+function spec(key: string, overrides: Partial<MessageTemplate> = {}): MessageTemplate {
+  return {
+    key,
+    name: `Template ${key}`,
+    email: { subject: "Hi {{ person.name }}", html: "<p>Hi</p>" },
+    ...overrides,
+  };
+}
+
+function serverRow(
+  id: string,
+  key: string,
+  hash: string,
+  extraDescription = "",
+): ServerMessageTemplate {
+  const marker = `<!-- iac:messaging-templates:${key} iac:hash:${hash} -->`;
+  return {
+    id,
+    name: `Template ${key}`,
+    description: extraDescription ? `${extraDescription}\n\n${marker}` : marker,
+    type: "email",
+    content: { templating: "liquid", email: { subject: "Hi", html: "<p>Hi</p>" } },
+  };
+}
+
+function desiredFor(specs: MessageTemplate[]): DesiredState {
+  const state: DesiredState = new Map();
+  state.set(
+    "messaging-templates",
+    specs.map((spec) => ({ path: "<test>", spec })),
+  );
+  return state;
+}
+
+function currentFor(rows: ServerMessageTemplate[]): Map<string, unknown[]> {
+  return new Map<string, unknown[]>([["messaging-templates", rows]]);
+}
+
+describe("messaging-template pipeline", () => {
+  it("emits create when desired has no matching server row", () => {
+    const slice = diff(desiredFor([spec("welcome")]), currentFor([])).get("messaging-templates")!;
+    expect(slice.ops[0]!.kind).toBe("create");
+  });
+
+  it("emits unchanged when server hash matches", () => {
+    const desired = spec("welcome");
+    const op = diff(
+      desiredFor([desired]),
+      currentFor([serverRow("m1", "welcome", messageTemplateHash(desired))]),
+    ).get("messaging-templates")!.ops[0]!;
+    expect(op.kind).toBe("unchanged");
+  });
+
+  it("emits update when server hash differs", () => {
+    const op = diff(
+      desiredFor([spec("welcome")]),
+      currentFor([serverRow("m1", "welcome", "stale00000000")]),
+    ).get("messaging-templates")!.ops[0]!;
+    expect(op.kind).toBe("update");
+  });
+
+  it("hash changes when the email content changes", () => {
+    expect(messageTemplateHash(spec("welcome"))).not.toBe(
+      messageTemplateHash(spec("welcome", { email: { subject: "Different" } })),
+    );
+  });
+
+  it("classifies a server-only managed template as an orphan", () => {
+    const slice = diff(desiredFor([]), currentFor([serverRow("gh", "ghost", "any")])).get(
+      "messaging-templates",
+    )!;
+    expect(slice.orphans.length).toBe(1);
+  });
+
+  it("safety invariant: ignores server rows without the identity marker", () => {
+    const handBuilt: ServerMessageTemplate = {
+      id: "hb",
+      name: "Hand-built",
+      description: "a template someone built in the UI",
+      type: "email",
+      content: { templating: "liquid", email: {} },
+    };
+    const slice = diff(desiredFor([]), currentFor([handBuilt])).get("messaging-templates")!;
+    expect(slice.ops.length).toBe(0);
+    expect(slice.orphans.length).toBe(0);
+  });
+});
+
+describe("messaging-template validation", () => {
+  it("rejects a non-email type", () => {
+    const issues = validateMessageTemplates([
+      spec("sms", { type: "sms" as MessageTemplate["type"] }),
+    ]);
+    expect(issues.some((m) => m.includes('type must be "email"'))).toBeTruthy();
+  });
+
+  it("requires an email content object", () => {
+    const issues = validateMessageTemplates([
+      spec("noemail", { email: undefined as unknown as MessageTemplate["email"] }),
+    ]);
+    expect(issues.some((m) => m.includes("requires an `email`"))).toBeTruthy();
+  });
+
+  it("rejects duplicate keys", () => {
+    const issues = validateMessageTemplates([spec("dup"), spec("dup")]);
+    expect(issues.some((m) => m.includes("Duplicate"))).toBeTruthy();
+  });
+
+  it("accepts a minimal valid spec", () => {
+    expect(validateMessageTemplates([spec("ok")])).toEqual([]);
+  });
+});

--- a/src/resources/messaging-template/pipeline.ts
+++ b/src/resources/messaging-template/pipeline.ts
@@ -1,0 +1,197 @@
+import type { ClientConfig } from "../../client/config.js";
+import { ApiError } from "../../client/typed.js";
+import { specHash } from "../../apply/hash.js";
+import { displayJson, obj, scalar, type DisplayValue } from "../../apply/display.js";
+import { SafetyViolationError } from "../../apply/errors.js";
+import { getResourceKind, type ApplyContext, type ResourceOp } from "../types.js";
+import type { MessageTemplate } from "./sdk.js";
+import {
+  createMessageTemplate,
+  deleteMessageTemplate,
+  getMessageTemplate,
+  type MessageTemplateCreate,
+  type ServerMessageTemplate,
+  updateMessageTemplate,
+} from "./client.js";
+
+/**
+ * Messaging templates have no `tags` field. Identity sits in a trailing
+ * HTML-comment marker on `description` (surveys / endpoints pattern).
+ */
+export const MESSAGING_TEMPLATE_IDENTITY_PREFIX = "iac:messaging-templates:";
+
+const MARKER_REGEX = /\n*<!--\s*iac:messaging-templates:(\S+)\s+iac:hash:(\S+)\s*-->\s*$/;
+const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+type ParsedMarker = { userDescription: string; key: string; hash: string };
+
+function parseMarker(description: string | null | undefined): ParsedMarker | undefined {
+  if (!description) return undefined;
+  const match = description.match(MARKER_REGEX);
+  if (!match || match.index === undefined) return undefined;
+  return {
+    userDescription: description.slice(0, match.index).replace(/\s+$/, ""),
+    key: match[1]!,
+    hash: match[2]!,
+  };
+}
+
+function withMarker(userDescription: string | undefined, key: string, hash: string): string {
+  const trailer = `<!-- iac:messaging-templates:${key} iac:hash:${hash} -->`;
+  const trimmed = (userDescription ?? "").replace(/\s+$/, "");
+  return trimmed ? `${trimmed}\n\n${trailer}` : trailer;
+}
+
+export function stripMarker(description: string | null | undefined): string | null {
+  if (!description) return null;
+  const parsed = parseMarker(description);
+  return parsed ? parsed.userDescription || null : description;
+}
+
+export function messageTemplateKeyFromServer(server: ServerMessageTemplate): string | undefined {
+  return parseMarker(server.description)?.key;
+}
+
+export function messageTemplateHashFromServer(server: ServerMessageTemplate): string | undefined {
+  return parseMarker(server.description)?.hash;
+}
+
+function specForHash(spec: MessageTemplate): unknown {
+  return {
+    key: spec.key,
+    name: spec.name,
+    description: spec.description ?? "",
+    type: spec.type ?? "email",
+    templating: spec.templating ?? "liquid",
+    email: spec.email ?? {},
+    message_category: spec.messageCategory ?? null,
+  };
+}
+
+export function messageTemplateHash(spec: MessageTemplate): string {
+  return specHash(specForHash(spec));
+}
+
+function buildPayload(spec: MessageTemplate, hash: string): MessageTemplateCreate {
+  const payload: MessageTemplateCreate = {
+    name: spec.name,
+    description: withMarker(spec.description, spec.key, hash),
+    type: spec.type ?? "email",
+    content: {
+      templating: spec.templating ?? "liquid",
+      email: (spec.email ?? {}) as Record<string, unknown>,
+    },
+  };
+  if (spec.messageCategory !== undefined) payload.message_category = spec.messageCategory;
+  return payload;
+}
+
+export function looksLikeMessageTemplate(value: unknown): value is MessageTemplate {
+  return getResourceKind(value) === "messaging-template";
+}
+
+export function validateMessageTemplates(specs: MessageTemplate[]): string[] {
+  const issues: string[] = [];
+  const seenKeys = new Set<string>();
+  const seenNames = new Set<string>();
+
+  for (const spec of specs) {
+    if (!spec.key) {
+      issues.push("messaging-template.key is required");
+      continue;
+    }
+    if (!KEY_PATTERN.test(spec.key)) {
+      issues.push(`messaging template "${spec.key}" key must match ${KEY_PATTERN.source}`);
+    }
+    if (seenKeys.has(spec.key)) issues.push(`Duplicate messaging template key "${spec.key}"`);
+    seenKeys.add(spec.key);
+
+    if (!spec.name || spec.name.trim() === "") {
+      issues.push(`messaging template "${spec.key}" name is required`);
+    } else if (seenNames.has(spec.name)) {
+      issues.push(`Duplicate messaging template name "${spec.name}"`);
+    } else {
+      seenNames.add(spec.name);
+    }
+
+    if (spec.type !== undefined && spec.type !== "email") {
+      issues.push(`messaging template "${spec.key}" type must be "email" (got "${spec.type}")`);
+    }
+
+    if (!spec.email || typeof spec.email !== "object") {
+      issues.push(`messaging template "${spec.key}" requires an \`email\` content object`);
+    }
+  }
+  return issues;
+}
+
+async function assertManaged(
+  config: ClientConfig,
+  id: string,
+  key: string,
+  options: { verbose?: boolean },
+): Promise<void> {
+  const current = await getMessageTemplate(config, id, options);
+  if (messageTemplateKeyFromServer(current) !== key) {
+    throw new SafetyViolationError("messaging-template", id, key);
+  }
+}
+
+export async function runMessageTemplateOp(
+  config: ClientConfig,
+  op: ResourceOp<MessageTemplate, ServerMessageTemplate>,
+  _ctx: ApplyContext,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+
+  const hash = messageTemplateHash(op.spec);
+
+  if (op.kind === "create") {
+    await createMessageTemplate(config, buildPayload(op.spec, hash), options);
+    return;
+  }
+
+  await assertManaged(config, op.server.id, op.spec.key, options);
+  await updateMessageTemplate(config, op.server.id, buildPayload(op.spec, hash), options);
+}
+
+export async function pruneMessageTemplate(
+  config: ClientConfig,
+  orphan: ServerMessageTemplate,
+  options: { verbose?: boolean } = {},
+): Promise<boolean> {
+  const key = messageTemplateKeyFromServer(orphan) ?? `id:${orphan.id}`;
+  try {
+    await assertManaged(config, orphan.id, key, options);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return false;
+    throw err;
+  }
+  await deleteMessageTemplate(config, orphan.id, options);
+  return true;
+}
+
+export function displayMessageTemplate(spec: MessageTemplate): DisplayValue {
+  return obj([
+    ["key", scalar(spec.key)],
+    ["name", scalar(spec.name)],
+    ["description", scalar(spec.description ?? null)],
+    ["type", scalar(spec.type ?? "email")],
+    ["templating", scalar(spec.templating ?? "liquid")],
+    ["email", displayJson(spec.email ?? {})],
+    ["message_category", scalar(spec.messageCategory ?? null)],
+  ]);
+}
+
+export function displayMessageTemplateFromServer(server: ServerMessageTemplate): DisplayValue {
+  return obj([
+    ["key", scalar(messageTemplateKeyFromServer(server) ?? null)],
+    ["name", scalar(server.name)],
+    ["description", scalar(stripMarker(server.description))],
+    ["type", scalar(server.type ?? "email")],
+    ["templating", scalar(server.content?.templating ?? "liquid")],
+    ["email", displayJson(server.content?.email ?? {})],
+    ["message_category", scalar(server.message_category ?? null)],
+  ]);
+}

--- a/src/resources/messaging-template/sdk.ts
+++ b/src/resources/messaging-template/sdk.ts
@@ -1,0 +1,40 @@
+import { markResourceKind } from "../types.js";
+
+/** Message channel. Currently only "email" exists. */
+export type MessageTemplateType = "email";
+
+/**
+ * Email content — a passthrough bag matching the API's EmailTemplate:
+ * `{ subject, text, html, design }`. `design` is the visual-editor JSON
+ * document; `subject`/`text`/`html` are Liquid-templated strings. Round-tripped
+ * verbatim and canonically hashed — posthog-definitions does not enumerate the
+ * design tree.
+ */
+export type EmailContent = {
+  subject?: string;
+  text?: string;
+  html?: string;
+  design?: Record<string, unknown>;
+};
+
+export type MessageTemplate = {
+  key: string;
+  name: string;
+  description?: string;
+  /** Defaults to "email" (the only channel today). */
+  type?: MessageTemplateType;
+  /** The email content. Replaced as a whole on update. */
+  email: EmailContent;
+  /** Templating language — always "liquid" (the default). */
+  templating?: "liquid";
+  /**
+   * Optional messaging category id (uuid) to file the template under. Must
+   * belong to the same project. Messaging categories are not managed by
+   * posthog-definitions, so this is a raw id passthrough.
+   */
+  messageCategory?: string;
+};
+
+export function messageTemplate(spec: MessageTemplate): MessageTemplate {
+  return markResourceKind(spec, "messaging-template");
+}

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -16,6 +16,7 @@ import { experimentSavedMetricResource } from "./experiment-saved-metric/index.j
 import { featureFlagResource } from "./feature-flag/index.js";
 import { insightResource } from "./insight/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
+import { messagingTemplateResource } from "./messaging-template/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
 
 describe("topoOrder", () => {
@@ -185,6 +186,7 @@ describe("RESOURCES (real registry)", () => {
         insightResource,
         projectSettingsResource,
         propertyGroupResource,
+        messagingTemplateResource,
       ].map((r) => r.name),
     );
     expect(new Set(RESOURCES.map((r) => r.name))).toEqual(expected);


### PR DESCRIPTION
Adds **messaging templates** (email) as a managed resource. First of the two resources that close Wave 1.

## Identity (investigated live — carrier was TBD in the plan)
`description` round-trips cleanly, so the surveys/endpoints **description-marker** pattern applies — `iac:messaging-templates:<key>`. No stop-and-report needed (unlike data color themes).

## Content
The email content (`content.email`: `subject` / `text` / `html` / `design`) is a **passthrough bag**, replaced as a whole on update and canonically hashed. `templating` is always `"liquid"`. `message_category` is a raw uuid passthrough (messaging categories aren't managed by posthog-definitions).

## Serializer fidelity (checked field-by-field, per the standing caution)
The full GET mirrors the create/update payload exactly — **no silently-dropped fields**. Content including the nested `design` tree round-trips verbatim.

## Live verification (project 806)
create → no-op re-apply (hash projection correct) → edit the email content → single update (content replaced whole) → orphan left alone → hand-built template (no marker) untouched → kind-scoped prune deletes managed only.

## Surprises
- **DELETE → 405** despite the schema advertising a `messaging_templates_destroy` op; templates soft-delete via PATCH `{deleted:true}`.
- No dedicated `message_template` API scope — the create op's security block requires **`hog_flow:write`**, so messaging templates ride the hog_flow scope.

## Follow-up
Hog flows / broadcasts reference message templates operationally, but there's no first-class `message_template_id` field in the flow/broadcast schemas, so there's no cross-resource key-resolution to wire here.

Gates green (`typecheck`, `typecheck:examples`, `test` — 304 pass, `lint`). Smoke wiring verified in isolation; full `smoke.sh` stays red on the pre-existing `actions` pull gap (lands on `pl/pull-actions`).

---

Stacks on #81 (base `pl/spec-migration`) — codegen only compiles there. Retarget to `main` when #81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)