### PR TITLE
feat(annotation): SDK factory + pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Alpha — do not use in production.**
 > This is pre-MVP software (`0.1.0-alpha.0`). The CLI, the on-disk file format, the SDK surface, and the tag-based identity model are all subject to breaking changes without notice. Use it on throwaway projects or in a sandbox while we stabilize.
 
-Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
+Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, experiment saved metrics, and annotations in TypeScript, then sync them to a PostHog project with one command.
 
 ## Why
 
@@ -51,6 +51,7 @@ export default dashboard({
    - `event_definition:read`, `event_definition:write` (also covers property groups)
    - `experiment:read`, `experiment:write` (also covers experiment holdouts)
    - `experiment_saved_metric:read`, `experiment_saved_metric:write`
+   - `annotation:read`, `annotation:write` (annotations reference insights/dashboards, so `insight:*` / `dashboard:*` above are also needed for scoped annotations)
 
    Then add it (and your numeric project ID) to a `.env` (or `.envrc`) file:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -13,7 +13,7 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 | Dashboards          | ✅ `projects/{id}/dashboards`            | ✅                  | Tag-identified via `iac:dashboards:<key>`     |
 | Insights            | ✅ `projects/{id}/insights`              | ✅                  | Standalone or inlined inside a dashboard tile |
 | Dashboard templates | ✅ `projects/{id}/dashboard_templates`   | ❌                  |                                               |
-| Annotations         | ✅ `projects/{id}/annotations`           | ❌                  |                                               |
+| Annotations         | ✅ `projects/{id}/annotations`           | ✅                  | Identity via `iac:annotations:<key>` marker in `content`. `scope` project/organization/dashboard_item(insight)/dashboard; insight/dashboard refs by key. `hidden` keeps deploy markers (and the marker comment) out of the UI. Full matrix refresh tracked in #78. |
 | Notebooks           | ✅ `projects/{id}/notebooks`             | ❌                  |                                               |
 | Alerts              | ✅ `environments/{id}/alerts`            | ❌                  |                                               |
 | Insight variables   | ✅ `environments/{id}/insight_variables` | ❌                  |                                               |

--- a/examples/posthog/annotations/deploy-marker.ts
+++ b/examples/posthog/annotations/deploy-marker.ts
@@ -1,0 +1,15 @@
+// The canonical IaC annotation: a deployment marker. It drops a vertical line
+// on every timeline at `dateMarker` so spikes line up with releases. Because
+// deploys are high-frequency, it's `hidden` (kept out of the charts UI but
+// readable over the API) and tagged `GIT` (a bot/deployment note, not a human
+// one). Project-scoped, so no insight/dashboard reference.
+import { annotation } from "@posthog/definitions";
+
+export default annotation({
+  key: "deploy-2026-08-01",
+  content: "Deployed web v2.3.1",
+  dateMarker: "2026-08-01T14:30:00Z",
+  scope: "project",
+  creationType: "GIT",
+  hidden: true,
+});

--- a/examples/posthog/annotations/incident-marker.ts
+++ b/examples/posthog/annotations/incident-marker.ts
@@ -1,0 +1,18 @@
+// An incident marker, visible in the UI (not hidden) with an emoji badge so it
+// stands out on charts during a post-mortem. Organization-scoped so it shows up
+// across every project's timelines. A human note, so the default creationType
+// (USR) is fine.
+//
+// (To pin an annotation to one insight or dashboard instead, set
+// `scope: "dashboard_item"` + `insight: <imported insight>` — or
+// `scope: "dashboard"` + `dashboard: <imported dashboard>` — and declare that
+// resource in the same run.)
+import { annotation } from "@posthog/definitions";
+
+export default annotation({
+  key: "incident-checkout-outage",
+  content: "Checkout outage — payments provider degraded",
+  dateMarker: "2026-08-03T09:12:00Z",
+  scope: "organization",
+  emoji: "🔥",
+});

--- a/openapi-filter.yaml
+++ b/openapi-filter.yaml
@@ -86,6 +86,11 @@ inverseOperationIds:
   - actions_partial_update
   - actions_destroy
 
+  - annotations_list
+  - annotations_create
+  - annotations_retrieve
+  - annotations_partial_update
+
 unusedComponents:
   - schemas
   - parameters

--- a/scripts/smoke-cleanup.ts
+++ b/scripts/smoke-cleanup.ts
@@ -82,6 +82,12 @@ import {
   pruneAction,
 } from "../src/resources/action/pipeline.js";
 
+import { listManagedAnnotations } from "../src/resources/annotation/client.js";
+import {
+  annotationKeyFromServer,
+  pruneAnnotation,
+} from "../src/resources/annotation/pipeline.js";
+
 import type { ClientConfig } from "../src/client/config.js";
 
 type Args = {
@@ -96,6 +102,7 @@ type Args = {
   "property-group"?: string;
   cohort?: string;
   endpoint?: string;
+  annotation?: string;
 };
 
 const ARG_KEYS: Array<keyof Args> = [
@@ -110,6 +117,7 @@ const ARG_KEYS: Array<keyof Args> = [
   "property-group",
   "cohort",
   "endpoint",
+  "annotation",
 ];
 
 function parseArgs(argv: string[]): Args {
@@ -268,6 +276,16 @@ async function main(): Promise<void> {
       listManagedEndpoints,
       (row) => endpointKeyFromServer(row),
       (c, row) => pruneEndpoint(c, row),
+    );
+  }
+  if (args["annotation"]) {
+    await deleteByKey(
+      "annotation",
+      args["annotation"],
+      config,
+      listManagedAnnotations,
+      (row) => annotationKeyFromServer(row),
+      (c, row) => pruneAnnotation(c, row),
     );
   }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -63,6 +63,7 @@ SAVED_METRIC_KEY="smoke-metric-${STAMP}"
 EXPERIMENT_KEY="smoke-experiment-${STAMP}"
 COHORT_KEY="smoke-cohort-${STAMP}"
 ENDPOINT_KEY="smoke-endpoint-${STAMP}"
+ANNOTATION_KEY="smoke-annotation-${STAMP}"
 
 # Names that round-trip cleanly through pull's slug-from-name. We use the
 # event-definition `name` as both the spec key AND the on-the-wire event
@@ -71,7 +72,7 @@ EVENT_NAME="${EVENT_DEFINITION_KEY}"
 
 # Resource kinds we'll seed and pull. Used both in --kind for pull and in
 # the no-op assertion's filter (we don't want unrelated kinds dirtying it).
-SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints"
+SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints,annotations"
 
 cleanup() {
   echo
@@ -88,6 +89,7 @@ cleanup() {
     "--property-group=${PROPERTY_GROUP_KEY}" \
     "--cohort=${COHORT_KEY}" \
     "--endpoint=${ENDPOINT_KEY}" \
+    "--annotation=${ANNOTATION_KEY}" \
     || echo "smoke: cleanup hit an error (continuing)"
   echo "smoke: removing workdir $WORK_DIR"
   rm -rf "$WORK_DIR"
@@ -153,7 +155,8 @@ mkdir -p \
   "$SEED_DIR/experiment-saved-metrics" \
   "$SEED_DIR/experiments" \
   "$SEED_DIR/cohorts" \
-  "$SEED_DIR/endpoints"
+  "$SEED_DIR/endpoints" \
+  "$SEED_DIR/annotations"
 
 # Insight — referenced by the dashboard tile below.
 cat > "$SEED_DIR/insights/smoke-insight.ts" <<EOF
@@ -306,6 +309,21 @@ export default endpoint({
   key: "${ENDPOINT_KEY}",
   name: "${ENDPOINT_KEY}",
   query: { kind: "HogQLQuery", query: "select 1 as smoke" },
+});
+EOF
+
+# Annotation — independent. Project-scoped hidden deploy marker. Content is the
+# key itself: annotations have no `name`, so pull derives the spec key by
+# slugifying `content` — keeping content == key makes the pulled key round-trip
+# (so the trap cleanup, which deletes by key, finds the row).
+cat > "$SEED_DIR/annotations/smoke-annotation.ts" <<EOF
+import { annotation } from "@posthog/definitions";
+export default annotation({
+  key: "${ANNOTATION_KEY}",
+  content: "${ANNOTATION_KEY}",
+  dateMarker: "2026-08-01T00:00:00Z",
+  scope: "project",
+  hidden: true,
 });
 EOF
 

--- a/src/apply/format-plan.ts
+++ b/src/apply/format-plan.ts
@@ -140,6 +140,18 @@ function buildDisplayContext(
       ctx.insightIdByKey.set(key, id);
     }
   }
+  // Same for dashboards, so annotation / subscription references to a dashboard
+  // render as keys rather than opaque ids.
+  const dashboardResource = resources.find((r) => r.name === "dashboards");
+  if (dashboardResource && dashboardResource.kind === "collection") {
+    for (const row of serverState.get("dashboards") ?? []) {
+      const key = dashboardResource.keyFromServer(row);
+      if (!key) continue;
+      const id = (row as { id: number }).id;
+      ctx.dashboardKeyByServerId.set(id, key);
+      ctx.dashboardIdByKey.set(key, id);
+    }
+  }
   return ctx;
 }
 

--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -32,6 +32,42 @@ export interface paths {
         patch: operations["actions_partial_update"];
         trace?: never;
     };
+    "/api/projects/{project_id}/annotations/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations. */
+        get: operations["annotations_list"];
+        put?: never;
+        /** @description Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations. */
+        post: operations["annotations_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/annotations/{id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations. */
+        get: operations["annotations_retrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** @description Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations. */
+        patch: operations["annotations_partial_update"];
+        trace?: never;
+    };
     "/api/projects/{project_id}/cohorts/": {
         parameters: {
             query?: never;
@@ -1193,6 +1229,59 @@ export interface components {
          * @enum {string}
          */
         AggregationType: "count" | "sum" | "avg";
+        Annotation: {
+            readonly id: number;
+            /** @description Annotation text shown on charts to describe the change, release, or incident. */
+            content?: string | null;
+            /**
+             * Format: date-time
+             * @description When this annotation happened (ISO 8601 timestamp). Used to position it on charts.
+             */
+            date_marker?: string | null;
+            /**
+             * @description Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
+             *
+             *     * `USR` - user
+             *     * `GIT` - GitHub
+             */
+            creation_type?: components["schemas"]["CreationTypeEnum"];
+            dashboard_item?: number | null;
+            dashboard_id?: number | null;
+            readonly dashboard_name: string | null;
+            readonly insight_short_id: string | null;
+            readonly insight_name: string | null;
+            readonly insight_derived_name: string | null;
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly created_at: string | null;
+            /** Format: date-time */
+            readonly updated_at: string;
+            /** @description Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
+            deleted?: boolean;
+            /**
+             * @description Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
+             *
+             *     * `dashboard_item` - insight
+             *     * `dashboard` - dashboard
+             *     * `project` - project
+             *     * `organization` - organization
+             *     * `recording` - recording
+             */
+            scope?: components["schemas"]["AnnotationScopeEnum"];
+            /** @description Optional emoji shown in place of the default badge when this annotation is surfaced on a chart. */
+            emoji?: string | null;
+            /** @description When true, the annotation is hidden from the PostHog UI (charts and the annotations list) but still readable over the API and MCP. Use for high-frequency markers like deployments that would otherwise crowd the UI. Null (the default) means the annotation is shown. */
+            hidden_in_user_interface?: boolean | null;
+        };
+        /**
+         * @description * `dashboard_item` - insight
+         *     * `dashboard` - dashboard
+         *     * `project` - project
+         *     * `organization` - organization
+         *     * `recording` - recording
+         * @enum {string}
+         */
+        AnnotationScopeEnum: "dashboard_item" | "dashboard" | "project" | "organization" | "recording";
         ArchiveExperiment: {
             /**
              * @description When the linked feature flag is still enabled, also disable and archive it along with the experiment. Has no effect if the flag is already disabled (it is archived either way).
@@ -2440,6 +2529,12 @@ export interface components {
          * @enum {string}
          */
         CreationModeEnum: "default" | "template" | "duplicate" | "unlisted";
+        /**
+         * @description * `USR` - user
+         *     * `GIT` - GitHub
+         * @enum {string}
+         */
+        CreationTypeEnum: "USR" | "GIT";
         /**
          * CurrencyCode
          * @enum {string}
@@ -10137,6 +10232,21 @@ export interface components {
             previous?: string | null;
             results: components["schemas"]["Action"][];
         };
+        PaginatedAnnotationList: {
+            /** @example 123 */
+            count: number;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=400&limit=100
+             */
+            next?: string | null;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=200&limit=100
+             */
+            previous?: string | null;
+            results: components["schemas"]["Annotation"][];
+        };
         PaginatedCohortList: {
             /** @example 123 */
             count: number;
@@ -10342,6 +10452,50 @@ export interface components {
             _create_in_folder?: string;
             /** @description The effective access level the user has for this object */
             readonly user_access_level?: string | null;
+        };
+        PatchedAnnotation: {
+            readonly id?: number;
+            /** @description Annotation text shown on charts to describe the change, release, or incident. */
+            content?: string | null;
+            /**
+             * Format: date-time
+             * @description When this annotation happened (ISO 8601 timestamp). Used to position it on charts.
+             */
+            date_marker?: string | null;
+            /**
+             * @description Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
+             *
+             *     * `USR` - user
+             *     * `GIT` - GitHub
+             */
+            creation_type?: components["schemas"]["CreationTypeEnum"];
+            dashboard_item?: number | null;
+            dashboard_id?: number | null;
+            readonly dashboard_name?: string | null;
+            readonly insight_short_id?: string | null;
+            readonly insight_name?: string | null;
+            readonly insight_derived_name?: string | null;
+            readonly created_by?: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly created_at?: string | null;
+            /** Format: date-time */
+            readonly updated_at?: string;
+            /** @description Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
+            deleted?: boolean;
+            /**
+             * @description Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
+             *
+             *     * `dashboard_item` - insight
+             *     * `dashboard` - dashboard
+             *     * `project` - project
+             *     * `organization` - organization
+             *     * `recording` - recording
+             */
+            scope?: components["schemas"]["AnnotationScopeEnum"];
+            /** @description Optional emoji shown in place of the default badge when this annotation is surfaced on a chart. */
+            emoji?: string | null;
+            /** @description When true, the annotation is hidden from the PostHog UI (charts and the annotations list) but still readable over the API and MCP. Use for high-frequency markers like deployments that would otherwise crowd the UI. Null (the default) means the annotation is shown. */
+            hidden_in_user_interface?: boolean | null;
         };
         PatchedCohort: {
             readonly id?: number;
@@ -18738,6 +18892,117 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["Action"];
                     "text/csv": components["schemas"]["Action"];
+                };
+            };
+        };
+    };
+    annotations_list: {
+        parameters: {
+            query?: {
+                /** @description Number of results to return per page. */
+                limit?: number;
+                /** @description The initial index from which to return the results. */
+                offset?: number;
+                /** @description A search term. */
+                search?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedAnnotationList"];
+                };
+            };
+        };
+    };
+    annotations_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["Annotation"];
+                "application/x-www-form-urlencoded": components["schemas"]["Annotation"];
+                "multipart/form-data": components["schemas"]["Annotation"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Annotation"];
+                };
+            };
+        };
+    };
+    annotations_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique integer value identifying this annotation. */
+                id: number;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Annotation"];
+                };
+            };
+        };
+    };
+    annotations_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique integer value identifying this annotation. */
+                id: number;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedAnnotation"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedAnnotation"];
+                "multipart/form-data": components["schemas"]["PatchedAnnotation"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Annotation"];
                 };
             };
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,9 @@ export type {
 export { cohort } from "./resources/cohort/index.js";
 export type { Cohort, CohortFilters, CohortType } from "./resources/cohort/index.js";
 
+export { annotation } from "./resources/annotation/index.js";
+export type { Annotation, AnnotationScope, AnnotationCreationType } from "./resources/annotation/index.js";
+
 export { action } from "./resources/action/index.js";
 export type {
   Action,

--- a/src/pull/run.ts
+++ b/src/pull/run.ts
@@ -152,7 +152,7 @@ export async function runPull(
   // global registry. Reusing topoOrder over the targets — it tolerates missing
   // edges (a target whose dependency isn't a target still works; the
   // optional-import path covers that case).
-  const orderedTargets = topoOrder(options.resources.slice());
+  const orderedTargets = topoOrder(options.resources.slice(), { lenient: true });
 
   for (const resource of orderedTargets) {
     if (resource.kind === "singleton") {

--- a/src/resources/annotation/client.test.ts
+++ b/src/resources/annotation/client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { ServerAnnotationSchema } from "./client.js";
+
+// Shape hand-derived from a real GET /api/projects/{id}/annotations/{id}/
+// response (project 806).
+const realAnnotation = {
+  id: 42,
+  content: "Deployed v2.3\n\n<!-- iac:annotations:deploy-v23 iac:hash:abcd1234 -->",
+  date_marker: "2026-08-01T00:00:00Z",
+  creation_type: "GIT",
+  dashboard_item: null,
+  dashboard_id: null,
+  scope: "project",
+  emoji: null,
+  hidden_in_user_interface: true,
+  deleted: false,
+  created_at: "2026-07-24T00:00:00Z",
+  created_by: { id: 1, uuid: "u", distinct_id: "d" },
+};
+
+describe("ServerAnnotationSchema", () => {
+  it("parses a real annotation payload", () => {
+    const parsed = ServerAnnotationSchema.parse(realAnnotation);
+    expect(parsed.id).toBe(42);
+    expect(parsed.scope).toBe("project");
+    expect(parsed.content).toContain("iac:annotations:deploy-v23");
+    expect(parsed.hidden_in_user_interface).toBe(true);
+  });
+
+  it("parses a dashboard_item-scoped annotation with an insight ref", () => {
+    const parsed = ServerAnnotationSchema.parse({
+      ...realAnnotation,
+      scope: "dashboard_item",
+      dashboard_item: 18104,
+    });
+    expect(parsed.dashboard_item).toBe(18104);
+  });
+
+  it("throws when id is missing", () => {
+    const { id: _omit, ...withoutId } = realAnnotation;
+    void _omit;
+    expect(() => ServerAnnotationSchema.parse(withoutId)).toThrow();
+  });
+});

--- a/src/resources/annotation/client.ts
+++ b/src/resources/annotation/client.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import type { ClientConfig } from "../../client/config.js";
+import type { components } from "../../generated/api.js";
+import { createApiClient, followPagination, type Paginated } from "../../client/typed.js";
+
+const MANAGED_CONTENT_PREFIX = "<!-- iac:annotations:";
+
+export const ServerAnnotationSchema = z
+  .object({
+    id: z.number(),
+    content: z.string().nullable().default(""),
+    date_marker: z.string().nullable().optional(),
+    scope: z.enum(["dashboard_item", "dashboard", "project", "organization", "recording"]).optional(),
+    dashboard_item: z.number().nullable().optional(),
+    dashboard_id: z.number().nullable().optional(),
+    emoji: z.string().nullable().optional(),
+    hidden_in_user_interface: z.boolean().nullable().optional(),
+    creation_type: z.string().nullable().optional(),
+    deleted: z.boolean().nullable().optional(),
+  })
+  .loose();
+
+export type ServerAnnotation = z.infer<typeof ServerAnnotationSchema>;
+
+export type AnnotationCreate = {
+  content: string;
+  date_marker: string;
+  scope: string;
+  dashboard_item?: number | null;
+  dashboard_id?: number | null;
+  emoji?: string | null;
+  hidden_in_user_interface?: boolean | null;
+  creation_type?: string;
+};
+
+export type AnnotationUpdate = Partial<AnnotationCreate> & { deleted?: boolean };
+
+type AnnotationBody = components["schemas"]["Annotation"];
+type PatchedAnnotationBody = components["schemas"]["PatchedAnnotation"];
+type GeneratedPaginatedList = components["schemas"]["PaginatedAnnotationList"];
+
+function paginatedFrom(raw: GeneratedPaginatedList): Paginated<unknown> {
+  return {
+    count: raw.count,
+    next: raw.next ?? null,
+    previous: raw.previous ?? null,
+    results: raw.results ?? [],
+  };
+}
+
+export async function listAnnotations(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerAnnotation[]> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/annotations/", {
+    params: { path: { project_id: config.projectId }, query: { limit: 100 } },
+  });
+  const firstPage = paginatedFrom(data!);
+  const allRaw = await followPagination<unknown>(config, firstPage, { verbose: options.verbose });
+  return allRaw.map((row) => ServerAnnotationSchema.parse(row));
+}
+
+export async function listManagedAnnotations(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerAnnotation[]> {
+  const all = await listAnnotations(config, options);
+  return all.filter((row) => (row.content ?? "").includes(MANAGED_CONTENT_PREFIX));
+}
+
+export async function getAnnotation(
+  config: ClientConfig,
+  id: number,
+  options: { verbose?: boolean } = {},
+): Promise<ServerAnnotation> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/annotations/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+  });
+  return ServerAnnotationSchema.parse(data);
+}
+
+export async function createAnnotation(
+  config: ClientConfig,
+  payload: AnnotationCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerAnnotation> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.POST("/api/projects/{project_id}/annotations/", {
+    params: { path: { project_id: config.projectId } },
+    body: payload as unknown as AnnotationBody,
+  });
+  return ServerAnnotationSchema.parse(data);
+}
+
+export async function updateAnnotation(
+  config: ClientConfig,
+  id: number,
+  payload: AnnotationUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerAnnotation> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.PATCH("/api/projects/{project_id}/annotations/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+    body: payload as unknown as PatchedAnnotationBody,
+  });
+  return ServerAnnotationSchema.parse(data);
+}
+
+/**
+ * Delete an annotation. The DELETE verb is 405; annotations soft-delete via
+ * PATCH { deleted: true }.
+ */
+export async function deleteAnnotation(
+  config: ClientConfig,
+  id: number,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  await updateAnnotation(config, id, { deleted: true }, options);
+}

--- a/src/resources/annotation/codegen.ts
+++ b/src/resources/annotation/codegen.ts
@@ -1,0 +1,96 @@
+import type { ClientConfig } from "../../client/config.js";
+import { renderObject, stringLiteral } from "../../pull/render.js";
+import { slugify } from "../../pull/slug.js";
+import type { PullDependency, PullRenderContext, RenderedFile } from "../../pull/types.js";
+import { type ServerAnnotation, updateAnnotation } from "./client.js";
+import { stripMarker } from "./pipeline.js";
+import type { Annotation } from "./sdk.js";
+
+const MARKER_PREFIX = "iac:annotations:";
+const HASH_MARKER_PREFIX = "iac:hash:";
+
+export function pullFilter(
+  server: ServerAnnotation,
+): { kept: true } | { kept: false; reason: string } {
+  if (server.deleted) return { kept: false, reason: "deleted" };
+  return { kept: true };
+}
+
+export function pullLabel(server: ServerAnnotation): { primary: string; secondary?: string } {
+  const text = stripMarker(server.content) ?? "(no text)";
+  return { primary: text.slice(0, 48), secondary: `[${server.scope ?? "project"}]` };
+}
+
+export function serverIdOf(server: ServerAnnotation): number {
+  return server.id;
+}
+
+export async function pullDependencies(
+  _config: ClientConfig,
+  server: ServerAnnotation,
+): Promise<PullDependency[]> {
+  const deps: PullDependency[] = [];
+  if (server.dashboard_item != null) {
+    deps.push({ resourceName: "insights", serverId: server.dashboard_item });
+  }
+  if (server.dashboard_id != null) {
+    deps.push({ resourceName: "dashboards", serverId: server.dashboard_id });
+  }
+  return deps;
+}
+
+export function renderToFile(
+  server: ServerAnnotation,
+  ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const text = stripMarker(server.content) ?? "";
+  const baseSlug = slugify(text) || `annotation-${server.id}`;
+  const slug = ctx.uniqueSlug(baseSlug);
+
+  const insightImport =
+    server.dashboard_item != null
+      ? ctx.importForServerIdOptional("insights", server.dashboard_item)
+      : undefined;
+  const dashboardImport =
+    server.dashboard_id != null
+      ? ctx.importForServerIdOptional("dashboards", server.dashboard_id)
+      : undefined;
+
+  const fields: Record<string, string> = {
+    key: stringLiteral(slug),
+    content: stringLiteral(text),
+  };
+  if (server.date_marker) fields.dateMarker = stringLiteral(server.date_marker);
+  if (server.scope && server.scope !== "project") fields.scope = stringLiteral(server.scope);
+  if (insightImport) fields.insight = insightImport.varName;
+  if (dashboardImport) fields.dashboard = dashboardImport.varName;
+  if (server.emoji) fields.emoji = stringLiteral(server.emoji);
+  if (server.hidden_in_user_interface) fields.hidden = "true";
+  if (server.creation_type) fields.creationType = stringLiteral(server.creation_type);
+
+  const parts: string[] = [`import { annotation } from "@posthog/definitions";`];
+  if (insightImport) {
+    parts.push(`import ${insightImport.varName} from "../insights/${insightImport.filename.replace(/\.ts$/, ".js")}";`);
+  }
+  if (dashboardImport) {
+    parts.push(`import ${dashboardImport.varName} from "../dashboards/${dashboardImport.filename.replace(/\.ts$/, ".js")}";`);
+  }
+  parts.push("");
+  parts.push(`export default annotation(${renderObject(fields, 2)});`);
+  parts.push("");
+
+  return { filename: `${slug}.ts`, contents: parts.join("\n"), specKey: slug };
+}
+
+export async function tagOnServer(
+  config: ClientConfig,
+  server: ServerAnnotation,
+  spec: Annotation,
+  hash: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const userContent = stripMarker(server.content) ?? "";
+  const marker = `<!-- ${MARKER_PREFIX}${spec.key} ${HASH_MARKER_PREFIX}${hash} -->`;
+  const newContent = userContent ? `${userContent}\n\n${marker}` : marker;
+  await updateAnnotation(config, server.id, { content: newContent }, options);
+}

--- a/src/resources/annotation/index.ts
+++ b/src/resources/annotation/index.ts
@@ -1,0 +1,60 @@
+import type { ApplyContext, CollectionResourceModule } from "../types.js";
+import { insightResource } from "../insight/index.js";
+import { dashboardResource } from "../dashboard/index.js";
+import type { Annotation } from "./sdk.js";
+import {
+  ANNOTATION_IDENTITY_PREFIX,
+  annotationHash,
+  annotationHashFromServer,
+  annotationKeyFromServer,
+  displayAnnotation,
+  displayAnnotationFromServer,
+  looksLikeAnnotation,
+  pruneAnnotation,
+  runAnnotationOp,
+  validateAnnotations,
+} from "./pipeline.js";
+import { getAnnotation, listAnnotations, listManagedAnnotations, type ServerAnnotation } from "./client.js";
+import {
+  pullDependencies,
+  pullFilter,
+  pullLabel,
+  renderToFile,
+  serverIdOf,
+  tagOnServer,
+} from "./codegen.js";
+
+export { annotation } from "./sdk.js";
+export type { Annotation, AnnotationScope, AnnotationCreationType } from "./sdk.js";
+
+export const annotationResource: CollectionResourceModule<Annotation, ServerAnnotation> = {
+  kind: "collection",
+  name: "annotations",
+  displayName: "annotation",
+  identityPrefix: ANNOTATION_IDENTITY_PREFIX,
+  dependsOn: [insightResource, dashboardResource],
+
+  isSpec: looksLikeAnnotation,
+  specKey: (spec) => spec.key,
+
+  list: listManagedAnnotations,
+  keyFromServer: (server) => annotationKeyFromServer(server),
+  hashFromServer: (server) => annotationHashFromServer(server),
+
+  hash: annotationHash,
+  validate: (specs, state) => validateAnnotations(specs, state),
+  executeOp: runAnnotationOp,
+  prune: pruneAnnotation,
+
+  displaySpec: (spec, _ctx: ApplyContext) => displayAnnotation(spec),
+  displayServer: (server, ctx: ApplyContext) => displayAnnotationFromServer(server, ctx),
+
+  listAll: listAnnotations,
+  getById: (config, id, options) => getAnnotation(config, Number(id), options),
+  pullFilter,
+  pullLabel,
+  serverIdOf,
+  pullDependencies,
+  renderToFile,
+  tagOnServer,
+};

--- a/src/resources/annotation/pipeline.test.ts
+++ b/src/resources/annotation/pipeline.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { diff } from "../../apply/diff.js";
+import type { DesiredState } from "../types.js";
+import type { Annotation } from "./sdk.js";
+import type { ServerAnnotation } from "./client.js";
+import { annotationHash, validateAnnotations } from "./pipeline.js";
+
+function spec(key: string, overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    key,
+    content: `Deploy ${key}`,
+    dateMarker: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function serverRow(id: number, key: string, hash: string, extraContent = "Deploy"): ServerAnnotation {
+  const marker = `<!-- iac:annotations:${key} iac:hash:${hash} -->`;
+  return {
+    id,
+    content: `${extraContent}\n\n${marker}`,
+    date_marker: "2026-08-01T00:00:00Z",
+    scope: "project",
+  };
+}
+
+function desiredFor(specs: Annotation[]): DesiredState {
+  const state: DesiredState = new Map();
+  state.set(
+    "annotations",
+    specs.map((spec) => ({ path: "<test>", spec })),
+  );
+  return state;
+}
+
+function currentFor(rows: ServerAnnotation[]): Map<string, unknown[]> {
+  return new Map<string, unknown[]>([["annotations", rows]]);
+}
+
+describe("annotation pipeline", () => {
+  it("emits create when desired has no matching server row", () => {
+    const slice = diff(desiredFor([spec("deploy-1")]), currentFor([])).get("annotations")!;
+    expect(slice.ops[0]!.kind).toBe("create");
+  });
+
+  it("emits unchanged when server hash matches", () => {
+    const desired = spec("deploy-1");
+    const op = diff(
+      desiredFor([desired]),
+      currentFor([serverRow(1, "deploy-1", annotationHash(desired), "Deploy deploy-1")]),
+    ).get("annotations")!.ops[0]!;
+    expect(op.kind).toBe("unchanged");
+  });
+
+  it("emits update when server hash differs", () => {
+    const op = diff(
+      desiredFor([spec("deploy-1")]),
+      currentFor([serverRow(1, "deploy-1", "stale00000000")]),
+    ).get("annotations")!.ops[0]!;
+    expect(op.kind).toBe("update");
+  });
+
+  it("hash changes when the date marker or scope changes", () => {
+    expect(annotationHash(spec("d"))).not.toBe(
+      annotationHash(spec("d", { dateMarker: "2026-09-01T00:00:00Z" })),
+    );
+    expect(annotationHash(spec("d"))).not.toBe(annotationHash(spec("d", { scope: "organization" })));
+  });
+
+  it("classifies a server-only managed annotation as an orphan", () => {
+    const slice = diff(desiredFor([]), currentFor([serverRow(9, "ghost", "any")])).get(
+      "annotations",
+    )!;
+    expect(slice.orphans.length).toBe(1);
+  });
+
+  it("safety invariant: ignores server rows without the identity marker", () => {
+    const handBuilt: ServerAnnotation = {
+      id: 99,
+      content: "A note someone left in the UI",
+      date_marker: "2026-08-01T00:00:00Z",
+      scope: "project",
+    };
+    const slice = diff(desiredFor([]), currentFor([handBuilt])).get("annotations")!;
+    expect(slice.ops.length).toBe(0);
+    expect(slice.orphans.length).toBe(0);
+  });
+});
+
+describe("annotation validation", () => {
+  const empty: DesiredState = new Map();
+
+  it("requires content and dateMarker", () => {
+    const issues = validateAnnotations(
+      [{ key: "x", content: "", dateMarker: "" } as Annotation],
+      empty,
+    );
+    expect(issues.some((m) => m.includes("content is required"))).toBeTruthy();
+    expect(issues.some((m) => m.includes("dateMarker"))).toBeTruthy();
+  });
+
+  it("scope dashboard_item requires an insight reference", () => {
+    const issues = validateAnnotations([spec("x", { scope: "dashboard_item" })], empty);
+    expect(issues.some((m) => m.includes('scope "dashboard_item" requires an `insight`'))).toBeTruthy();
+  });
+
+  it("scope dashboard requires a dashboard reference", () => {
+    const issues = validateAnnotations([spec("x", { scope: "dashboard" })], empty);
+    expect(issues.some((m) => m.includes('scope "dashboard" requires a `dashboard`'))).toBeTruthy();
+  });
+
+  it("project scope must not declare a ref", () => {
+    const issues = validateAnnotations(
+      [spec("x", { insight: { key: "i" } as Annotation["insight"] })],
+      empty,
+    );
+    expect(issues.some((m) => m.includes("must not declare"))).toBeTruthy();
+  });
+
+  it("accepts a minimal project-scoped annotation", () => {
+    expect(validateAnnotations([spec("ok")], empty)).toEqual([]);
+  });
+});

--- a/src/resources/annotation/pipeline.ts
+++ b/src/resources/annotation/pipeline.ts
@@ -1,0 +1,262 @@
+import type { ClientConfig } from "../../client/config.js";
+import { ApiError } from "../../client/typed.js";
+import { specHash } from "../../apply/hash.js";
+import { obj, scalar, type DisplayValue } from "../../apply/display.js";
+import { SafetyViolationError } from "../../apply/errors.js";
+import { getResourceKind, type ApplyContext, type DesiredState, type ResourceOp } from "../types.js";
+import type { Insight } from "../insight/sdk.js";
+import type { Dashboard } from "../dashboard/sdk.js";
+import type { Annotation, AnnotationScope } from "./sdk.js";
+import {
+  type AnnotationCreate,
+  createAnnotation,
+  deleteAnnotation,
+  getAnnotation,
+  type ServerAnnotation,
+  updateAnnotation,
+} from "./client.js";
+
+export const ANNOTATION_IDENTITY_PREFIX = "iac:annotations:";
+
+const MARKER_REGEX = /\n*<!--\s*iac:annotations:(\S+)\s+iac:hash:(\S+)\s*-->\s*$/;
+const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+type ParsedMarker = { userContent: string; key: string; hash: string };
+
+function parseMarker(content: string | null | undefined): ParsedMarker | undefined {
+  if (!content) return undefined;
+  const match = content.match(MARKER_REGEX);
+  if (!match || match.index === undefined) return undefined;
+  return {
+    userContent: content.slice(0, match.index).replace(/\s+$/, ""),
+    key: match[1]!,
+    hash: match[2]!,
+  };
+}
+
+function withMarker(userContent: string, key: string, hash: string): string {
+  const trailer = `<!-- iac:annotations:${key} iac:hash:${hash} -->`;
+  const trimmed = userContent.replace(/\s+$/, "");
+  return trimmed ? `${trimmed}\n\n${trailer}` : trailer;
+}
+
+export function stripMarker(content: string | null | undefined): string | null {
+  if (!content) return null;
+  const parsed = parseMarker(content);
+  return parsed ? parsed.userContent || null : content;
+}
+
+export function annotationKeyFromServer(server: ServerAnnotation): string | undefined {
+  return parseMarker(server.content)?.key;
+}
+
+export function annotationHashFromServer(server: ServerAnnotation): string | undefined {
+  return parseMarker(server.content)?.hash;
+}
+
+function desiredScope(spec: Annotation): AnnotationScope {
+  return spec.scope ?? "project";
+}
+
+function specForHash(spec: Annotation): unknown {
+  return {
+    key: spec.key,
+    content: spec.content,
+    date_marker: spec.dateMarker,
+    scope: desiredScope(spec),
+    insight_key: spec.insight?.key ?? null,
+    dashboard_key: spec.dashboard?.key ?? null,
+    emoji: spec.emoji ?? null,
+    hidden: spec.hidden ?? null,
+    creation_type: spec.creationType ?? null,
+  };
+}
+
+export function annotationHash(spec: Annotation): string {
+  return specHash(specForHash(spec));
+}
+
+function buildPayload(spec: Annotation, hash: string, ctx: ApplyContext): AnnotationCreate {
+  const scope = desiredScope(spec);
+  const payload: AnnotationCreate = {
+    content: withMarker(spec.content, spec.key, hash),
+    date_marker: spec.dateMarker,
+    scope,
+  };
+  if (scope === "dashboard_item") {
+    const id = ctx.insightIdByKey.get(spec.insight!.key);
+    if (id === undefined) {
+      throw new Error(
+        `annotation "${spec.key}" references insight "${spec.insight!.key}" but no server id is known. Insights must run before annotations.`,
+      );
+    }
+    payload.dashboard_item = id;
+  }
+  if (scope === "dashboard") {
+    const id = ctx.dashboardIdByKey.get(spec.dashboard!.key);
+    if (id === undefined) {
+      throw new Error(
+        `annotation "${spec.key}" references dashboard "${spec.dashboard!.key}" but no server id is known. Dashboards must run before annotations.`,
+      );
+    }
+    payload.dashboard_id = id;
+  }
+  if (spec.emoji !== undefined) payload.emoji = spec.emoji;
+  if (spec.hidden !== undefined) payload.hidden_in_user_interface = spec.hidden;
+  if (spec.creationType !== undefined) payload.creation_type = spec.creationType;
+  return payload;
+}
+
+export function looksLikeAnnotation(value: unknown): value is Annotation {
+  return getResourceKind(value) === "annotation";
+}
+
+export function validateAnnotations(specs: Annotation[], state: DesiredState): string[] {
+  const issues: string[] = [];
+  const seenKeys = new Set<string>();
+
+  const knownInsightKeys = new Set<string>();
+  for (const loaded of state.get("insights") ?? []) {
+    const insight = loaded.spec as Insight;
+    if (insight?.key) knownInsightKeys.add(insight.key);
+  }
+  const knownDashboardKeys = new Set<string>();
+  for (const loaded of state.get("dashboards") ?? []) {
+    const dashboard = loaded.spec as Dashboard;
+    if (dashboard?.key) knownDashboardKeys.add(dashboard.key);
+  }
+
+  for (const spec of specs) {
+    if (!spec.key) {
+      issues.push("annotation.key is required");
+      continue;
+    }
+    if (!KEY_PATTERN.test(spec.key)) {
+      issues.push(`annotation "${spec.key}" key must match ${KEY_PATTERN.source}`);
+    }
+    if (seenKeys.has(spec.key)) issues.push(`Duplicate annotation key "${spec.key}"`);
+    seenKeys.add(spec.key);
+
+    if (!spec.content || spec.content.trim() === "") {
+      issues.push(`annotation "${spec.key}" content is required (it carries the identity marker)`);
+    }
+    if (!spec.dateMarker) {
+      issues.push(`annotation "${spec.key}" dateMarker (ISO timestamp) is required`);
+    }
+
+    const scope = desiredScope(spec);
+    if (scope === "dashboard_item") {
+      if (!spec.insight) {
+        issues.push(`annotation "${spec.key}" scope "dashboard_item" requires an \`insight\` reference`);
+      } else if (!knownInsightKeys.has(spec.insight.key)) {
+        issues.push(
+          `annotation "${spec.key}" references unknown insight "${spec.insight.key}" — declare it in the same run`,
+        );
+      }
+      if (spec.dashboard) issues.push(`annotation "${spec.key}" scope "dashboard_item" must not declare a \`dashboard\``);
+    } else if (scope === "dashboard") {
+      if (!spec.dashboard) {
+        issues.push(`annotation "${spec.key}" scope "dashboard" requires a \`dashboard\` reference`);
+      } else if (!knownDashboardKeys.has(spec.dashboard.key)) {
+        issues.push(
+          `annotation "${spec.key}" references unknown dashboard "${spec.dashboard.key}" — declare it in the same run`,
+        );
+      }
+      if (spec.insight) issues.push(`annotation "${spec.key}" scope "dashboard" must not declare an \`insight\``);
+    } else {
+      // project / organization
+      if (spec.insight || spec.dashboard) {
+        issues.push(
+          `annotation "${spec.key}" scope "${scope}" must not declare an \`insight\` or \`dashboard\` reference`,
+        );
+      }
+    }
+  }
+  return issues;
+}
+
+async function assertManaged(
+  config: ClientConfig,
+  id: number,
+  key: string,
+  options: { verbose?: boolean },
+): Promise<void> {
+  const current = await getAnnotation(config, id, options);
+  if (annotationKeyFromServer(current) !== key) {
+    throw new SafetyViolationError("annotation", id, key);
+  }
+}
+
+export async function runAnnotationOp(
+  config: ClientConfig,
+  op: ResourceOp<Annotation, ServerAnnotation>,
+  ctx: ApplyContext,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+
+  const payload = buildPayload(op.spec, annotationHash(op.spec), ctx);
+
+  if (op.kind === "create") {
+    await createAnnotation(config, payload, options);
+    return;
+  }
+
+  await assertManaged(config, op.server.id, op.spec.key, options);
+  await updateAnnotation(config, op.server.id, payload, options);
+}
+
+export async function pruneAnnotation(
+  config: ClientConfig,
+  orphan: ServerAnnotation,
+  options: { verbose?: boolean } = {},
+): Promise<boolean> {
+  const key = annotationKeyFromServer(orphan) ?? `id:${orphan.id}`;
+  try {
+    await assertManaged(config, orphan.id, key, options);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return false;
+    throw err;
+  }
+  await deleteAnnotation(config, orphan.id, options);
+  return true;
+}
+
+export function displayAnnotation(spec: Annotation): DisplayValue {
+  return obj([
+    ["key", scalar(spec.key)],
+    ["content", scalar(spec.content)],
+    ["date_marker", scalar(spec.dateMarker)],
+    ["scope", scalar(desiredScope(spec))],
+    ["insight", scalar(spec.insight?.key ?? null)],
+    ["dashboard", scalar(spec.dashboard?.key ?? null)],
+    ["emoji", scalar(spec.emoji ?? null)],
+    ["hidden", scalar(spec.hidden ?? null)],
+    ["creation_type", scalar(spec.creationType ?? null)],
+  ]);
+}
+
+export function displayAnnotationFromServer(
+  server: ServerAnnotation,
+  ctx: ApplyContext,
+): DisplayValue {
+  const insightKey =
+    server.dashboard_item != null
+      ? (ctx.insightKeyByServerId.get(server.dashboard_item) ?? `id:${server.dashboard_item}`)
+      : null;
+  const dashboardKey =
+    server.dashboard_id != null
+      ? (ctx.dashboardKeyByServerId.get(server.dashboard_id) ?? `id:${server.dashboard_id}`)
+      : null;
+  return obj([
+    ["key", scalar(annotationKeyFromServer(server) ?? null)],
+    ["content", scalar(stripMarker(server.content))],
+    ["date_marker", scalar(server.date_marker ?? null)],
+    ["scope", scalar(server.scope ?? "project")],
+    ["insight", scalar(insightKey)],
+    ["dashboard", scalar(dashboardKey)],
+    ["emoji", scalar(server.emoji ?? null)],
+    ["hidden", scalar(server.hidden_in_user_interface ?? null)],
+    ["creation_type", scalar(server.creation_type ?? null)],
+  ]);
+}

--- a/src/resources/annotation/sdk.ts
+++ b/src/resources/annotation/sdk.ts
@@ -1,0 +1,43 @@
+import { markResourceKind } from "../types.js";
+import type { Insight } from "../insight/sdk.js";
+import type { Dashboard } from "../dashboard/sdk.js";
+
+/**
+ * Where the annotation is visible:
+ *  - `project` (default) / `organization` — a global marker on every timeline.
+ *  - `dashboard_item` — attached to one insight (declare `insight`).
+ *  - `dashboard` — attached to one dashboard (declare `dashboard`).
+ */
+export type AnnotationScope = "project" | "organization" | "dashboard" | "dashboard_item";
+
+/** `USR` (user note) or `GIT` (bot / deployment marker). */
+export type AnnotationCreationType = "USR" | "GIT";
+
+export type Annotation = {
+  key: string;
+  /**
+   * Annotation text shown on charts. Also carries the identity marker (a
+   * trailing HTML comment), the way endpoints/surveys carry identity in a
+   * free-text field. Set `hidden: true` to keep deploy markers (and their
+   * marker comment) out of the UI entirely.
+   */
+  content: string;
+  /** ISO 8601 timestamp the annotation marks on the timeline. */
+  dateMarker: string;
+  /** Visibility scope. Defaults to `project`. */
+  scope?: AnnotationScope;
+  /** The insight this annotation is attached to — required iff scope is `dashboard_item`. Resolved to an id at apply time; declare it in the same run. */
+  insight?: Insight;
+  /** The dashboard this annotation is attached to — required iff scope is `dashboard`. Resolved to an id at apply time; declare it in the same run. */
+  dashboard?: Dashboard;
+  /** Emoji shown in place of the default badge. */
+  emoji?: string;
+  /** Hide from the PostHog UI (still readable over the API). Ideal for high-frequency deploy markers. */
+  hidden?: boolean;
+  /** `USR` (default) or `GIT` for bot/deployment notes. */
+  creationType?: AnnotationCreationType;
+};
+
+export function annotation(spec: Annotation): Annotation {
+  return markResourceKind(spec, "annotation");
+}

--- a/src/resources/dashboard/pipeline.ts
+++ b/src/resources/dashboard/pipeline.ts
@@ -273,17 +273,24 @@ export async function runDashboardOp(
   ctx: ApplyContext,
   options: { verbose?: boolean } = {},
 ): Promise<void> {
-  if (op.kind === "unchanged") return;
+  // Expose the dashboard's server id by key so dependents (annotations,
+  // subscriptions) can resolve dashboard references at execute time.
+  if (op.kind === "unchanged") {
+    ctx.dashboardIdByKey.set(op.spec.key, op.server.id);
+    return;
+  }
 
   const payload = dashboardPayload(op.spec, dashboardHash(op.spec), ctx.insightIdByKey);
 
   if (op.kind === "create") {
-    await createDashboard(config, payload, options);
+    const created = await createDashboard(config, payload, options);
+    ctx.dashboardIdByKey.set(op.spec.key, created.id);
     return;
   }
 
   await assertManagedDashboard(config, op.server.id, op.spec.key, options);
   await updateDashboard(config, op.server.id, payload, options);
+  ctx.dashboardIdByKey.set(op.spec.key, op.server.id);
 }
 
 export async function pruneDashboard(

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -2,6 +2,7 @@ import type { ResourceModule } from "./types.js";
 import { topoOrder } from "./order.js";
 import { actionResource } from "./action/index.js";
 import { cohortResource } from "./cohort/index.js";
+import { annotationResource } from "./annotation/index.js";
 import { dashboardResource } from "./dashboard/index.js";
 import { endpointResource } from "./endpoint/index.js";
 import { featureFlagResource } from "./feature-flag/index.js";
@@ -31,6 +32,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
   insightResource as ResourceModule<unknown, unknown>,
   projectSettingsResource as ResourceModule<unknown, unknown>,
   propertyGroupResource as ResourceModule<unknown, unknown>,
+  annotationResource as ResourceModule<unknown, unknown>,
 ];
 
 /**
@@ -48,6 +50,7 @@ export { cohortResource } from "./cohort/index.js";
 export { featureFlagResource } from "./feature-flag/index.js";
 export { endpointResource } from "./endpoint/index.js";
 export { propertyGroupResource } from "./property-group/index.js";
+export { annotationResource } from "./annotation/index.js";
 export { eventDefinitionResource } from "./event-definition/index.js";
 export { experimentHoldoutResource } from "./experiment-holdout/index.js";
 export { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -155,6 +155,23 @@ describe("topoOrder", () => {
     );
   });
 
+  it("lenient mode tolerates a dependency absent from the input set (pull)", () => {
+    const absent = makeFakeResource({ name: "absent" });
+    const dependent = makeFakeResource({ name: "dependent", dependsOn: [absent] });
+
+    // Strict throws; lenient drops the out-of-set edge and orders the rest.
+    expect(topoOrder([dependent], { lenient: true }).map((r) => r.name)).toEqual(["dependent"]);
+  });
+
+  it("lenient mode still orders in-set dependencies correctly", () => {
+    const absent = makeFakeResource({ name: "absent" });
+    const a = makeFakeResource({ name: "a" });
+    const b = makeFakeResource({ name: "b", dependsOn: [a, absent] });
+
+    // `absent` edge dropped; `a` before `b` preserved.
+    expect(topoOrder([b, a], { lenient: true }).map((r) => r.name)).toEqual(["a", "b"]);
+  });
+
   it("throws on duplicate resource names with distinct objects", () => {
     const a1 = makeFakeResource({ name: "a" });
     const a2 = makeFakeResource({ name: "a" });

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -7,6 +7,7 @@ import { topoOrder } from "./order.js";
 import { RESOURCES } from "./index.js";
 import { actionResource } from "./action/index.js";
 import { cohortResource } from "./cohort/index.js";
+import { annotationResource } from "./annotation/index.js";
 import { dashboardResource } from "./dashboard/index.js";
 import { endpointResource } from "./endpoint/index.js";
 import { eventDefinitionResource } from "./event-definition/index.js";
@@ -185,6 +186,7 @@ describe("RESOURCES (real registry)", () => {
         insightResource,
         projectSettingsResource,
         propertyGroupResource,
+        annotationResource,
       ].map((r) => r.name),
     );
     expect(new Set(RESOURCES.map((r) => r.name))).toEqual(expected);

--- a/src/resources/order.ts
+++ b/src/resources/order.ts
@@ -11,9 +11,16 @@ import type { ResourceModule } from "./types.js";
  * Within a topo level (modules whose dependencies have all been emitted), input
  * order is preserved. That keeps plan output deterministic and gives a stable
  * tiebreak between independent resources.
+ *
+ * `lenient` (used by pull, which orders an arbitrary `--kind` subset): edges
+ * pointing at modules outside the input set are dropped instead of throwing. A
+ * dependent can be ordered without its dependency present — pull resolves
+ * cross-resource references at render time via the optional-import path, so a
+ * missing dependency kind is fine there.
  */
 export function topoOrder<T extends ResourceModule<unknown, unknown>>(
   resources: ReadonlyArray<T>,
+  options: { lenient?: boolean } = {},
 ): T[] {
   const known = new Set<ResourceModule<unknown, unknown>>(resources);
   const seenNames = new Set<string>();
@@ -26,7 +33,7 @@ export function topoOrder<T extends ResourceModule<unknown, unknown>>(
       if (dep === r) {
         throw new Error(`Resource "${r.name}" depends on itself.`);
       }
-      if (!known.has(dep)) {
+      if (!known.has(dep) && !options.lenient) {
         throw new Error(
           `Resource "${r.name}" depends on "${dep.name}", which is not in the registry.`,
         );
@@ -38,9 +45,15 @@ export function topoOrder<T extends ResourceModule<unknown, unknown>>(
   const emitted = new Set<ResourceModule<unknown, unknown>>();
   const remaining = resources.slice();
 
+  // Only in-set dependencies gate readiness; out-of-set edges are ignored
+  // (they can never be emitted here). Under strict mode every edge is in-set
+  // anyway, so this is a no-op there.
+  const gatingDeps = (r: T): ReadonlyArray<ResourceModule<unknown, unknown>> =>
+    (r.dependsOn ?? []).filter((dep) => known.has(dep));
+
   while (remaining.length > 0) {
     const readyIndex = remaining.findIndex((r) =>
-      (r.dependsOn ?? []).every((dep) => emitted.has(dep)),
+      gatingDeps(r).every((dep) => emitted.has(dep)),
     );
     if (readyIndex === -1) {
       const stuck = remaining.map((r) => r.name).join(", ");

--- a/src/resources/types.ts
+++ b/src/resources/types.ts
@@ -69,6 +69,10 @@ export type ApplyContext = {
   insightIdByKey: Map<string, number>;
   /** Inverse of insightIdByKey; populated when displaying server-side dashboard tiles so we can show keys rather than ids. */
   insightKeyByServerId: Map<number, string>;
+  /** Dashboard server id by spec key. Populated by the dashboard module's executor; read by resources that reference a dashboard by key (annotations, subscriptions). */
+  dashboardIdByKey: Map<string, number>;
+  /** Inverse of dashboardIdByKey; populated for display so dashboard references render as keys rather than opaque ids. */
+  dashboardKeyByServerId: Map<number, string>;
   /** Property-group server id by spec key. Populated by the property-group module's executor; read by the event-definition module to reconcile EventSchema links. */
   propertyGroupIdByKey: Map<string, string>;
   /** Experiment-holdout server id by spec key. Populated by the experiment-holdout module's executor; read by the experiment module's resolver. */
@@ -81,6 +85,8 @@ export function newApplyContext(): ApplyContext {
   return {
     insightIdByKey: new Map(),
     insightKeyByServerId: new Map(),
+    dashboardIdByKey: new Map(),
+    dashboardKeyByServerId: new Map(),
     propertyGroupIdByKey: new Map(),
     experimentHoldoutIdByKey: new Map(),
     experimentSavedMetricIdByKey: new Map(),


### PR DESCRIPTION
Adds **annotations** as a managed resource (first of the two Wave 2 greenlit resources).

## Identity
Content-marker pattern (`iac:annotations:<key>` in `content`, the only free-text field) — as designed in the identity investigation.

## Marker visibility (the UI check you asked for)
Checked the frontend render paths:
- **Chart tooltip / overlay** (the primary surface, where annotations appear on insights) renders `content` through `LemonMarkdown`, which **strips the trailing HTML comment** → the marker is **invisible** there.
- The **annotations management list scene** renders `content` as plain React JSX → the marker shows as **literal trailing text** there (a secondary admin view).
- `hidden: true` (recommended for deploy markers) removes the annotation from **both** surfaces entirely.

So the cosmetic cost is limited to the annotations list scene, and avoidable with `hidden`. Annotations are operational metadata (lower bar than alert names) — noted as a known cost per your call.

## Scope + refs
`scope` project / organization / dashboard_item / dashboard is declarative; `date_marker`, `emoji`, `creation_type` (USR/GIT), `hidden` round-trip as plain fields. Scoped annotations reference an **insight** (dashboard_item) or **dashboard** (dashboard) by key, resolved to ids at execute time; validation enforces exactly-one-ref-per-scope and same-run declaration.

## Supporting infra
- `feat(apply): expose dashboard ids by key in ApplyContext` — adds `dashboardIdByKey` / `dashboardKeyByServerId` (populated by the dashboard executor + plan pass), mirroring `insightIdByKey`. Needed for `scope: dashboard` refs; **subscriptions (next PR) needs the same field** — heads up for a trivial dedupe if both merge.
- `fix(pull): tolerate dependency kinds absent from a --kind subset` — `pull --kind annotations` (deps on insights+dashboards) threw in topoOrder even though pull resolves refs at render time. Added a `lenient` mode to topoOrder (drops out-of-set edges) that pull uses; apply stays strict. Exposed by annotations (first pull-capable resource with deps a user would pull alone).

## Live verification (project 806)
create → no-op re-apply (hash projection correct) → edit → single update → **cross-resource ref** (a `dashboard_item` annotation resolved a same-run insight to its server id) → orphan left alone → hand-built annotation (no marker) untouched → kind-scoped prune deletes managed only. Delete is soft-delete via PATCH `{deleted:true}` (DELETE → 405).

## Surprise
Pull derives an annotation's key by slugifying `content` (annotations have no `name`), so a pulled annotation's key follows its content. The smoke fixture sets `content == key` so the key round-trips for the trap cleanup.

Scope: `annotation:read` / `annotation:write` (+ `insight:*` / `dashboard:*` for scoped annotations). Gates green (typecheck / typecheck:examples / test 307 / lint). Smoke wiring verified in isolation.

---

Stacks on #81 (base `pl/spec-migration`). Retarget to `main` when #81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)