### PR TITLE
feat(error-tracking-settings): singleton SDK factory + pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Alpha — do not use in production.**
 > This is pre-MVP software (`0.1.0-alpha.0`). The CLI, the on-disk file format, the SDK surface, and the tag-based identity model are all subject to breaking changes without notice. Use it on throwaway projects or in a sandbox while we stabilize.
 
-Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
+Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, experiment saved metrics, and error-tracking settings in TypeScript, then sync them to a PostHog project with one command.
 
 ## Why
 
@@ -51,6 +51,7 @@ export default dashboard({
    - `event_definition:read`, `event_definition:write` (also covers property groups)
    - `experiment:read`, `experiment:write` (also covers experiment holdouts)
    - `experiment_saved_metric:read`, `experiment_saved_metric:write`
+   - `error_tracking:read`, `error_tracking:write` (error-tracking settings)
 
    Then add it (and your numeric project ID) to a `.env` (or `.envrc`) file:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -2,7 +2,7 @@
 
 What PostHog exposes via API vs. what `posthog-definitions` can manage as code.
 
-Legend: ✅ supported · 🟡 partial / read-only / inline-only · ❌ not supported (yet) · — not applicable for IaC
+Legend: ✅ supported · 🟡 partial / read-only / inline-only · ❌ not supported (yet) · 🚫 excluded (API or charter blocks it) · — not applicable for IaC
 
 Source of truth for the API column: registered viewsets in [`posthog/posthog/api/__init__.py`](https://github.com/PostHog/posthog/blob/master/posthog/api/__init__.py). Last refreshed against `master` on 2026-05-13.
 
@@ -77,8 +77,8 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 | Assignment rules       | ✅ `environments/{id}/error_tracking/assignment_rules`       | ❌                  |       |
 | Grouping rules         | ✅ `environments/{id}/error_tracking/grouping_rules`         | ❌                  |       |
 | Suppression rules      | ✅ `environments/{id}/error_tracking/suppression_rules`      | ❌                  |       |
-| Spike detection config | ✅ `environments/{id}/error_tracking/spike_detection_config` | ❌                  |       |
-| Settings               | ✅ `environments/{id}/error_tracking/settings`               | ❌                  |       |
+| Spike detection config | ✅ `environments/{id}/error_tracking/spike_detection_config` | 🚫                  | Excluded — the `update_config` write endpoint rejects personal API key access ("does not support personal API key access"), so the CLI can't manage it. |
+| Settings               | ✅ `environments/{id}/error_tracking/settings`               | ✅                  | Singleton (no key). Field-scoped PATCH of the exception-ingestion rate limits; only declared fields are written. Full matrix refresh tracked in #78. |
 
 ## Project & org configuration
 

--- a/examples/posthog/error-tracking-settings/settings.ts
+++ b/examples/posthog/error-tracking-settings/settings.ts
@@ -1,0 +1,17 @@
+// A singleton: one error-tracking settings block per project (no key). These
+// are the ingestion rate limits for exception events — cap how many are
+// accepted per bucket, project-wide and per individual issue, so one noisy
+// deploy can't drown out everything else. Apply only ever PATCHes the fields
+// declared here; anything you omit is left exactly as it is on the server.
+// Set a field to `null` to remove that limit.
+import { errorTrackingSettings } from "@posthog/definitions";
+
+export default errorTrackingSettings({
+  // Project-wide: at most 50k exception events per 60-minute bucket.
+  project_rate_limit_value: 50000,
+  project_rate_limit_bucket_size_minutes: 60,
+  // Per issue: at most 1k events per 60-minute bucket, so a single runaway
+  // error can't consume the whole project budget.
+  per_issue_rate_limit_value: 1000,
+  per_issue_rate_limit_bucket_size_minutes: 60,
+});

--- a/openapi-filter.yaml
+++ b/openapi-filter.yaml
@@ -86,6 +86,9 @@ inverseOperationIds:
   - actions_partial_update
   - actions_destroy
 
+  - error_tracking_settings_retrieve_settings_retrieve
+  - error_tracking_settings_update_settings_partial_update
+
 unusedComponents:
   - schemas
   - parameters

--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -160,6 +160,38 @@ export interface paths {
         patch: operations["environments_partial_update"];
         trace?: never;
     };
+    "/api/projects/{project_id}/error_tracking/settings/retrieve_settings/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["error_tracking_settings_retrieve_settings_retrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/error_tracking/settings/update_settings/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["error_tracking_settings_update_settings_partial_update"];
+        trace?: never;
+    };
     "/api/projects/{project_id}/event_definitions/": {
         parameters: {
             query?: never;
@@ -4244,6 +4276,16 @@ export interface components {
              * @default null
              */
             warnings: (components["schemas"]["DataWarehouseSyncWarning"] | components["schemas"]["AccessControlFilterWarning"])[] | null;
+        };
+        ErrorTrackingSettings: {
+            /** @description Maximum number of exception events ingested per bucket for the entire project. Null removes the limit. */
+            project_rate_limit_value?: number | null;
+            /** @description Bucket window over which the project-wide rate limit applies, in minutes. */
+            project_rate_limit_bucket_size_minutes?: number | null;
+            /** @description Maximum number of exception events ingested per bucket for each individual issue. Null removes the limit. */
+            per_issue_rate_limit_value?: number | null;
+            /** @description Bucket window over which the per-issue rate limit applies, in minutes. */
+            per_issue_rate_limit_bucket_size_minutes?: number | null;
         };
         /**
          * @description * `server` - Server
@@ -10450,6 +10492,16 @@ export interface components {
             post_to_slack: boolean;
             default_columns?: string[];
             readonly media_preview_urls?: string[];
+        };
+        PatchedErrorTrackingSettings: {
+            /** @description Maximum number of exception events ingested per bucket for the entire project. Null removes the limit. */
+            project_rate_limit_value?: number | null;
+            /** @description Bucket window over which the project-wide rate limit applies, in minutes. */
+            project_rate_limit_bucket_size_minutes?: number | null;
+            /** @description Maximum number of exception events ingested per bucket for each individual issue. Null removes the limit. */
+            per_issue_rate_limit_value?: number | null;
+            /** @description Bucket window over which the per-issue rate limit applies, in minutes. */
+            per_issue_rate_limit_bucket_size_minutes?: number | null;
         };
         /** @description A holdout group — a stable slice of users excluded from experiment exposure. */
         PatchedExperimentHoldout: {
@@ -19284,6 +19336,56 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Team"];
+                };
+            };
+        };
+    };
+    error_tracking_settings_retrieve_settings_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorTrackingSettings"];
+                };
+            };
+        };
+    };
+    error_tracking_settings_update_settings_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedErrorTrackingSettings"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedErrorTrackingSettings"];
+                "multipart/form-data": components["schemas"]["PatchedErrorTrackingSettings"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorTrackingSettings"];
                 };
             };
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,5 +75,8 @@ export type {
 export { projectSettings } from "./resources/project-settings/index.js";
 export type { ProjectSettings } from "./resources/project-settings/index.js";
 
+export { errorTrackingSettings } from "./resources/error-tracking-settings/index.js";
+export type { ErrorTrackingSettings } from "./resources/error-tracking-settings/index.js";
+
 export { createTypedPostHog } from "./client/typed-posthog.js";
 export type { TypedPostHog, CaptureCapableClient } from "./client/typed-posthog.js";

--- a/src/resources/error-tracking-settings/client.ts
+++ b/src/resources/error-tracking-settings/client.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import type { ClientConfig } from "../../client/config.js";
+import type { components } from "../../generated/api.js";
+import { createApiClient } from "../../client/typed.js";
+
+/**
+ * Server shape for the error-tracking settings singleton. All four fields are
+ * nullable integers (null = "no limit").
+ */
+export const ServerErrorTrackingSettingsSchema = z
+  .object({
+    project_rate_limit_value: z.number().nullable().optional(),
+    project_rate_limit_bucket_size_minutes: z.number().nullable().optional(),
+    per_issue_rate_limit_value: z.number().nullable().optional(),
+    per_issue_rate_limit_bucket_size_minutes: z.number().nullable().optional(),
+  })
+  .loose();
+
+export type ServerErrorTrackingSettings = z.infer<typeof ServerErrorTrackingSettingsSchema>;
+
+export type ErrorTrackingSettingsPayload = Partial<
+  components["schemas"]["PatchedErrorTrackingSettings"]
+>;
+
+/** GET the settings via the custom `retrieve_settings` action route. */
+export async function getErrorTrackingSettings(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerErrorTrackingSettings> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET(
+    "/api/projects/{project_id}/error_tracking/settings/retrieve_settings/",
+    { params: { path: { project_id: config.projectId } } },
+  );
+  return ServerErrorTrackingSettingsSchema.parse(data);
+}
+
+/** PATCH the declared fields via the custom `update_settings` action route. */
+export async function patchErrorTrackingSettings(
+  config: ClientConfig,
+  payload: ErrorTrackingSettingsPayload,
+  options: { verbose?: boolean } = {},
+): Promise<ServerErrorTrackingSettings> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.PATCH(
+    "/api/projects/{project_id}/error_tracking/settings/update_settings/",
+    {
+      params: { path: { project_id: config.projectId } },
+      body: payload as unknown as components["schemas"]["PatchedErrorTrackingSettings"],
+    },
+  );
+  return ServerErrorTrackingSettingsSchema.parse(data);
+}

--- a/src/resources/error-tracking-settings/codegen.ts
+++ b/src/resources/error-tracking-settings/codegen.ts
@@ -1,0 +1,33 @@
+import { renderObject } from "../../pull/render.js";
+import type { PullRenderContext, RenderedFile } from "../../pull/types.js";
+import type { ServerErrorTrackingSettings } from "./client.js";
+
+const PULLED_FIELDS: ReadonlyArray<string> = [
+  "project_rate_limit_value",
+  "project_rate_limit_bucket_size_minutes",
+  "per_issue_rate_limit_value",
+  "per_issue_rate_limit_bucket_size_minutes",
+];
+
+export function renderToFile(
+  server: ServerErrorTrackingSettings,
+  _ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const fields: Record<string, string> = {};
+  for (const key of PULLED_FIELDS) {
+    const value = (server as Record<string, unknown>)[key];
+    if (value === undefined || value === null) continue;
+    if (typeof value === "number" && Number.isFinite(value)) fields[key] = String(value);
+  }
+
+  if (Object.keys(fields).length === 0) {
+    return { skipped: true, reason: "error tracking settings: all rate limits are unset (null)" };
+  }
+
+  const contents =
+    `import { errorTrackingSettings } from "@posthog/definitions";\n\n` +
+    `export default errorTrackingSettings(${renderObject(fields, 2)});\n`;
+  // Singletons have no key; reuse the resource name so the tag-back step (which
+  // only runs for collections) is a natural no-op.
+  return { filename: "error-tracking-settings.ts", contents, specKey: "error-tracking-settings" };
+}

--- a/src/resources/error-tracking-settings/index.ts
+++ b/src/resources/error-tracking-settings/index.ts
@@ -1,0 +1,37 @@
+import type { ApplyContext, SingletonResourceModule } from "../types.js";
+import type { ErrorTrackingSettings } from "./sdk.js";
+import {
+  diffErrorTrackingSettings,
+  displayErrorTrackingSettings,
+  displayErrorTrackingSettingsFromServer,
+  looksLikeErrorTrackingSettings,
+  runErrorTrackingSettingsOp,
+  validateErrorTrackingSettings,
+} from "./pipeline.js";
+import { getErrorTrackingSettings, type ServerErrorTrackingSettings } from "./client.js";
+import { renderToFile } from "./codegen.js";
+
+export { errorTrackingSettings } from "./sdk.js";
+export type { ErrorTrackingSettings } from "./sdk.js";
+
+export const errorTrackingSettingsResource: SingletonResourceModule<
+  ErrorTrackingSettings,
+  ServerErrorTrackingSettings
+> = {
+  kind: "singleton",
+  name: "error-tracking-settings",
+  displayName: "error tracking settings",
+
+  isSpec: looksLikeErrorTrackingSettings,
+
+  fetchOne: getErrorTrackingSettings,
+  diffFields: diffErrorTrackingSettings,
+
+  validate: (specs) => validateErrorTrackingSettings(specs),
+  executeOp: runErrorTrackingSettingsOp,
+
+  displaySpec: (spec, _ctx: ApplyContext) => displayErrorTrackingSettings(spec),
+  displayServer: (server, _ctx: ApplyContext) => displayErrorTrackingSettingsFromServer(server),
+
+  renderToFile,
+};

--- a/src/resources/error-tracking-settings/pipeline.test.ts
+++ b/src/resources/error-tracking-settings/pipeline.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { errorTrackingSettings, type ErrorTrackingSettings } from "./sdk.js";
+import type { ServerErrorTrackingSettings } from "./client.js";
+import { diffErrorTrackingSettings, validateErrorTrackingSettings } from "./pipeline.js";
+
+function server(overrides: Partial<ServerErrorTrackingSettings> = {}): ServerErrorTrackingSettings {
+  return {
+    project_rate_limit_value: null,
+    project_rate_limit_bucket_size_minutes: null,
+    per_issue_rate_limit_value: null,
+    per_issue_rate_limit_bucket_size_minutes: null,
+    ...overrides,
+  };
+}
+
+describe("error-tracking-settings field diff", () => {
+  it("reports nothing changed when every declared field matches the server", () => {
+    const spec: ErrorTrackingSettings = errorTrackingSettings({ project_rate_limit_value: 1000 });
+    expect(diffErrorTrackingSettings(spec, server({ project_rate_limit_value: 1000 }))).toEqual([]);
+  });
+
+  it("emits a change for a declared field that differs", () => {
+    const spec: ErrorTrackingSettings = errorTrackingSettings({ project_rate_limit_value: 1000 });
+    expect(diffErrorTrackingSettings(spec, server({ project_rate_limit_value: 500 }))).toEqual([
+      { field: "project_rate_limit_value", before: 500, after: 1000 },
+    ]);
+  });
+
+  it("never emits a change for an undeclared field, regardless of server value", () => {
+    const spec: ErrorTrackingSettings = errorTrackingSettings({ project_rate_limit_value: 1000 });
+    const result = diffErrorTrackingSettings(
+      spec,
+      server({ project_rate_limit_value: 1000, per_issue_rate_limit_value: 42 }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("treats explicit null (remove the limit) distinctly from missing", () => {
+    const spec: ErrorTrackingSettings = errorTrackingSettings({ project_rate_limit_value: null });
+    expect(diffErrorTrackingSettings(spec, server({ project_rate_limit_value: 1000 }))).toEqual([
+      { field: "project_rate_limit_value", before: 1000, after: null },
+    ]);
+  });
+
+  it("does not flag a field that's null on both sides", () => {
+    const spec: ErrorTrackingSettings = errorTrackingSettings({ project_rate_limit_value: null });
+    expect(diffErrorTrackingSettings(spec, server())).toEqual([]);
+  });
+});
+
+describe("error-tracking-settings validation", () => {
+  it("rejects a zero or negative rate limit", () => {
+    expect(
+      validateErrorTrackingSettings([errorTrackingSettings({ project_rate_limit_value: 0 })]),
+    ).toHaveLength(1);
+    expect(
+      validateErrorTrackingSettings([errorTrackingSettings({ per_issue_rate_limit_value: -5 })]),
+    ).toHaveLength(1);
+  });
+
+  it("accepts a positive integer or null", () => {
+    expect(
+      validateErrorTrackingSettings([
+        errorTrackingSettings({ project_rate_limit_value: 1000, per_issue_rate_limit_value: null }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("rejects declaring the singleton more than once", () => {
+    const issues = validateErrorTrackingSettings([
+      errorTrackingSettings({ project_rate_limit_value: 1 }),
+      errorTrackingSettings({ per_issue_rate_limit_value: 1 }),
+    ]);
+    expect(issues.some((m) => m.includes("singleton"))).toBeTruthy();
+  });
+
+  it("accepts an empty spec (nothing declared)", () => {
+    expect(validateErrorTrackingSettings([errorTrackingSettings({})])).toEqual([]);
+  });
+});

--- a/src/resources/error-tracking-settings/pipeline.ts
+++ b/src/resources/error-tracking-settings/pipeline.ts
@@ -1,0 +1,116 @@
+import type { ClientConfig } from "../../client/config.js";
+import { specHash } from "../../apply/hash.js";
+import { obj, scalar, type DisplayValue } from "../../apply/display.js";
+import {
+  type ApplyContext,
+  type FieldChange,
+  getResourceKind,
+  type ResourceOp,
+} from "../types.js";
+import type { ErrorTrackingSettings } from "./sdk.js";
+import {
+  patchErrorTrackingSettings,
+  type ErrorTrackingSettingsPayload,
+  type ServerErrorTrackingSettings,
+} from "./client.js";
+
+export function looksLikeErrorTrackingSettings(value: unknown): value is ErrorTrackingSettings {
+  return getResourceKind(value) === "error-tracking-settings";
+}
+
+/**
+ * Per-field diff. Only iterates keys present in `spec` — undeclared keys are
+ * invisible to the pipeline. That's the field-scoping safety invariant: apply
+ * PATCHes only what the user has explicitly opted into managing.
+ */
+export function diffErrorTrackingSettings(
+  spec: ErrorTrackingSettings,
+  server: ServerErrorTrackingSettings,
+): FieldChange[] {
+  const changes: FieldChange[] = [];
+  for (const field of Object.keys(spec) as Array<keyof ErrorTrackingSettings>) {
+    const before = (server as Record<string, unknown>)[field];
+    const after = spec[field];
+    if (!valuesEqual(before, after)) {
+      changes.push({ field, before, after });
+    }
+  }
+  return changes;
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  return specHash(a) === specHash(b);
+}
+
+const FIELDS: ReadonlyArray<keyof ErrorTrackingSettings> = [
+  "project_rate_limit_value",
+  "project_rate_limit_bucket_size_minutes",
+  "per_issue_rate_limit_value",
+  "per_issue_rate_limit_bucket_size_minutes",
+];
+
+export function validateErrorTrackingSettings(specs: ErrorTrackingSettings[]): string[] {
+  if (specs.length > 1) {
+    return [`errorTrackingSettings is a singleton; declared ${specs.length} times`];
+  }
+  const issues: string[] = [];
+  const spec = specs[0];
+  if (!spec) return issues;
+  for (const field of FIELDS) {
+    if (!(field in spec)) continue;
+    const value = spec[field];
+    if (value === null) continue; // null = "remove the limit" — valid.
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+      issues.push(`error tracking settings: ${field} must be a positive integer or null`);
+    }
+  }
+  return issues;
+}
+
+function buildPayload(spec: ErrorTrackingSettings): ErrorTrackingSettingsPayload {
+  const payload: ErrorTrackingSettingsPayload = {};
+  for (const field of Object.keys(spec) as Array<keyof ErrorTrackingSettings>) {
+    (payload as Record<string, unknown>)[field] = spec[field];
+  }
+  return payload;
+}
+
+export async function runErrorTrackingSettingsOp(
+  config: ClientConfig,
+  op: ResourceOp<ErrorTrackingSettings, ServerErrorTrackingSettings>,
+  _ctx: ApplyContext,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+  if (op.kind === "create") {
+    throw new Error(
+      "error-tracking-settings: received a create op, but the singleton row always exists",
+    );
+  }
+  await patchErrorTrackingSettings(config, buildPayload(op.spec), options);
+}
+
+export function displayErrorTrackingSettings(spec: ErrorTrackingSettings): DisplayValue {
+  return obj(
+    (Object.keys(spec) as Array<keyof ErrorTrackingSettings>).map(
+      (field) => [field as string, scalar(spec[field] ?? null)] as [string, DisplayValue],
+    ),
+  );
+}
+
+export function displayErrorTrackingSettingsFromServer(
+  server: ServerErrorTrackingSettings,
+): DisplayValue {
+  return obj(
+    FIELDS.map(
+      (field) =>
+        [field as string, scalar((server as Record<string, unknown>)[field] ?? null)] as [
+          string,
+          DisplayValue,
+        ],
+    ),
+  );
+}

--- a/src/resources/error-tracking-settings/sdk.ts
+++ b/src/resources/error-tracking-settings/sdk.ts
@@ -1,0 +1,23 @@
+import type { components } from "../../generated/api.js";
+import { markResourceKind } from "../types.js";
+
+/**
+ * Spec for the per-project error-tracking settings singleton — the ingestion
+ * rate limits for exception events.
+ *
+ * Every field is optional: the field-scoping invariant is that apply only
+ * PATCHes the keys the user explicitly declares, and never touches the rest.
+ * To stop managing a field, remove the key (the server value persists — there
+ * is no before-state to roll back to). To reset a limit, declare it: a `null`
+ * removes the limit, an integer sets it. Omitting the key entirely leaves the
+ * server value alone — `null` and "missing" are distinct.
+ *
+ * Note: error-tracking *spike detection config* is a sibling singleton but is
+ * NOT managed here — its `update_config` endpoint rejects personal API key
+ * access, so the CLI can't write it. See docs/resources.md.
+ */
+export type ErrorTrackingSettings = Partial<components["schemas"]["ErrorTrackingSettings"]>;
+
+export function errorTrackingSettings(spec: ErrorTrackingSettings): ErrorTrackingSettings {
+  return markResourceKind(spec, "error-tracking-settings");
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -11,6 +11,7 @@ import { experimentResource } from "./experiment/index.js";
 import { experimentHoldoutResource } from "./experiment-holdout/index.js";
 import { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
+import { errorTrackingSettingsResource } from "./error-tracking-settings/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
 
 /**
@@ -30,6 +31,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
   featureFlagResource as ResourceModule<unknown, unknown>,
   insightResource as ResourceModule<unknown, unknown>,
   projectSettingsResource as ResourceModule<unknown, unknown>,
+  errorTrackingSettingsResource as ResourceModule<unknown, unknown>,
   propertyGroupResource as ResourceModule<unknown, unknown>,
 ];
 
@@ -53,6 +55,7 @@ export { experimentHoldoutResource } from "./experiment-holdout/index.js";
 export { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 export { experimentResource } from "./experiment/index.js";
 export { projectSettingsResource } from "./project-settings/index.js";
+export { errorTrackingSettingsResource } from "./error-tracking-settings/index.js";
 export type {
   ResourceModule,
   CollectionResourceModule,

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -16,6 +16,7 @@ import { experimentSavedMetricResource } from "./experiment-saved-metric/index.j
 import { featureFlagResource } from "./feature-flag/index.js";
 import { insightResource } from "./insight/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
+import { errorTrackingSettingsResource } from "./error-tracking-settings/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
 
 describe("topoOrder", () => {
@@ -184,6 +185,7 @@ describe("RESOURCES (real registry)", () => {
         featureFlagResource,
         insightResource,
         projectSettingsResource,
+        errorTrackingSettingsResource,
         propertyGroupResource,
       ].map((r) => r.name),
     );


### PR DESCRIPTION
Adds the **error-tracking settings** singleton (via the `add-singleton-resource` pattern). Ships **one** singleton, not two — see the spike-detection exclusion below.

## Error tracking settings (shipped)
Field-scoped PATCH of the four exception-ingestion rate limits (`project_rate_limit_value` / `_bucket_size_minutes`, `per_issue_rate_limit_value` / `_bucket_size_minutes`). GET via the custom `retrieve_settings` route, PATCH via `update_settings`. Only declared fields are written; `null` removes a limit, omitting a key leaves the server value alone.

**Live-verified on 806** (add-singleton flow): apply → no-op re-apply (unchanged) → edit one field → single-field PATCH → **field-scoping invariant** (an undeclared field set out-of-band survives re-apply untouched). All test state restored to the original all-null afterward.

## Spike detection config (excluded — report-only)
The sibling singleton the branch was scoped for is **not buildable**: its `update_config` write endpoint **rejects personal API key access** — both PATCH and POST return `"This action does not support personal API key access"`. The GET works, but there is no write path for our auth (the CLI is personal-API-key only), so it can't round-trip. Marked 🚫 in `docs/resources.md`. This is the singleton analogue of the data-color-themes verdict: read-only surface for our tooling.

Splitting the PR would leave an empty second half, so this is one singleton with the exclusion documented — flagging in case the tracker expected two.

## Surprises
- Spike detection's `spike_detection_config` GET schema declares an **array** response, but the live endpoint returns a **single object** (serializer drift) — it is a singleton in practice regardless.
- The write auth barrier above.

Scope: `error_tracking:read` / `error_tracking:write`. Singletons are excluded from the smoke seed (would mutate an unrestorable project-wide row). Gates green (`typecheck`, `typecheck:examples`, `test` — 300 pass, `lint`).

---

Stacks on #81 (base `pl/spec-migration`) — codegen only compiles there. Retarget to `main` when #81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)