### PR TITLE
feat(product-tour): SDK factory + pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Alpha — do not use in production.**
 > This is pre-MVP software (`0.1.0-alpha.0`). The CLI, the on-disk file format, the SDK surface, and the tag-based identity model are all subject to breaking changes without notice. Use it on throwaway projects or in a sandbox while we stabilize.
 
-Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
+Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, experiment saved metrics, and product tours in TypeScript, then sync them to a PostHog project with one command.
 
 ## Why
 
@@ -51,6 +51,7 @@ export default dashboard({
    - `event_definition:read`, `event_definition:write` (also covers property groups)
    - `experiment:read`, `experiment:write` (also covers experiment holdouts)
    - `experiment_saved_metric:read`, `experiment_saved_metric:write`
+   - `product_tour:read`, `product_tour:write`
 
    Then add it (and your numeric project ID) to a `.env` (or `.envrc`) file:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -32,7 +32,7 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 | Surveys                  | ✅ `projects/{id}/surveys`                  | ❌                  |                                                                                                        |
 | Early access features    | ✅ `projects/{id}/early_access_feature`     | ❌                  |                                                                                                        |
 | Web experiments          | ✅ `projects/{id}/web_experiments`          | ❌                  |                                                                                                        |
-| Product tours            | ✅ `projects/{id}/product_tours`            | ❌                  |                                                                                                        |
+| Product tours            | ✅ `projects/{id}/product_tours`            | ✅                  | Identity via `iac:product-tours:<key>` marker in `description`. Tour `content` round-tripped as a passthrough bag; scheduling (`autoLaunch` / `startDate` / `endDate` / `archived`) declared directly. Targeting flags are server-managed (read-only). Full matrix refresh tracked in #78. |
 | Scheduled changes        | ✅ `projects/{id}/scheduled_changes`        | ❌                  | Time-bound flag/cohort rollout changes                                                                 |
 
 ## Data & taxonomy

--- a/examples/posthog/product-tours/feature-launch-tour.ts
+++ b/examples/posthog/product-tours/feature-launch-tour.ts
@@ -1,0 +1,20 @@
+// A time-boxed tour announcing a new feature — scheduled with an explicit
+// window and NOT auto-launched (users open it from a "What's new" prompt). The
+// dates are literal ISO strings, so re-applying is a clean no-op (no drift from
+// an injected "now").
+import { productTour } from "@posthog/definitions";
+
+export default productTour({
+  key: "feature-launch-tour",
+  name: "Reports 2.0 announcement",
+  description: "Walk existing users through the reporting revamp during launch week.",
+  autoLaunch: false,
+  startDate: "2026-09-01T00:00:00Z",
+  endDate: "2026-09-14T00:00:00Z",
+  content: {
+    steps: [
+      { title: "Reports got an upgrade", body: "Faster, filterable, shareable." },
+      { title: "Try a saved view", body: "Pin the reports your team checks daily." },
+    ],
+  },
+});

--- a/examples/posthog/product-tours/onboarding-tour.ts
+++ b/examples/posthog/product-tours/onboarding-tour.ts
@@ -1,0 +1,19 @@
+// A first-run product tour: a few steps the app shows new users, auto-launched
+// the moment they land. `content` is the step tree from the tour builder,
+// round-tripped as an opaque bag. Scheduling is declarative — `autoLaunch`
+// turns it on; `startDate` / `endDate` bound the window if you want one.
+import { productTour } from "@posthog/definitions";
+
+export default productTour({
+  key: "onboarding-tour",
+  name: "First-run onboarding",
+  description: "Point new workspaces at the three things that matter on day one.",
+  autoLaunch: true,
+  content: {
+    steps: [
+      { title: "Welcome to Acme", body: "Let's get your workspace set up." },
+      { title: "Invite your team", body: "Acme is better with teammates." },
+      { title: "Connect your data", body: "Send us your first events." },
+    ],
+  },
+});

--- a/openapi-filter.yaml
+++ b/openapi-filter.yaml
@@ -86,6 +86,12 @@ inverseOperationIds:
   - actions_partial_update
   - actions_destroy
 
+  - product_tours_list
+  - product_tours_create
+  - product_tours_retrieve
+  - product_tours_partial_update
+  - product_tours_destroy
+
 unusedComponents:
   - schemas
   - parameters

--- a/scripts/smoke-cleanup.ts
+++ b/scripts/smoke-cleanup.ts
@@ -82,6 +82,12 @@ import {
   pruneAction,
 } from "../src/resources/action/pipeline.js";
 
+import { listManagedProductTours } from "../src/resources/product-tour/client.js";
+import {
+  productTourKeyFromServer,
+  pruneProductTour,
+} from "../src/resources/product-tour/pipeline.js";
+
 import type { ClientConfig } from "../src/client/config.js";
 
 type Args = {
@@ -96,6 +102,7 @@ type Args = {
   "property-group"?: string;
   cohort?: string;
   endpoint?: string;
+  "product-tour"?: string;
 };
 
 const ARG_KEYS: Array<keyof Args> = [
@@ -110,6 +117,7 @@ const ARG_KEYS: Array<keyof Args> = [
   "property-group",
   "cohort",
   "endpoint",
+  "product-tour",
 ];
 
 function parseArgs(argv: string[]): Args {
@@ -268,6 +276,16 @@ async function main(): Promise<void> {
       listManagedEndpoints,
       (row) => endpointKeyFromServer(row),
       (c, row) => pruneEndpoint(c, row),
+    );
+  }
+  if (args["product-tour"]) {
+    await deleteByKey(
+      "product-tour",
+      args["product-tour"],
+      config,
+      listManagedProductTours,
+      (row) => productTourKeyFromServer(row),
+      (c, row) => pruneProductTour(c, row),
     );
   }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -63,6 +63,7 @@ SAVED_METRIC_KEY="smoke-metric-${STAMP}"
 EXPERIMENT_KEY="smoke-experiment-${STAMP}"
 COHORT_KEY="smoke-cohort-${STAMP}"
 ENDPOINT_KEY="smoke-endpoint-${STAMP}"
+PRODUCT_TOUR_KEY="smoke-tour-${STAMP}"
 
 # Names that round-trip cleanly through pull's slug-from-name. We use the
 # event-definition `name` as both the spec key AND the on-the-wire event
@@ -71,7 +72,7 @@ EVENT_NAME="${EVENT_DEFINITION_KEY}"
 
 # Resource kinds we'll seed and pull. Used both in --kind for pull and in
 # the no-op assertion's filter (we don't want unrelated kinds dirtying it).
-SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints"
+SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints,product-tours"
 
 cleanup() {
   echo
@@ -88,6 +89,7 @@ cleanup() {
     "--property-group=${PROPERTY_GROUP_KEY}" \
     "--cohort=${COHORT_KEY}" \
     "--endpoint=${ENDPOINT_KEY}" \
+    "--product-tour=${PRODUCT_TOUR_KEY}" \
     || echo "smoke: cleanup hit an error (continuing)"
   echo "smoke: removing workdir $WORK_DIR"
   rm -rf "$WORK_DIR"
@@ -153,7 +155,8 @@ mkdir -p \
   "$SEED_DIR/experiment-saved-metrics" \
   "$SEED_DIR/experiments" \
   "$SEED_DIR/cohorts" \
-  "$SEED_DIR/endpoints"
+  "$SEED_DIR/endpoints" \
+  "$SEED_DIR/product-tours"
 
 # Insight — referenced by the dashboard tile below.
 cat > "$SEED_DIR/insights/smoke-insight.ts" <<EOF
@@ -306,6 +309,18 @@ export default endpoint({
   key: "${ENDPOINT_KEY}",
   name: "${ENDPOINT_KEY}",
   query: { kind: "HogQLQuery", query: "select 1 as smoke" },
+});
+EOF
+
+# Product tour — independent. Minimal single-step tour, not auto-launched.
+cat > "$SEED_DIR/product-tours/smoke-tour.ts" <<EOF
+import { productTour } from "@posthog/definitions";
+export default productTour({
+  key: "${PRODUCT_TOUR_KEY}",
+  name: "${PRODUCT_TOUR_KEY}",
+  description: "Smoke fixture product tour",
+  autoLaunch: false,
+  content: { steps: [{ title: "Smoke" }] },
 });
 EOF
 

--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -616,6 +616,43 @@ export interface paths {
         patch: operations["insights_partial_update"];
         trace?: never;
     };
+    "/api/projects/{project_id}/product_tours/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Create, read, update, and manage product tours and their targeting. */
+        get: operations["product_tours_list"];
+        put?: never;
+        /** @description Create, read, update, and manage product tours and their targeting. */
+        post: operations["product_tours_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/product_tours/{id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Create, read, update, and manage product tours and their targeting. */
+        get: operations["product_tours_retrieve"];
+        put?: never;
+        post?: never;
+        /** @description Create, read, update, and manage product tours and their targeting. */
+        delete: operations["product_tours_destroy"];
+        options?: never;
+        head?: never;
+        /** @description Create, read, update, and manage product tours and their targeting. */
+        patch: operations["product_tours_partial_update"];
+        trace?: never;
+    };
     "/api/projects/{project_id}/schema_property_groups/": {
         parameters: {
             query?: never;
@@ -10287,6 +10324,21 @@ export interface components {
             previous?: string | null;
             results: components["schemas"]["Insight"][];
         };
+        PaginatedProductTourList: {
+            /** @example 123 */
+            count: number;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=400&limit=100
+             */
+            next?: string | null;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=200&limit=100
+             */
+            previous?: string | null;
+            results: components["schemas"]["ProductTour"][];
+        };
         PaginatedSchemaPropertyGroupList: {
             /** @example 123 */
             count: number;
@@ -10723,6 +10775,36 @@ export interface components {
              * @default false
              */
             delete_insights: boolean;
+        };
+        /** @description Serializer for creating and updating ProductTour. */
+        PatchedProductTourSerializerCreateUpdateOnly: {
+            /** Format: uuid */
+            readonly id?: string;
+            name?: string;
+            description?: string;
+            readonly internal_targeting_flag?: components["schemas"]["MinimalFeatureFlag"];
+            readonly linked_flag?: components["schemas"]["MinimalFeatureFlag"];
+            linked_flag_id?: number | null;
+            targeting_flag_filters?: unknown;
+            auto_launch?: boolean;
+            /** Format: date-time */
+            start_date?: string | null;
+            /** Format: date-time */
+            end_date?: string | null;
+            /** Format: date-time */
+            readonly created_at?: string;
+            readonly created_by?: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at?: string;
+            archived?: boolean;
+            /**
+             * @description Where the tour was created/updated from
+             *
+             *     * `app` - app
+             *     * `toolbar` - toolbar
+             * @default app
+             */
+            creation_context: components["schemas"]["ProductTourSerializerCreateUpdateOnlyCreationContextEnum"];
         };
         PatchedSchemaPropertyGroup: {
             /** Format: uuid */
@@ -11353,6 +11435,70 @@ export interface components {
          * @enum {string}
          */
         PrecomputationMode: "precomputed" | "direct";
+        /** @description Read-only serializer for ProductTour. */
+        ProductTour: {
+            /** Format: uuid */
+            readonly id: string;
+            name: string;
+            description?: string;
+            readonly internal_targeting_flag: components["schemas"]["MinimalFeatureFlag"];
+            readonly linked_flag: components["schemas"]["MinimalFeatureFlag"];
+            /** @description Return the targeting flag filters, excluding the base exclusion properties. */
+            readonly targeting_flag_filters: {
+                [key: string]: unknown;
+            } | null;
+            readonly draft_content: unknown;
+            readonly has_draft: boolean;
+            auto_launch?: boolean;
+            /** Format: date-time */
+            start_date?: string | null;
+            /** Format: date-time */
+            end_date?: string | null;
+            /** Format: date-time */
+            readonly created_at: string;
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at: string;
+            archived?: boolean;
+            /** @description How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match, returned only when no exact match exists). Null when the list is not filtered by `search`. */
+            readonly search_match_type: components["schemas"]["SearchMatchTypeEnum"] | components["schemas"]["NullEnum"];
+        };
+        /** @description Serializer for creating and updating ProductTour. */
+        ProductTourSerializerCreateUpdateOnly: {
+            /** Format: uuid */
+            readonly id: string;
+            name: string;
+            description?: string;
+            readonly internal_targeting_flag: components["schemas"]["MinimalFeatureFlag"];
+            readonly linked_flag: components["schemas"]["MinimalFeatureFlag"];
+            linked_flag_id?: number | null;
+            targeting_flag_filters?: unknown;
+            auto_launch?: boolean;
+            /** Format: date-time */
+            start_date?: string | null;
+            /** Format: date-time */
+            end_date?: string | null;
+            /** Format: date-time */
+            readonly created_at: string;
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at: string;
+            archived?: boolean;
+            /**
+             * @description Where the tour was created/updated from
+             *
+             *     * `app` - app
+             *     * `toolbar` - toolbar
+             * @default app
+             */
+            creation_context: components["schemas"]["ProductTourSerializerCreateUpdateOnlyCreationContextEnum"];
+        };
+        /**
+         * @description * `app` - app
+         *     * `toolbar` - toolbar
+         * @enum {string}
+         */
+        ProductTourSerializerCreateUpdateOnlyCreationContextEnum: "app" | "toolbar";
         /**
          * @description * `event` - event
          *     * `event_metadata` - event_metadata
@@ -20498,6 +20644,140 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["Insight"];
                     "text/csv": components["schemas"]["Insight"];
+                };
+            };
+        };
+    };
+    product_tours_list: {
+        parameters: {
+            query?: {
+                /** @description Number of results to return per page. */
+                limit?: number;
+                /** @description The initial index from which to return the results. */
+                offset?: number;
+                /** @description Match against product tour `name` and `description`. Returns exact (case-insensitive substring) matches only; if no exact match exists, returns similar (fuzzy trigram — typos, prefix-as-you-type) matches instead. Each result's `search_match_type` is `exact` or `similar`. */
+                search?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedProductTourList"];
+                };
+            };
+        };
+    };
+    product_tours_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProductTourSerializerCreateUpdateOnly"];
+                "application/x-www-form-urlencoded": components["schemas"]["ProductTourSerializerCreateUpdateOnly"];
+                "multipart/form-data": components["schemas"]["ProductTourSerializerCreateUpdateOnly"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProductTourSerializerCreateUpdateOnly"];
+                };
+            };
+        };
+    };
+    product_tours_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this product tour. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProductTour"];
+                };
+            };
+        };
+    };
+    product_tours_destroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this product tour. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    product_tours_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A UUID string identifying this product tour. */
+                id: string;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedProductTourSerializerCreateUpdateOnly"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedProductTourSerializerCreateUpdateOnly"];
+                "multipart/form-data": components["schemas"]["PatchedProductTourSerializerCreateUpdateOnly"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProductTourSerializerCreateUpdateOnly"];
                 };
             };
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,5 +75,8 @@ export type {
 export { projectSettings } from "./resources/project-settings/index.js";
 export type { ProjectSettings } from "./resources/project-settings/index.js";
 
+export { productTour } from "./resources/product-tour/index.js";
+export type { ProductTour, TourContent } from "./resources/product-tour/index.js";
+
 export { createTypedPostHog } from "./client/typed-posthog.js";
 export type { TypedPostHog, CaptureCapableClient } from "./client/typed-posthog.js";

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -12,6 +12,7 @@ import { experimentHoldoutResource } from "./experiment-holdout/index.js";
 import { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
+import { productTourResource } from "./product-tour/index.js";
 
 /**
  * Source-of-truth registry. Listed in stable, human-readable order — the
@@ -31,6 +32,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
   insightResource as ResourceModule<unknown, unknown>,
   projectSettingsResource as ResourceModule<unknown, unknown>,
   propertyGroupResource as ResourceModule<unknown, unknown>,
+  productTourResource as ResourceModule<unknown, unknown>,
 ];
 
 /**
@@ -53,6 +55,7 @@ export { experimentHoldoutResource } from "./experiment-holdout/index.js";
 export { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 export { experimentResource } from "./experiment/index.js";
 export { projectSettingsResource } from "./project-settings/index.js";
+export { productTourResource } from "./product-tour/index.js";
 export type {
   ResourceModule,
   CollectionResourceModule,

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -17,6 +17,7 @@ import { featureFlagResource } from "./feature-flag/index.js";
 import { insightResource } from "./insight/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
+import { productTourResource } from "./product-tour/index.js";
 
 describe("topoOrder", () => {
   it("returns an empty array for empty input", () => {
@@ -185,6 +186,7 @@ describe("RESOURCES (real registry)", () => {
         insightResource,
         projectSettingsResource,
         propertyGroupResource,
+        productTourResource,
       ].map((r) => r.name),
     );
     expect(new Set(RESOURCES.map((r) => r.name))).toEqual(expected);

--- a/src/resources/product-tour/client.test.ts
+++ b/src/resources/product-tour/client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { ServerProductTourSchema } from "./client.js";
+
+// Shape hand-derived from a real GET
+// /api/projects/{id}/product_tours/{id}/ response (project 806).
+const realTour = {
+  id: "18880131-ee7b-44eb-b2eb-293c6c0bad6b",
+  name: "Onboarding tour",
+  description: "First-run tour\n\n<!-- iac:product-tours:onboarding iac:hash:abcd1234 -->",
+  content: { steps: [{ title: "Welcome" }] },
+  auto_launch: true,
+  start_date: "2026-08-01T00:00:00Z",
+  end_date: null,
+  archived: false,
+  // Read-only fields the server always includes:
+  linked_flag: null,
+  internal_targeting_flag: null,
+  targeting_flag_filters: null,
+  draft_content: null,
+  has_draft: false,
+  created_at: "2026-07-23T00:00:00Z",
+  created_by: { id: 1, uuid: "u", distinct_id: "d" },
+};
+
+describe("ServerProductTourSchema", () => {
+  it("parses a real product tour payload", () => {
+    const parsed = ServerProductTourSchema.parse(realTour);
+    expect(parsed.id).toBe("18880131-ee7b-44eb-b2eb-293c6c0bad6b");
+    expect(parsed.auto_launch).toBe(true);
+    expect(parsed.start_date).toBe("2026-08-01T00:00:00Z");
+    expect(parsed.content).toMatchObject({ steps: [{ title: "Welcome" }] });
+  });
+
+  it("parses the minimal list shape (null dates)", () => {
+    const parsed = ServerProductTourSchema.parse({ ...realTour, start_date: null, auto_launch: false });
+    expect(parsed.start_date).toBeNull();
+  });
+
+  it("throws when name is missing", () => {
+    const { name: _omit, ...withoutName } = realTour;
+    void _omit;
+    expect(() => ServerProductTourSchema.parse(withoutName)).toThrow();
+  });
+});

--- a/src/resources/product-tour/client.ts
+++ b/src/resources/product-tour/client.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+import type { ClientConfig } from "../../client/config.js";
+import type { components } from "../../generated/api.js";
+import { createApiClient, followPagination, type Paginated } from "../../client/typed.js";
+
+const MANAGED_DESCRIPTION_PREFIX = "<!-- iac:product-tours:";
+
+export const ServerProductTourSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().nullable().default(""),
+    content: z.record(z.string(), z.unknown()).nullable().optional(),
+    auto_launch: z.boolean().nullable().optional(),
+    start_date: z.string().nullable().optional(),
+    end_date: z.string().nullable().optional(),
+    archived: z.boolean().nullable().optional(),
+  })
+  .loose();
+
+export type ServerProductTour = z.infer<typeof ServerProductTourSchema>;
+
+export type ProductTourCreate = {
+  name: string;
+  description: string;
+  content: Record<string, unknown>;
+  auto_launch?: boolean;
+  start_date?: string | null;
+  end_date?: string | null;
+  archived?: boolean;
+};
+
+export type ProductTourUpdate = Partial<ProductTourCreate>;
+
+type ProductTourBody = components["schemas"]["ProductTourSerializerCreateUpdateOnly"];
+type PatchedProductTourBody = components["schemas"]["PatchedProductTourSerializerCreateUpdateOnly"];
+type GeneratedPaginatedList = components["schemas"]["PaginatedProductTourList"];
+
+function paginatedFrom(raw: GeneratedPaginatedList): Paginated<unknown> {
+  return {
+    count: raw.count,
+    next: raw.next ?? null,
+    previous: raw.previous ?? null,
+    results: raw.results ?? [],
+  };
+}
+
+export async function listProductTours(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerProductTour[]> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/product_tours/", {
+    params: { path: { project_id: config.projectId }, query: { limit: 100 } },
+  });
+  const firstPage = paginatedFrom(data!);
+  const allRaw = await followPagination<unknown>(config, firstPage, { verbose: options.verbose });
+  return allRaw.map((row) => ServerProductTourSchema.parse(row));
+}
+
+export async function listManagedProductTours(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerProductTour[]> {
+  const all = await listProductTours(config, options);
+  return all.filter((row) => (row.description ?? "").includes(MANAGED_DESCRIPTION_PREFIX));
+}
+
+export async function getProductTour(
+  config: ClientConfig,
+  id: string,
+  options: { verbose?: boolean } = {},
+): Promise<ServerProductTour> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/product_tours/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+  });
+  return ServerProductTourSchema.parse(data);
+}
+
+export async function createProductTour(
+  config: ClientConfig,
+  payload: ProductTourCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerProductTour> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.POST("/api/projects/{project_id}/product_tours/", {
+    params: { path: { project_id: config.projectId } },
+    body: payload as unknown as ProductTourBody,
+  });
+  return ServerProductTourSchema.parse(data);
+}
+
+export async function updateProductTour(
+  config: ClientConfig,
+  id: string,
+  payload: ProductTourUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerProductTour> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.PATCH("/api/projects/{project_id}/product_tours/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+    body: payload as unknown as PatchedProductTourBody,
+  });
+  return ServerProductTourSchema.parse(data);
+}
+
+/** Product tours support a real DELETE (204). */
+export async function deleteProductTour(
+  config: ClientConfig,
+  id: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  await api.DELETE("/api/projects/{project_id}/product_tours/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+  });
+}

--- a/src/resources/product-tour/codegen.ts
+++ b/src/resources/product-tour/codegen.ts
@@ -1,0 +1,68 @@
+import type { ClientConfig } from "../../client/config.js";
+import { renderObject, renderRawLiteral, stringLiteral } from "../../pull/render.js";
+import { slugify } from "../../pull/slug.js";
+import type { PullRenderContext, RenderedFile } from "../../pull/types.js";
+import { type ServerProductTour, updateProductTour } from "./client.js";
+import { stripMarker } from "./pipeline.js";
+import type { ProductTour } from "./sdk.js";
+
+const MARKER_PREFIX = "iac:product-tours:";
+const HASH_MARKER_PREFIX = "iac:hash:";
+
+export function pullFilter(
+  server: ServerProductTour,
+): { kept: true } | { kept: false; reason: string } {
+  if ((server as { deleted?: boolean }).deleted) return { kept: false, reason: "deleted" };
+  return { kept: true };
+}
+
+export function pullLabel(server: ServerProductTour): { primary: string; secondary?: string } {
+  const status = server.end_date ? "stopped" : server.start_date ? "live" : "draft";
+  return { primary: server.name, secondary: `[${status}]` };
+}
+
+export function serverIdOf(server: ServerProductTour): string {
+  return server.id;
+}
+
+export function renderToFile(
+  server: ServerProductTour,
+  ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const baseSlug = slugify(server.name) || `product-tour-${server.id}`;
+  const slug = ctx.uniqueSlug(baseSlug);
+
+  const fields: Record<string, string> = {
+    key: stringLiteral(slug),
+    name: stringLiteral(server.name),
+  };
+  const userDescription = stripMarker(server.description);
+  if (userDescription) fields.description = stringLiteral(userDescription);
+  fields.content = renderRawLiteral(server.content ?? {}, 2);
+  if (server.auto_launch) fields.autoLaunch = "true";
+  if (server.start_date) fields.startDate = stringLiteral(server.start_date);
+  if (server.end_date) fields.endDate = stringLiteral(server.end_date);
+  if (server.archived) fields.archived = "true";
+
+  const contents = [
+    `import { productTour } from "@posthog/definitions";`,
+    "",
+    `export default productTour(${renderObject(fields, 2)});`,
+    "",
+  ].join("\n");
+
+  return { filename: `${slug}.ts`, contents, specKey: slug };
+}
+
+export async function tagOnServer(
+  config: ClientConfig,
+  server: ServerProductTour,
+  spec: ProductTour,
+  hash: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const userDescription = stripMarker(server.description);
+  const marker = `<!-- ${MARKER_PREFIX}${spec.key} ${HASH_MARKER_PREFIX}${hash} -->`;
+  const newDescription = userDescription ? `${userDescription}\n\n${marker}` : marker;
+  await updateProductTour(config, server.id, { description: newDescription }, options);
+}

--- a/src/resources/product-tour/index.ts
+++ b/src/resources/product-tour/index.ts
@@ -1,0 +1,54 @@
+import type { ApplyContext, CollectionResourceModule } from "../types.js";
+import type { ProductTour } from "./sdk.js";
+import {
+  displayProductTour,
+  displayProductTourFromServer,
+  PRODUCT_TOUR_IDENTITY_PREFIX,
+  productTourHash,
+  productTourHashFromServer,
+  productTourKeyFromServer,
+  looksLikeProductTour,
+  pruneProductTour,
+  runProductTourOp,
+  validateProductTours,
+} from "./pipeline.js";
+import {
+  getProductTour,
+  listManagedProductTours,
+  listProductTours,
+  type ServerProductTour,
+} from "./client.js";
+import { pullFilter, pullLabel, renderToFile, serverIdOf, tagOnServer } from "./codegen.js";
+
+export { productTour } from "./sdk.js";
+export type { ProductTour, TourContent } from "./sdk.js";
+
+export const productTourResource: CollectionResourceModule<ProductTour, ServerProductTour> = {
+  kind: "collection",
+  name: "product-tours",
+  displayName: "product tour",
+  identityPrefix: PRODUCT_TOUR_IDENTITY_PREFIX,
+
+  isSpec: looksLikeProductTour,
+  specKey: (spec) => spec.key,
+
+  list: listManagedProductTours,
+  keyFromServer: (server) => productTourKeyFromServer(server),
+  hashFromServer: (server) => productTourHashFromServer(server),
+
+  hash: productTourHash,
+  validate: (specs) => validateProductTours(specs),
+  executeOp: runProductTourOp,
+  prune: pruneProductTour,
+
+  displaySpec: (spec, _ctx: ApplyContext) => displayProductTour(spec),
+  displayServer: (server, _ctx: ApplyContext) => displayProductTourFromServer(server),
+
+  listAll: listProductTours,
+  getById: (config, id, options) => getProductTour(config, String(id), options),
+  pullFilter,
+  pullLabel,
+  serverIdOf,
+  renderToFile,
+  tagOnServer,
+};

--- a/src/resources/product-tour/pipeline.test.ts
+++ b/src/resources/product-tour/pipeline.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { diff } from "../../apply/diff.js";
+import type { DesiredState } from "../types.js";
+import type { ProductTour } from "./sdk.js";
+import type { ServerProductTour } from "./client.js";
+import { productTourHash, validateProductTours } from "./pipeline.js";
+
+function spec(key: string, overrides: Partial<ProductTour> = {}): ProductTour {
+  return {
+    key,
+    name: `Tour ${key}`,
+    content: { steps: [{ title: "Welcome" }] },
+    ...overrides,
+  };
+}
+
+function serverRow(
+  id: string,
+  key: string,
+  hash: string,
+  extraDescription = "",
+): ServerProductTour {
+  const marker = `<!-- iac:product-tours:${key} iac:hash:${hash} -->`;
+  return {
+    id,
+    name: `Tour ${key}`,
+    description: extraDescription ? `${extraDescription}\n\n${marker}` : marker,
+    content: { steps: [{ title: "Welcome" }] },
+    auto_launch: false,
+    archived: false,
+  };
+}
+
+function desiredFor(specs: ProductTour[]): DesiredState {
+  const state: DesiredState = new Map();
+  state.set(
+    "product-tours",
+    specs.map((spec) => ({ path: "<test>", spec })),
+  );
+  return state;
+}
+
+function currentFor(rows: ServerProductTour[]): Map<string, unknown[]> {
+  return new Map<string, unknown[]>([["product-tours", rows]]);
+}
+
+describe("product-tour pipeline", () => {
+  it("emits create when desired has no matching server row", () => {
+    const slice = diff(desiredFor([spec("welcome")]), currentFor([])).get("product-tours")!;
+    expect(slice.ops[0]!.kind).toBe("create");
+  });
+
+  it("emits unchanged when server hash matches", () => {
+    const desired = spec("welcome");
+    const op = diff(
+      desiredFor([desired]),
+      currentFor([serverRow("p1", "welcome", productTourHash(desired))]),
+    ).get("product-tours")!.ops[0]!;
+    expect(op.kind).toBe("unchanged");
+  });
+
+  it("emits update when server hash differs", () => {
+    const op = diff(
+      desiredFor([spec("welcome")]),
+      currentFor([serverRow("p1", "welcome", "stale00000000")]),
+    ).get("product-tours")!.ops[0]!;
+    expect(op.kind).toBe("update");
+  });
+
+  it("hash changes when a schedule field changes (no injected now)", () => {
+    expect(productTourHash(spec("welcome"))).not.toBe(
+      productTourHash(spec("welcome", { startDate: "2026-08-01T00:00:00Z" })),
+    );
+    expect(productTourHash(spec("welcome"))).not.toBe(
+      productTourHash(spec("welcome", { autoLaunch: true })),
+    );
+  });
+
+  it("classifies a server-only managed tour as an orphan", () => {
+    const slice = diff(desiredFor([]), currentFor([serverRow("gh", "ghost", "any")])).get(
+      "product-tours",
+    )!;
+    expect(slice.orphans.length).toBe(1);
+  });
+
+  it("safety invariant: ignores server rows without the identity marker", () => {
+    const handBuilt: ServerProductTour = {
+      id: "hb",
+      name: "Hand-built",
+      description: "a tour someone built in the UI",
+      content: { steps: [] },
+      auto_launch: true,
+    };
+    const slice = diff(desiredFor([]), currentFor([handBuilt])).get("product-tours")!;
+    expect(slice.ops.length).toBe(0);
+    expect(slice.orphans.length).toBe(0);
+  });
+});
+
+describe("product-tour validation", () => {
+  it("requires a content object", () => {
+    const issues = validateProductTours([
+      spec("nocontent", { content: undefined as unknown as ProductTour["content"] }),
+    ]);
+    expect(issues.some((m) => m.includes("requires a `content`"))).toBeTruthy();
+  });
+
+  it("rejects duplicate keys", () => {
+    const issues = validateProductTours([spec("dup"), spec("dup")]);
+    expect(issues.some((m) => m.includes("Duplicate"))).toBeTruthy();
+  });
+
+  it("requires a non-empty name", () => {
+    const issues = validateProductTours([spec("ok", { name: "" })]);
+    expect(issues.some((m) => m.includes("name is required"))).toBeTruthy();
+  });
+
+  it("accepts a minimal valid spec", () => {
+    expect(validateProductTours([spec("ok")])).toEqual([]);
+  });
+});

--- a/src/resources/product-tour/pipeline.ts
+++ b/src/resources/product-tour/pipeline.ts
@@ -1,0 +1,195 @@
+import type { ClientConfig } from "../../client/config.js";
+import { ApiError } from "../../client/typed.js";
+import { specHash } from "../../apply/hash.js";
+import { displayJson, obj, scalar, type DisplayValue } from "../../apply/display.js";
+import { SafetyViolationError } from "../../apply/errors.js";
+import { getResourceKind, type ApplyContext, type ResourceOp } from "../types.js";
+import type { ProductTour } from "./sdk.js";
+import {
+  createProductTour,
+  deleteProductTour,
+  getProductTour,
+  type ProductTourCreate,
+  type ServerProductTour,
+  updateProductTour,
+} from "./client.js";
+
+/**
+ * Product tours have no `tags` field. Identity sits in a trailing HTML-comment
+ * marker on `description` (surveys / endpoints pattern).
+ */
+export const PRODUCT_TOUR_IDENTITY_PREFIX = "iac:product-tours:";
+
+const MARKER_REGEX = /\n*<!--\s*iac:product-tours:(\S+)\s+iac:hash:(\S+)\s*-->\s*$/;
+const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+type ParsedMarker = { userDescription: string; key: string; hash: string };
+
+function parseMarker(description: string | null | undefined): ParsedMarker | undefined {
+  if (!description) return undefined;
+  const match = description.match(MARKER_REGEX);
+  if (!match || match.index === undefined) return undefined;
+  return {
+    userDescription: description.slice(0, match.index).replace(/\s+$/, ""),
+    key: match[1]!,
+    hash: match[2]!,
+  };
+}
+
+function withMarker(userDescription: string | undefined, key: string, hash: string): string {
+  const trailer = `<!-- iac:product-tours:${key} iac:hash:${hash} -->`;
+  const trimmed = (userDescription ?? "").replace(/\s+$/, "");
+  return trimmed ? `${trimmed}\n\n${trailer}` : trailer;
+}
+
+export function stripMarker(description: string | null | undefined): string | null {
+  if (!description) return null;
+  const parsed = parseMarker(description);
+  return parsed ? parsed.userDescription || null : description;
+}
+
+export function productTourKeyFromServer(server: ServerProductTour): string | undefined {
+  return parseMarker(server.description)?.key;
+}
+
+export function productTourHashFromServer(server: ServerProductTour): string | undefined {
+  return parseMarker(server.description)?.hash;
+}
+
+function specForHash(spec: ProductTour): unknown {
+  return {
+    key: spec.key,
+    name: spec.name,
+    description: spec.description ?? "",
+    content: spec.content ?? {},
+    auto_launch: spec.autoLaunch ?? false,
+    start_date: spec.startDate ?? null,
+    end_date: spec.endDate ?? null,
+    archived: spec.archived ?? false,
+  };
+}
+
+export function productTourHash(spec: ProductTour): string {
+  return specHash(specForHash(spec));
+}
+
+function buildPayload(spec: ProductTour, hash: string): ProductTourCreate {
+  const payload: ProductTourCreate = {
+    name: spec.name,
+    description: withMarker(spec.description, spec.key, hash),
+    content: (spec.content ?? {}) as Record<string, unknown>,
+    auto_launch: spec.autoLaunch ?? false,
+    archived: spec.archived ?? false,
+  };
+  if (spec.startDate !== undefined) payload.start_date = spec.startDate;
+  if (spec.endDate !== undefined) payload.end_date = spec.endDate;
+  return payload;
+}
+
+export function looksLikeProductTour(value: unknown): value is ProductTour {
+  return getResourceKind(value) === "product-tour";
+}
+
+export function validateProductTours(specs: ProductTour[]): string[] {
+  const issues: string[] = [];
+  const seenKeys = new Set<string>();
+  const seenNames = new Set<string>();
+
+  for (const spec of specs) {
+    if (!spec.key) {
+      issues.push("product-tour.key is required");
+      continue;
+    }
+    if (!KEY_PATTERN.test(spec.key)) {
+      issues.push(`product tour "${spec.key}" key must match ${KEY_PATTERN.source}`);
+    }
+    if (seenKeys.has(spec.key)) issues.push(`Duplicate product tour key "${spec.key}"`);
+    seenKeys.add(spec.key);
+
+    if (!spec.name || spec.name.trim() === "") {
+      issues.push(`product tour "${spec.key}" name is required`);
+    } else if (seenNames.has(spec.name)) {
+      issues.push(`Duplicate product tour name "${spec.name}"`);
+    } else {
+      seenNames.add(spec.name);
+    }
+
+    if (!spec.content || typeof spec.content !== "object") {
+      issues.push(`product tour "${spec.key}" requires a \`content\` object`);
+    }
+  }
+  return issues;
+}
+
+async function assertManaged(
+  config: ClientConfig,
+  id: string,
+  key: string,
+  options: { verbose?: boolean },
+): Promise<void> {
+  const current = await getProductTour(config, id, options);
+  if (productTourKeyFromServer(current) !== key) {
+    throw new SafetyViolationError("product-tour", id, key);
+  }
+}
+
+export async function runProductTourOp(
+  config: ClientConfig,
+  op: ResourceOp<ProductTour, ServerProductTour>,
+  _ctx: ApplyContext,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+
+  const hash = productTourHash(op.spec);
+
+  if (op.kind === "create") {
+    await createProductTour(config, buildPayload(op.spec, hash), options);
+    return;
+  }
+
+  await assertManaged(config, op.server.id, op.spec.key, options);
+  await updateProductTour(config, op.server.id, buildPayload(op.spec, hash), options);
+}
+
+export async function pruneProductTour(
+  config: ClientConfig,
+  orphan: ServerProductTour,
+  options: { verbose?: boolean } = {},
+): Promise<boolean> {
+  const key = productTourKeyFromServer(orphan) ?? `id:${orphan.id}`;
+  try {
+    await assertManaged(config, orphan.id, key, options);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return false;
+    throw err;
+  }
+  await deleteProductTour(config, orphan.id, options);
+  return true;
+}
+
+export function displayProductTour(spec: ProductTour): DisplayValue {
+  return obj([
+    ["key", scalar(spec.key)],
+    ["name", scalar(spec.name)],
+    ["description", scalar(spec.description ?? null)],
+    ["content", displayJson(spec.content ?? {})],
+    ["auto_launch", scalar(spec.autoLaunch ?? false)],
+    ["start_date", scalar(spec.startDate ?? null)],
+    ["end_date", scalar(spec.endDate ?? null)],
+    ["archived", scalar(spec.archived ?? false)],
+  ]);
+}
+
+export function displayProductTourFromServer(server: ServerProductTour): DisplayValue {
+  return obj([
+    ["key", scalar(productTourKeyFromServer(server) ?? null)],
+    ["name", scalar(server.name)],
+    ["description", scalar(stripMarker(server.description))],
+    ["content", displayJson(server.content ?? {})],
+    ["auto_launch", scalar(server.auto_launch ?? false)],
+    ["start_date", scalar(server.start_date ?? null)],
+    ["end_date", scalar(server.end_date ?? null)],
+    ["archived", scalar(server.archived ?? false)],
+  ]);
+}

--- a/src/resources/product-tour/sdk.ts
+++ b/src/resources/product-tour/sdk.ts
@@ -1,0 +1,35 @@
+import { markResourceKind } from "../types.js";
+
+/**
+ * Tour content — a passthrough bag. Shape: `{ steps: [...] }`, the step tree
+ * authored in the tour builder. Round-tripped verbatim and canonically hashed;
+ * posthog-definitions does not enumerate the step schema.
+ */
+export type TourContent = Record<string, unknown>;
+
+export type ProductTour = {
+  key: string;
+  name: string;
+  description?: string;
+  /** The tour step tree. Round-tripped verbatim. */
+  content: TourContent;
+  /**
+   * Whether the tour launches automatically for matching users.
+   *
+   * Scheduling / lifecycle is expressed directly through the writable
+   * `autoLaunch` / `startDate` / `endDate` / `archived` fields — unlike surveys
+   * (which need launch/stop endpoints because `start_date` is server-managed),
+   * a product tour's schedule dates are set on the row itself, so they are
+   * declared as plain fields with no injected "now" (which would drift).
+   */
+  autoLaunch?: boolean;
+  /** ISO datetime the tour becomes active, or null. */
+  startDate?: string | null;
+  /** ISO datetime the tour stops, or null. */
+  endDate?: string | null;
+  archived?: boolean;
+};
+
+export function productTour(spec: ProductTour): ProductTour {
+  return markResourceKind(spec, "product-tour");
+}


### PR DESCRIPTION
Adds **product tours** as a managed resource. Closes Wave 1 (8 shipped / 2 deferred).

## Identity
Description marker (no `tags`) — `iac:product-tours:<key>`.

## Content + lifecycle
- `content` (the step tree) is a **passthrough bag**, canonically hashed.
- Scheduling/lifecycle is declared through **directly-writable fields**: `autoLaunch` / `startDate` / `endDate` / `archived`. Unlike surveys (whose `start_date` is server-managed, forcing launch/stop endpoints + a status abstraction), a product tour's schedule dates are set on the row itself — so they're plain declarative fields with **no injected `now()`**. Re-applying a scheduled tour is a clean no-op instead of drifting each run.
- Targeting flags (`linked_flag` / `internal_targeting_flag` / `targeting_flag_filters`) are **server-managed and read-only** — no flag references exposed.

## Serializer fidelity (checked carefully — younger API)
Full GET mirrors the create/update payload exactly — **no silently-dropped fields**. The `draft_content` / `has_draft` draft workflow is read-only and left alone (we manage the published `content` directly).

## Live verification (project 806)
create → no-op re-apply (hash projection correct; explicit dates don't drift) → edit the content → single update → orphan left alone → hand-built tour (no marker) untouched → kind-scoped prune deletes managed only. Delete is a real DELETE (204).

## Notes
Scope: `product_tour:read` / `product_tour:write`. Gates green (`typecheck`, `typecheck:examples`, `test` — 304 pass, `lint`). Smoke wiring verified in isolation; full `smoke.sh` stays red on the pre-existing `actions` pull gap (lands on `pl/pull-actions`).

---

Stacks on #81 (base `pl/spec-migration`) — codegen only compiles there. Retarget to `main` when #81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)