### PR TITLE
feat(subscription): SDK factory + pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Alpha — do not use in production.**
 > This is pre-MVP software (`0.1.0-alpha.0`). The CLI, the on-disk file format, the SDK surface, and the tag-based identity model are all subject to breaking changes without notice. Use it on throwaway projects or in a sandbox while we stabilize.
 
-Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
+Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, experiment saved metrics, and subscriptions in TypeScript, then sync them to a PostHog project with one command.
 
 ## Why
 
@@ -51,6 +51,7 @@ export default dashboard({
    - `event_definition:read`, `event_definition:write` (also covers property groups)
    - `experiment:read`, `experiment:write` (also covers experiment holdouts)
    - `experiment_saved_metric:read`, `experiment_saved_metric:write`
+   - `subscription:read`, `subscription:write` (subscriptions reference insights/dashboards, so `insight:*` / `dashboard:*` above are also needed)
 
    Then add it (and your numeric project ID) to a `.env` (or `.envrc`) file:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -16,6 +16,7 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 | Annotations         | ✅ `projects/{id}/annotations`           | ❌                  |                                               |
 | Notebooks           | ✅ `projects/{id}/notebooks`             | ❌                  |                                               |
 | Alerts              | ✅ `environments/{id}/alerts`            | ❌                  |                                               |
+| Subscriptions       | ✅ `environments/{id}/subscriptions`     | ✅                  | Identity via `iac:subscriptions:<key>` marker in `title` (server caps `title` at 100 chars — title + key budget ≈ 45). Exactly one insight/dashboard ref by key; email/Slack targets; `send_test_now` forced false (apply never delivers). Full matrix refresh tracked in #78. |
 | Insight variables   | ✅ `environments/{id}/insight_variables` | ❌                  |                                               |
 | Comments            | ✅ `projects/{id}/comments`              | —                   | Ephemeral by nature                           |
 

--- a/examples/posthog/subscriptions/daily-errors-slack.ts
+++ b/examples/posthog/subscriptions/daily-errors-slack.ts
@@ -1,0 +1,23 @@
+// Post a single insight to a Slack channel every morning. Slack targets need an
+// `integrationId` — the id of the project's Slack integration. That id is
+// ENVIRONMENT-SPECIFIC: it won't be the same in another project, so this
+// definition isn't portable as-is (swap the id per project). It round-trips and
+// is part of the hash.
+import { insight, subscription, trends } from "../../../src/index.js";
+
+const errors = insight({
+  key: "daily-error-count",
+  name: "Daily error count",
+  query: trends({ series: [{ event: "$exception", math: "total" }], interval: "day" }),
+});
+
+export default subscription({
+  key: "daily-errors-slack",
+  title: "Daily error count → #eng-alerts",
+  insight: errors,
+  targetType: "slack",
+  target: "#eng-alerts",
+  integrationId: 1, // replace with this project's Slack integration id
+  frequency: "daily",
+  startDate: "2026-08-01T07:00:00Z",
+});

--- a/examples/posthog/subscriptions/weekly-growth-email.ts
+++ b/examples/posthog/subscriptions/weekly-growth-email.ts
@@ -1,0 +1,31 @@
+// Email the growth dashboard to the team every Monday. A subscription targets
+// exactly one insight OR one dashboard — here a dashboard, defined inline and
+// referenced by object (resolved to its id at apply time).
+//
+// Delivery note: applying an email subscription INVITES the recipients (PostHog
+// emails them). posthog-definitions never sends the one-off "test on save"
+// delivery, but the recipient invite is inherent to the product — use real
+// addresses only when you mean to.
+import { dashboard, insight, subscription, trends } from "../../../src/index.js";
+
+const signups = insight({
+  key: "weekly-signups",
+  name: "Weekly signups",
+  query: trends({ series: [{ event: "signed_up", math: "total" }], interval: "week" }),
+});
+
+const growth = dashboard({
+  key: "growth-overview",
+  name: "Growth overview",
+  tiles: [{ insight: signups, layout: { x: 0, y: 0, w: 6, h: 4 } }],
+});
+
+export default subscription({
+  key: "weekly-growth-email",
+  title: "Weekly growth digest",
+  dashboard: growth,
+  targetType: "email",
+  target: "growth-team@example.com",
+  frequency: "weekly",
+  startDate: "2026-08-03T08:00:00Z",
+});

--- a/openapi-filter.yaml
+++ b/openapi-filter.yaml
@@ -86,6 +86,11 @@ inverseOperationIds:
   - actions_partial_update
   - actions_destroy
 
+  - subscriptions_list
+  - subscriptions_create
+  - subscriptions_retrieve
+  - subscriptions_partial_update
+
 unusedComponents:
   - schemas
   - parameters

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -16,6 +16,11 @@
 # project-settings (singleton) is intentionally skipped: applying it would
 # mutate a project-wide row we can't restore.
 #
+# subscriptions are intentionally skipped: their identity marker lives in
+# `title`, which the server caps at 100 chars, and pull derives the spec key by
+# slugifying `title` — so a STAMP-length seed key can't round-trip through pull
+# within the length budget. Verified in isolation instead.
+#
 # Steps:
 #   1. Seed:    write the fixture and apply it.
 #   2. Pull:    pull the same kinds back into a scratch dir.

--- a/src/apply/format-plan.ts
+++ b/src/apply/format-plan.ts
@@ -140,6 +140,18 @@ function buildDisplayContext(
       ctx.insightIdByKey.set(key, id);
     }
   }
+  // Same for dashboards, so annotation / subscription references to a dashboard
+  // render as keys rather than opaque ids.
+  const dashboardResource = resources.find((r) => r.name === "dashboards");
+  if (dashboardResource && dashboardResource.kind === "collection") {
+    for (const row of serverState.get("dashboards") ?? []) {
+      const key = dashboardResource.keyFromServer(row);
+      if (!key) continue;
+      const id = (row as { id: number }).id;
+      ctx.dashboardKeyByServerId.set(id, key);
+      ctx.dashboardIdByKey.set(key, id);
+    }
+  }
   return ctx;
 }
 

--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -648,6 +648,38 @@ export interface paths {
         patch: operations["schema_property_groups_partial_update"];
         trace?: never;
     };
+    "/api/projects/{project_id}/subscriptions/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["subscriptions_list"];
+        put?: never;
+        post: operations["subscriptions_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/subscriptions/{id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["subscriptions_retrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["subscriptions_partial_update"];
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -657,6 +689,35 @@ export interface components {
          * @enum {string}
          */
         AIEventType: "$ai_generation" | "$ai_embedding" | "$ai_span" | "$ai_trace" | "$ai_metric" | "$ai_feedback" | "$ai_evaluation" | "$ai_tag" | "$ai_trace_summary" | "$ai_generation_summary" | "$ai_trace_clusters" | "$ai_generation_clusters";
+        AIPromptConfig: {
+            /** @description Analysis window for the report. Omitted = 'since_last_sent' (everything since the previous scheduled delivery). */
+            window?: components["schemas"]["AIWindowConfig"];
+        };
+        AIWindowConfig: {
+            /**
+             * @description What the report analyzes each run:
+             *     * `since_last_sent` (default) — everything since the previous successful scheduled delivery (gap-free; test/manual sends don't move the anchor)
+             *     * `last_n_days` — a fixed trailing window of start_days_ago days
+             *     * `days_ago_range` — the explicit range from start_days_ago to end_days_ago days ago
+             *
+             *     * `since_last_sent` - Since last report
+             *     * `last_n_days` - Last N days
+             *     * `days_ago_range` - Between X and Y days ago
+             * @default since_last_sent
+             */
+            mode: components["schemas"]["AIWindowConfigModeEnum"];
+            /** @description Lower bound of the analysis window, in days before the run. Required for 'last_n_days' (the N) and 'days_ago_range'; ignored for 'since_last_sent'. 1-365. */
+            start_days_ago?: number | null;
+            /** @description Upper bound of the analysis window, in days before the run (0 = now). Required for 'days_ago_range' and must be less than start_days_ago; ignored for other modes. 0-365. */
+            end_days_ago?: number | null;
+        };
+        /**
+         * @description * `since_last_sent` - Since last report
+         *     * `last_n_days` - Last N days
+         *     * `days_ago_range` - Between X and Y days ago
+         * @enum {string}
+         */
+        AIWindowConfigModeEnum: "since_last_sent" | "last_n_days" | "days_ago_range";
         /** AccessControlFilterWarning */
         AccessControlFilterWarning: {
             /**
@@ -10302,6 +10363,21 @@ export interface components {
             previous?: string | null;
             results: components["schemas"]["SchemaPropertyGroup"][];
         };
+        PaginatedSubscriptionList: {
+            /** @example 123 */
+            count: number;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=400&limit=100
+             */
+            next?: string | null;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=200&limit=100
+             */
+            previous?: string | null;
+            results: components["schemas"]["Subscription"][];
+        };
         /**
          * ParserMode
          * @enum {string}
@@ -10736,6 +10812,89 @@ export interface components {
             /** Format: date-time */
             readonly updated_at?: string;
             readonly created_by?: components["schemas"]["UserBasic"];
+        };
+        /** @description Standard Subscription serializer. */
+        PatchedSubscription: {
+            readonly id?: number;
+            /**
+             * @description What the subscription delivers: 'insight' (snapshot of one insight), 'dashboard' (snapshot of one dashboard), or 'ai_prompt' (LLM-generated report). Read-only — derived from the populated target (insight → insight, dashboard → dashboard, prompt → ai_prompt).
+             *
+             *     * `insight` - Insight
+             *     * `dashboard` - Dashboard
+             *     * `ai_prompt` - AI prompt
+             */
+            readonly resource_type?: components["schemas"]["ResourceTypeEnum"];
+            /** @description Dashboard ID to subscribe to (mutually exclusive with insight on create). */
+            dashboard?: number | null;
+            /** @description Insight ID to subscribe to (mutually exclusive with dashboard on create). */
+            insight?: number | null;
+            readonly insight_short_id?: string | null;
+            readonly resource_name?: string | null;
+            /** @description List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6. */
+            dashboard_export_insights?: number[];
+            /** @description Free-text prompt that drives the AI-generated report. Required when resource_type is 'ai_prompt'. Max 4000 characters. */
+            prompt?: string | null;
+            /** @description Configuration for AI report subscriptions (analysis window, future knobs). Only valid when resource_type is 'ai_prompt'. Replaced wholesale on writes. */
+            ai_prompt_config?: components["schemas"]["AIPromptConfig"];
+            /**
+             * @description Delivery channel: email or slack.
+             *
+             *     * `email` - Email
+             *     * `slack` - Slack
+             */
+            target_type?: components["schemas"]["TargetTypeEnum"];
+            /** @description Recipient(s): comma-separated email addresses for email, or Slack channel name/ID for slack. */
+            target_value?: string;
+            /**
+             * @description How often to deliver: daily, weekly, monthly, or yearly.
+             *
+             *     * `daily` - Daily
+             *     * `weekly` - Weekly
+             *     * `monthly` - Monthly
+             *     * `yearly` - Yearly
+             */
+            frequency?: components["schemas"]["RecurrenceIntervalEnum"];
+            /** @description Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Required on create; must be 1 or greater. */
+            interval?: number;
+            /** @description Days of week for weekly subscriptions: monday, tuesday, wednesday, thursday, friday, saturday, sunday. */
+            byweekday?: ("monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday" | "sunday")[] | null;
+            /** @description Position within byweekday set for monthly frequency (e.g. 1 for first, -1 for last). */
+            bysetpos?: number | null;
+            /** @description Total number of deliveries before the subscription stops. Null for unlimited. */
+            count?: number | null;
+            /**
+             * Format: date-time
+             * @description When to start delivering (ISO 8601 datetime).
+             */
+            start_date?: string;
+            /**
+             * Format: date-time
+             * @description When to stop delivering (ISO 8601 datetime). Null for indefinite.
+             */
+            until_date?: string | null;
+            /** Format: date-time */
+            readonly created_at?: string;
+            readonly created_by?: components["schemas"]["UserBasic"];
+            /** @description Set to true to soft-delete. Subscriptions cannot be hard-deleted. */
+            deleted?: boolean;
+            /** @description Whether the subscription is active. Set to false to pause delivery without deleting. Auto-set to false when the delivery integration becomes invalid. */
+            enabled?: boolean;
+            /** @description Human-readable name for this subscription. */
+            title?: string | null;
+            /** @description Human-readable schedule summary, e.g. 'sent daily'. */
+            readonly summary?: string;
+            /** Format: date-time */
+            readonly next_delivery_date?: string | null;
+            /** @description ID of a connected Slack integration. Required when target_type is slack. */
+            integration_id?: number | null;
+            /** @description Optional message included in the invitation email when adding new recipients. */
+            invite_message?: string | null;
+            /** @description Whether to immediately deliver the subscription once on save so the editor can confirm it looks right. Defaults to true on create. When omitted on update, a delivery is sent only if the edit changed what gets delivered (recipient, channel, source) or re-enabled the subscription. The recurring schedule is unaffected. */
+            send_test_now?: boolean;
+            /** @description Whether to attach an AI-generated summary to each delivery (insight and dashboard subscriptions only). Requires the organization to have approved AI data processing, and is subject to the org's active-summary cap and AI credit budget; otherwise the write is rejected. Not applicable to prompt subscriptions, which are themselves AI-generated. */
+            summary_enabled?: boolean;
+            /** @description Optional free-text guidance (max 500 chars) steering the AI summary, e.g. which metrics to emphasize. Only settable when AI summary context is enabled for the organization; clearing it (empty string) is always allowed. */
+            summary_prompt_guide?: string;
         };
         PatchedTeam: {
             readonly id?: number;
@@ -11589,6 +11748,14 @@ export interface components {
              */
             value: (string | number | boolean)[] | string | number | boolean | null;
         };
+        /**
+         * @description * `daily` - Daily
+         *     * `weekly` - Weekly
+         *     * `monthly` - Monthly
+         *     * `yearly` - Yearly
+         * @enum {string}
+         */
+        RecurrenceIntervalEnum: "daily" | "weekly" | "monthly" | "yearly";
         /** ResolvedDateRangeResponse */
         ResolvedDateRangeResponse: {
             /**
@@ -11602,6 +11769,13 @@ export interface components {
              */
             date_to: string;
         };
+        /**
+         * @description * `insight` - Insight
+         *     * `dashboard` - Dashboard
+         *     * `ai_prompt` - AI prompt
+         * @enum {string}
+         */
+        ResourceTypeEnum: "insight" | "dashboard" | "ai_prompt";
         /** Response */
         Response: {
             /** Columns */
@@ -15558,6 +15732,89 @@ export interface components {
          * @enum {string}
          */
         Style: "none" | "number" | "short" | "percent";
+        /** @description Standard Subscription serializer. */
+        Subscription: {
+            readonly id: number;
+            /**
+             * @description What the subscription delivers: 'insight' (snapshot of one insight), 'dashboard' (snapshot of one dashboard), or 'ai_prompt' (LLM-generated report). Read-only — derived from the populated target (insight → insight, dashboard → dashboard, prompt → ai_prompt).
+             *
+             *     * `insight` - Insight
+             *     * `dashboard` - Dashboard
+             *     * `ai_prompt` - AI prompt
+             */
+            readonly resource_type: components["schemas"]["ResourceTypeEnum"];
+            /** @description Dashboard ID to subscribe to (mutually exclusive with insight on create). */
+            dashboard?: number | null;
+            /** @description Insight ID to subscribe to (mutually exclusive with dashboard on create). */
+            insight?: number | null;
+            readonly insight_short_id: string | null;
+            readonly resource_name: string | null;
+            /** @description List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6. */
+            dashboard_export_insights?: number[];
+            /** @description Free-text prompt that drives the AI-generated report. Required when resource_type is 'ai_prompt'. Max 4000 characters. */
+            prompt?: string | null;
+            /** @description Configuration for AI report subscriptions (analysis window, future knobs). Only valid when resource_type is 'ai_prompt'. Replaced wholesale on writes. */
+            ai_prompt_config?: components["schemas"]["AIPromptConfig"];
+            /**
+             * @description Delivery channel: email or slack.
+             *
+             *     * `email` - Email
+             *     * `slack` - Slack
+             */
+            target_type: components["schemas"]["TargetTypeEnum"];
+            /** @description Recipient(s): comma-separated email addresses for email, or Slack channel name/ID for slack. */
+            target_value: string;
+            /**
+             * @description How often to deliver: daily, weekly, monthly, or yearly.
+             *
+             *     * `daily` - Daily
+             *     * `weekly` - Weekly
+             *     * `monthly` - Monthly
+             *     * `yearly` - Yearly
+             */
+            frequency: components["schemas"]["RecurrenceIntervalEnum"];
+            /** @description Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Required on create; must be 1 or greater. */
+            interval: number;
+            /** @description Days of week for weekly subscriptions: monday, tuesday, wednesday, thursday, friday, saturday, sunday. */
+            byweekday?: ("monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday" | "sunday")[] | null;
+            /** @description Position within byweekday set for monthly frequency (e.g. 1 for first, -1 for last). */
+            bysetpos?: number | null;
+            /** @description Total number of deliveries before the subscription stops. Null for unlimited. */
+            count?: number | null;
+            /**
+             * Format: date-time
+             * @description When to start delivering (ISO 8601 datetime).
+             */
+            start_date: string;
+            /**
+             * Format: date-time
+             * @description When to stop delivering (ISO 8601 datetime). Null for indefinite.
+             */
+            until_date?: string | null;
+            /** Format: date-time */
+            readonly created_at: string;
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** @description Set to true to soft-delete. Subscriptions cannot be hard-deleted. */
+            deleted?: boolean;
+            /** @description Whether the subscription is active. Set to false to pause delivery without deleting. Auto-set to false when the delivery integration becomes invalid. */
+            enabled?: boolean;
+            /** @description Human-readable name for this subscription. */
+            title?: string | null;
+            /** @description Human-readable schedule summary, e.g. 'sent daily'. */
+            readonly summary: string;
+            /** Format: date-time */
+            readonly next_delivery_date: string | null;
+            /** @description ID of a connected Slack integration. Required when target_type is slack. */
+            integration_id?: number | null;
+            /** @description Optional message included in the invitation email when adding new recipients. */
+            invite_message?: string | null;
+            /** @description Whether to immediately deliver the subscription once on save so the editor can confirm it looks right. Defaults to true on create. When omitted on update, a delivery is sent only if the edit changed what gets delivered (recipient, channel, source) or re-enabled the subscription. The recurring schedule is unaffected. */
+            send_test_now?: boolean;
+            /** @description Whether to attach an AI-generated summary to each delivery (insight and dashboard subscriptions only). Requires the organization to have approved AI data processing, and is subject to the org's active-summary cap and AI credit budget; otherwise the write is rejected. Not applicable to prompt subscriptions, which are themselves AI-generated. */
+            summary_enabled?: boolean;
+            /** @description Optional free-text guidance (max 500 chars) steering the AI summary, e.g. which metrics to emphasize. Only settable when AI summary context is enabled for the organization; clearing it (empty string) is always allowed. */
+            summary_prompt_guide?: string;
+        };
         /** TableSettings */
         TableSettings: {
             /**
@@ -15581,6 +15838,12 @@ export interface components {
              */
             transpose: boolean | null;
         };
+        /**
+         * @description * `email` - Email
+         *     * `slack` - Slack
+         * @enum {string}
+         */
+        TargetTypeEnum: "email" | "slack";
         /**
          * TaxonomicFilterGroupType
          * @enum {string}
@@ -20630,6 +20893,133 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SchemaPropertyGroup"];
+                };
+            };
+        };
+    };
+    subscriptions_list: {
+        parameters: {
+            query?: {
+                /** @description Filter by creator user UUID. */
+                created_by?: string;
+                /** @description Filter by dashboard ID. */
+                dashboard?: number;
+                /** @description Filter to subscriptions on insights that are tiles of the given dashboard ID. */
+                dashboard_tiles?: number;
+                /** @description Filter by insight ID. */
+                insight?: number;
+                /** @description Filter by a comma-separated list of insight IDs. */
+                insights?: string;
+                /** @description Number of results to return per page. */
+                limit?: number;
+                /** @description The initial index from which to return the results. */
+                offset?: number;
+                /** @description Which field to use when ordering the results. */
+                ordering?: string;
+                /** @description Filter by subscription resource: insight, dashboard export, or AI report. */
+                resource_type?: "ai_prompt" | "dashboard" | "insight";
+                /** @description A search term. */
+                search?: string;
+                /** @description Filter by delivery channel (email or Slack). */
+                target_type?: "email" | "slack";
+            };
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedSubscriptionList"];
+                };
+            };
+        };
+    };
+    subscriptions_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Subscription"];
+                "application/x-www-form-urlencoded": components["schemas"]["Subscription"];
+                "multipart/form-data": components["schemas"]["Subscription"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Subscription"];
+                };
+            };
+        };
+    };
+    subscriptions_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique integer value identifying this subscription. */
+                id: number;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Subscription"];
+                };
+            };
+        };
+    };
+    subscriptions_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique integer value identifying this subscription. */
+                id: number;
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedSubscription"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedSubscription"];
+                "multipart/form-data": components["schemas"]["PatchedSubscription"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Subscription"];
                 };
             };
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,13 @@ export type {
 export { cohort } from "./resources/cohort/index.js";
 export type { Cohort, CohortFilters, CohortType } from "./resources/cohort/index.js";
 
+export { subscription } from "./resources/subscription/index.js";
+export type {
+  Subscription,
+  SubscriptionTargetType,
+  SubscriptionFrequency,
+} from "./resources/subscription/index.js";
+
 export { action } from "./resources/action/index.js";
 export type {
   Action,

--- a/src/pull/run.ts
+++ b/src/pull/run.ts
@@ -152,7 +152,7 @@ export async function runPull(
   // global registry. Reusing topoOrder over the targets — it tolerates missing
   // edges (a target whose dependency isn't a target still works; the
   // optional-import path covers that case).
-  const orderedTargets = topoOrder(options.resources.slice());
+  const orderedTargets = topoOrder(options.resources.slice(), { lenient: true });
 
   for (const resource of orderedTargets) {
     if (resource.kind === "singleton") {

--- a/src/resources/dashboard/pipeline.ts
+++ b/src/resources/dashboard/pipeline.ts
@@ -273,17 +273,24 @@ export async function runDashboardOp(
   ctx: ApplyContext,
   options: { verbose?: boolean } = {},
 ): Promise<void> {
-  if (op.kind === "unchanged") return;
+  // Expose the dashboard's server id by key so dependents (annotations,
+  // subscriptions) can resolve dashboard references at execute time.
+  if (op.kind === "unchanged") {
+    ctx.dashboardIdByKey.set(op.spec.key, op.server.id);
+    return;
+  }
 
   const payload = dashboardPayload(op.spec, dashboardHash(op.spec), ctx.insightIdByKey);
 
   if (op.kind === "create") {
-    await createDashboard(config, payload, options);
+    const created = await createDashboard(config, payload, options);
+    ctx.dashboardIdByKey.set(op.spec.key, created.id);
     return;
   }
 
   await assertManagedDashboard(config, op.server.id, op.spec.key, options);
   await updateDashboard(config, op.server.id, payload, options);
+  ctx.dashboardIdByKey.set(op.spec.key, op.server.id);
 }
 
 export async function pruneDashboard(

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -2,6 +2,7 @@ import type { ResourceModule } from "./types.js";
 import { topoOrder } from "./order.js";
 import { actionResource } from "./action/index.js";
 import { cohortResource } from "./cohort/index.js";
+import { subscriptionResource } from "./subscription/index.js";
 import { dashboardResource } from "./dashboard/index.js";
 import { endpointResource } from "./endpoint/index.js";
 import { featureFlagResource } from "./feature-flag/index.js";
@@ -31,6 +32,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
   insightResource as ResourceModule<unknown, unknown>,
   projectSettingsResource as ResourceModule<unknown, unknown>,
   propertyGroupResource as ResourceModule<unknown, unknown>,
+  subscriptionResource as ResourceModule<unknown, unknown>,
 ];
 
 /**
@@ -48,6 +50,7 @@ export { cohortResource } from "./cohort/index.js";
 export { featureFlagResource } from "./feature-flag/index.js";
 export { endpointResource } from "./endpoint/index.js";
 export { propertyGroupResource } from "./property-group/index.js";
+export { subscriptionResource } from "./subscription/index.js";
 export { eventDefinitionResource } from "./event-definition/index.js";
 export { experimentHoldoutResource } from "./experiment-holdout/index.js";
 export { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -7,6 +7,7 @@ import { topoOrder } from "./order.js";
 import { RESOURCES } from "./index.js";
 import { actionResource } from "./action/index.js";
 import { cohortResource } from "./cohort/index.js";
+import { subscriptionResource } from "./subscription/index.js";
 import { dashboardResource } from "./dashboard/index.js";
 import { endpointResource } from "./endpoint/index.js";
 import { eventDefinitionResource } from "./event-definition/index.js";
@@ -202,6 +203,7 @@ describe("RESOURCES (real registry)", () => {
         insightResource,
         projectSettingsResource,
         propertyGroupResource,
+        subscriptionResource,
       ].map((r) => r.name),
     );
     expect(new Set(RESOURCES.map((r) => r.name))).toEqual(expected);

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -154,6 +154,23 @@ describe("topoOrder", () => {
     );
   });
 
+  it("lenient mode tolerates a dependency absent from the input set (pull)", () => {
+    const absent = makeFakeResource({ name: "absent" });
+    const dependent = makeFakeResource({ name: "dependent", dependsOn: [absent] });
+
+    // Strict throws; lenient drops the out-of-set edge and orders the rest.
+    expect(topoOrder([dependent], { lenient: true }).map((r) => r.name)).toEqual(["dependent"]);
+  });
+
+  it("lenient mode still orders in-set dependencies correctly", () => {
+    const absent = makeFakeResource({ name: "absent" });
+    const a = makeFakeResource({ name: "a" });
+    const b = makeFakeResource({ name: "b", dependsOn: [a, absent] });
+
+    // `absent` edge dropped; `a` before `b` preserved.
+    expect(topoOrder([b, a], { lenient: true }).map((r) => r.name)).toEqual(["a", "b"]);
+  });
+
   it("throws on duplicate resource names with distinct objects", () => {
     const a1 = makeFakeResource({ name: "a" });
     const a2 = makeFakeResource({ name: "a" });

--- a/src/resources/order.ts
+++ b/src/resources/order.ts
@@ -11,9 +11,16 @@ import type { ResourceModule } from "./types.js";
  * Within a topo level (modules whose dependencies have all been emitted), input
  * order is preserved. That keeps plan output deterministic and gives a stable
  * tiebreak between independent resources.
+ *
+ * `lenient` (used by pull, which orders an arbitrary `--kind` subset): edges
+ * pointing at modules outside the input set are dropped instead of throwing. A
+ * dependent can be ordered without its dependency present — pull resolves
+ * cross-resource references at render time via the optional-import path, so a
+ * missing dependency kind is fine there.
  */
 export function topoOrder<T extends ResourceModule<unknown, unknown>>(
   resources: ReadonlyArray<T>,
+  options: { lenient?: boolean } = {},
 ): T[] {
   const known = new Set<ResourceModule<unknown, unknown>>(resources);
   const seenNames = new Set<string>();
@@ -26,7 +33,7 @@ export function topoOrder<T extends ResourceModule<unknown, unknown>>(
       if (dep === r) {
         throw new Error(`Resource "${r.name}" depends on itself.`);
       }
-      if (!known.has(dep)) {
+      if (!known.has(dep) && !options.lenient) {
         throw new Error(
           `Resource "${r.name}" depends on "${dep.name}", which is not in the registry.`,
         );
@@ -38,9 +45,15 @@ export function topoOrder<T extends ResourceModule<unknown, unknown>>(
   const emitted = new Set<ResourceModule<unknown, unknown>>();
   const remaining = resources.slice();
 
+  // Only in-set dependencies gate readiness; out-of-set edges are ignored
+  // (they can never be emitted here). Under strict mode every edge is in-set
+  // anyway, so this is a no-op there.
+  const gatingDeps = (r: T): ReadonlyArray<ResourceModule<unknown, unknown>> =>
+    (r.dependsOn ?? []).filter((dep) => known.has(dep));
+
   while (remaining.length > 0) {
     const readyIndex = remaining.findIndex((r) =>
-      (r.dependsOn ?? []).every((dep) => emitted.has(dep)),
+      gatingDeps(r).every((dep) => emitted.has(dep)),
     );
     if (readyIndex === -1) {
       const stuck = remaining.map((r) => r.name).join(", ");

--- a/src/resources/subscription/client.test.ts
+++ b/src/resources/subscription/client.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { ServerSubscriptionSchema } from "./client.js";
+
+// Shape hand-derived from a real GET /api/environments/{id}/subscriptions/{id}/
+// response (project 806).
+const realSubscription = {
+  id: 67,
+  title: "Weekly report\n\n<!-- iac:subscriptions:weekly iac:hash:abcd1234 -->",
+  insight: 18104,
+  dashboard: null,
+  target_type: "email",
+  target_value: "ops@example.com",
+  frequency: "weekly",
+  interval: 1,
+  start_date: "2026-08-01T00:00:00Z",
+  byweekday: null,
+  bysetpos: null,
+  count: null,
+  until_date: null,
+  enabled: true,
+  integration_id: null,
+  summary_enabled: false,
+  deleted: false,
+  created_at: "2026-07-24T00:00:00Z",
+  created_by: { id: 1, uuid: "u", distinct_id: "d" },
+};
+
+describe("ServerSubscriptionSchema", () => {
+  it("parses a real subscription payload", () => {
+    const parsed = ServerSubscriptionSchema.parse(realSubscription);
+    expect(parsed.id).toBe(67);
+    expect(parsed.target_type).toBe("email");
+    expect(parsed.insight).toBe(18104);
+    expect(parsed.title).toContain("iac:subscriptions:weekly");
+  });
+
+  it("parses a slack subscription with an integration id", () => {
+    const parsed = ServerSubscriptionSchema.parse({
+      ...realSubscription,
+      target_type: "slack",
+      target_value: "#alerts",
+      integration_id: 12,
+    });
+    expect(parsed.target_type).toBe("slack");
+    expect(parsed.integration_id).toBe(12);
+  });
+
+  it("throws when id is missing", () => {
+    const { id: _omit, ...withoutId } = realSubscription;
+    void _omit;
+    expect(() => ServerSubscriptionSchema.parse(withoutId)).toThrow();
+  });
+});

--- a/src/resources/subscription/client.ts
+++ b/src/resources/subscription/client.ts
@@ -1,0 +1,146 @@
+import { z } from "zod";
+import type { ClientConfig } from "../../client/config.js";
+import type { components } from "../../generated/api.js";
+import { createApiClient, followPagination, type Paginated } from "../../client/typed.js";
+
+const MANAGED_TITLE_PREFIX = "<!-- iac:subscriptions:";
+
+export const ServerSubscriptionSchema = z
+  .object({
+    id: z.number(),
+    title: z.string().nullable().default(""),
+    insight: z.number().nullable().optional(),
+    dashboard: z.number().nullable().optional(),
+    target_type: z.enum(["email", "slack"]).optional(),
+    target_value: z.string().optional(),
+    frequency: z.enum(["daily", "weekly", "monthly", "yearly"]).optional(),
+    interval: z.number().nullable().optional(),
+    start_date: z.string().nullable().optional(),
+    byweekday: z.array(z.string()).nullable().optional(),
+    bysetpos: z.number().nullable().optional(),
+    count: z.number().nullable().optional(),
+    until_date: z.string().nullable().optional(),
+    enabled: z.boolean().nullable().optional(),
+    integration_id: z.number().nullable().optional(),
+    summary_enabled: z.boolean().nullable().optional(),
+    summary_prompt_guide: z.string().nullable().optional(),
+    prompt: z.string().nullable().optional(),
+    deleted: z.boolean().nullable().optional(),
+  })
+  .loose();
+
+export type ServerSubscription = z.infer<typeof ServerSubscriptionSchema>;
+
+export type SubscriptionCreate = {
+  title: string;
+  insight?: number | null;
+  dashboard?: number | null;
+  target_type: string;
+  target_value: string;
+  frequency: string;
+  interval?: number;
+  start_date: string;
+  byweekday?: string[] | null;
+  bysetpos?: number | null;
+  count?: number | null;
+  until_date?: string | null;
+  enabled?: boolean;
+  integration_id?: number | null;
+  summary_enabled?: boolean;
+  summary_prompt_guide?: string;
+  prompt?: string | null;
+  /**
+   * Always false from posthog-definitions: `send_test_now` defaults to TRUE on
+   * create (and fires on qualifying updates), which would deliver the
+   * subscription immediately. IaC must never trigger a delivery as a side
+   * effect of apply.
+   */
+  send_test_now: boolean;
+};
+
+export type SubscriptionUpdate = Partial<SubscriptionCreate> & { deleted?: boolean };
+
+type SubscriptionBody = components["schemas"]["Subscription"];
+type PatchedSubscriptionBody = components["schemas"]["PatchedSubscription"];
+type GeneratedPaginatedList = components["schemas"]["PaginatedSubscriptionList"];
+
+function paginatedFrom(raw: GeneratedPaginatedList): Paginated<unknown> {
+  return {
+    count: raw.count,
+    next: raw.next ?? null,
+    previous: raw.previous ?? null,
+    results: raw.results ?? [],
+  };
+}
+
+export async function listSubscriptions(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerSubscription[]> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/subscriptions/", {
+    params: { path: { project_id: config.projectId }, query: { limit: 100 } },
+  });
+  const firstPage = paginatedFrom(data!);
+  const allRaw = await followPagination<unknown>(config, firstPage, { verbose: options.verbose });
+  return allRaw.map((row) => ServerSubscriptionSchema.parse(row));
+}
+
+export async function listManagedSubscriptions(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerSubscription[]> {
+  const all = await listSubscriptions(config, options);
+  return all.filter((row) => (row.title ?? "").includes(MANAGED_TITLE_PREFIX));
+}
+
+export async function getSubscription(
+  config: ClientConfig,
+  id: number,
+  options: { verbose?: boolean } = {},
+): Promise<ServerSubscription> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/subscriptions/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+  });
+  return ServerSubscriptionSchema.parse(data);
+}
+
+export async function createSubscription(
+  config: ClientConfig,
+  payload: SubscriptionCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerSubscription> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.POST("/api/projects/{project_id}/subscriptions/", {
+    params: { path: { project_id: config.projectId } },
+    body: payload as unknown as SubscriptionBody,
+  });
+  return ServerSubscriptionSchema.parse(data);
+}
+
+export async function updateSubscription(
+  config: ClientConfig,
+  id: number,
+  payload: SubscriptionUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerSubscription> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.PATCH("/api/projects/{project_id}/subscriptions/{id}/", {
+    params: { path: { project_id: config.projectId, id } },
+    body: payload as unknown as PatchedSubscriptionBody,
+  });
+  return ServerSubscriptionSchema.parse(data);
+}
+
+/**
+ * Delete a subscription. The DELETE verb is 405; subscriptions soft-delete via
+ * PATCH { deleted: true }.
+ */
+export async function deleteSubscription(
+  config: ClientConfig,
+  id: number,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  await updateSubscription(config, id, { deleted: true }, options);
+}

--- a/src/resources/subscription/codegen.ts
+++ b/src/resources/subscription/codegen.ts
@@ -1,0 +1,95 @@
+import type { ClientConfig } from "../../client/config.js";
+import { renderObject, stringLiteral } from "../../pull/render.js";
+import { slugify } from "../../pull/slug.js";
+import type { PullDependency, PullRenderContext, RenderedFile } from "../../pull/types.js";
+import { type ServerSubscription, updateSubscription } from "./client.js";
+import { stripMarker } from "./pipeline.js";
+import type { Subscription } from "./sdk.js";
+
+const MARKER_PREFIX = "iac:subscriptions:";
+const HASH_MARKER_PREFIX = "iac:hash:";
+
+export function pullFilter(
+  server: ServerSubscription,
+): { kept: true } | { kept: false; reason: string } {
+  if (server.deleted) return { kept: false, reason: "deleted" };
+  return { kept: true };
+}
+
+export function pullLabel(server: ServerSubscription): { primary: string; secondary?: string } {
+  const title = stripMarker(server.title) ?? "(untitled)";
+  return { primary: title.slice(0, 48), secondary: `[${server.frequency ?? "?"} ${server.target_type ?? ""}]` };
+}
+
+export function serverIdOf(server: ServerSubscription): number {
+  return server.id;
+}
+
+export async function pullDependencies(
+  _config: ClientConfig,
+  server: ServerSubscription,
+): Promise<PullDependency[]> {
+  const deps: PullDependency[] = [];
+  if (server.insight != null) deps.push({ resourceName: "insights", serverId: server.insight });
+  if (server.dashboard != null) deps.push({ resourceName: "dashboards", serverId: server.dashboard });
+  return deps;
+}
+
+export function renderToFile(
+  server: ServerSubscription,
+  ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const title = stripMarker(server.title) ?? "";
+  const baseSlug = slugify(title) || `subscription-${server.id}`;
+  const slug = ctx.uniqueSlug(baseSlug);
+
+  const insightImport =
+    server.insight != null ? ctx.importForServerIdOptional("insights", server.insight) : undefined;
+  const dashboardImport =
+    server.dashboard != null
+      ? ctx.importForServerIdOptional("dashboards", server.dashboard)
+      : undefined;
+
+  const fields: Record<string, string> = {
+    key: stringLiteral(slug),
+    title: stringLiteral(title),
+  };
+  if (insightImport) fields.insight = insightImport.varName;
+  if (dashboardImport) fields.dashboard = dashboardImport.varName;
+  if (server.target_type) fields.targetType = stringLiteral(server.target_type);
+  if (server.target_value) fields.target = stringLiteral(server.target_value);
+  if (server.frequency) fields.frequency = stringLiteral(server.frequency);
+  if (server.interval != null && server.interval !== 1) fields.interval = String(server.interval);
+  if (server.start_date) fields.startDate = stringLiteral(server.start_date);
+  if (server.enabled === false) fields.enabled = "false";
+  if (server.integration_id != null) fields.integrationId = String(server.integration_id);
+  if (server.summary_enabled) fields.summaryEnabled = "true";
+
+  const parts: string[] = [`import { subscription } from "@posthog/definitions";`];
+  if (insightImport) {
+    parts.push(`import ${insightImport.varName} from "../insights/${insightImport.filename.replace(/\.ts$/, ".js")}";`);
+  }
+  if (dashboardImport) {
+    parts.push(`import ${dashboardImport.varName} from "../dashboards/${dashboardImport.filename.replace(/\.ts$/, ".js")}";`);
+  }
+  parts.push("");
+  parts.push(`export default subscription(${renderObject(fields, 2)});`);
+  parts.push("");
+
+  return { filename: `${slug}.ts`, contents: parts.join("\n"), specKey: slug };
+}
+
+export async function tagOnServer(
+  config: ClientConfig,
+  server: ServerSubscription,
+  spec: Subscription,
+  hash: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const userTitle = stripMarker(server.title) ?? "";
+  const marker = `<!-- ${MARKER_PREFIX}${spec.key} ${HASH_MARKER_PREFIX}${hash} -->`;
+  const newTitle = userTitle ? `${userTitle}\n\n${marker}` : marker;
+  // send_test_now:false — a title-only edit doesn't trigger delivery, but never
+  // rely on that default.
+  await updateSubscription(config, server.id, { title: newTitle, send_test_now: false }, options);
+}

--- a/src/resources/subscription/index.ts
+++ b/src/resources/subscription/index.ts
@@ -1,0 +1,65 @@
+import type { ApplyContext, CollectionResourceModule } from "../types.js";
+import { insightResource } from "../insight/index.js";
+import { dashboardResource } from "../dashboard/index.js";
+import type { Subscription } from "./sdk.js";
+import {
+  SUBSCRIPTION_IDENTITY_PREFIX,
+  subscriptionHash,
+  subscriptionHashFromServer,
+  subscriptionKeyFromServer,
+  displaySubscription,
+  displaySubscriptionFromServer,
+  looksLikeSubscription,
+  pruneSubscription,
+  runSubscriptionOp,
+  validateSubscriptions,
+} from "./pipeline.js";
+import {
+  getSubscription,
+  listSubscriptions,
+  listManagedSubscriptions,
+  type ServerSubscription,
+} from "./client.js";
+import {
+  pullDependencies,
+  pullFilter,
+  pullLabel,
+  renderToFile,
+  serverIdOf,
+  tagOnServer,
+} from "./codegen.js";
+
+export { subscription } from "./sdk.js";
+export type { Subscription, SubscriptionTargetType, SubscriptionFrequency } from "./sdk.js";
+
+export const subscriptionResource: CollectionResourceModule<Subscription, ServerSubscription> = {
+  kind: "collection",
+  name: "subscriptions",
+  displayName: "subscription",
+  identityPrefix: SUBSCRIPTION_IDENTITY_PREFIX,
+  dependsOn: [insightResource, dashboardResource],
+
+  isSpec: looksLikeSubscription,
+  specKey: (spec) => spec.key,
+
+  list: listManagedSubscriptions,
+  keyFromServer: (server) => subscriptionKeyFromServer(server),
+  hashFromServer: (server) => subscriptionHashFromServer(server),
+
+  hash: subscriptionHash,
+  validate: (specs, state) => validateSubscriptions(specs, state),
+  executeOp: runSubscriptionOp,
+  prune: pruneSubscription,
+
+  displaySpec: (spec, _ctx: ApplyContext) => displaySubscription(spec),
+  displayServer: (server, ctx: ApplyContext) => displaySubscriptionFromServer(server, ctx),
+
+  listAll: listSubscriptions,
+  getById: (config, id, options) => getSubscription(config, Number(id), options),
+  pullFilter,
+  pullLabel,
+  serverIdOf,
+  pullDependencies,
+  renderToFile,
+  tagOnServer,
+};

--- a/src/resources/subscription/pipeline.test.ts
+++ b/src/resources/subscription/pipeline.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { diff } from "../../apply/diff.js";
+import type { DesiredState } from "../types.js";
+import type { Subscription } from "./sdk.js";
+import type { Insight } from "../insight/sdk.js";
+import type { ServerSubscription } from "./client.js";
+import { subscriptionHash, validateSubscriptions } from "./pipeline.js";
+
+const insightRef = { key: "signups" } as Insight;
+
+function spec(key: string, overrides: Partial<Subscription> = {}): Subscription {
+  return {
+    key,
+    title: `Weekly ${key}`,
+    insight: insightRef,
+    targetType: "email",
+    target: "ops@example.com",
+    frequency: "weekly",
+    startDate: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function serverRow(id: number, key: string, hash: string, extraTitle = "Weekly"): ServerSubscription {
+  const marker = `<!-- iac:subscriptions:${key} iac:hash:${hash} -->`;
+  return {
+    id,
+    title: `${extraTitle}\n\n${marker}`,
+    insight: 100,
+    target_type: "email",
+    target_value: "ops@example.com",
+    frequency: "weekly",
+    start_date: "2026-08-01T00:00:00Z",
+  };
+}
+
+function desiredFor(specs: Subscription[]): DesiredState {
+  const state: DesiredState = new Map();
+  state.set(
+    "subscriptions",
+    specs.map((spec) => ({ path: "<test>", spec })),
+  );
+  return state;
+}
+
+function currentFor(rows: ServerSubscription[]): Map<string, unknown[]> {
+  return new Map<string, unknown[]>([["subscriptions", rows]]);
+}
+
+describe("subscription pipeline", () => {
+  it("emits create when desired has no matching server row", () => {
+    const slice = diff(desiredFor([spec("s1")]), currentFor([])).get("subscriptions")!;
+    expect(slice.ops[0]!.kind).toBe("create");
+  });
+
+  it("emits unchanged when server hash matches", () => {
+    const desired = spec("s1");
+    const op = diff(
+      desiredFor([desired]),
+      currentFor([serverRow(1, "s1", subscriptionHash(desired), "Weekly s1")]),
+    ).get("subscriptions")!.ops[0]!;
+    expect(op.kind).toBe("unchanged");
+  });
+
+  it("emits update when server hash differs", () => {
+    const op = diff(
+      desiredFor([spec("s1")]),
+      currentFor([serverRow(1, "s1", "stale00000000")]),
+    ).get("subscriptions")!.ops[0]!;
+    expect(op.kind).toBe("update");
+  });
+
+  it("hash changes when the delivery target or frequency changes", () => {
+    expect(subscriptionHash(spec("s"))).not.toBe(
+      subscriptionHash(spec("s", { target: "other@example.com" })),
+    );
+    expect(subscriptionHash(spec("s"))).not.toBe(subscriptionHash(spec("s", { frequency: "daily" })));
+  });
+
+  it("classifies a server-only managed subscription as an orphan", () => {
+    const slice = diff(desiredFor([]), currentFor([serverRow(9, "ghost", "any")])).get(
+      "subscriptions",
+    )!;
+    expect(slice.orphans.length).toBe(1);
+  });
+
+  it("safety invariant: ignores server rows without the identity marker", () => {
+    const handBuilt: ServerSubscription = {
+      id: 99,
+      title: "A subscription set up in the UI",
+      insight: 5,
+      target_type: "email",
+      target_value: "someone@example.com",
+      frequency: "daily",
+    };
+    const slice = diff(desiredFor([]), currentFor([handBuilt])).get("subscriptions")!;
+    expect(slice.ops.length).toBe(0);
+    expect(slice.orphans.length).toBe(0);
+  });
+});
+
+describe("subscription validation", () => {
+  const state: DesiredState = new Map([
+    ["insights", [{ path: "<t>", spec: { key: "signups" } }]],
+    ["dashboards", [{ path: "<t>", spec: { key: "growth" } }]],
+  ]);
+
+  it("requires exactly one of insight/dashboard (neither)", () => {
+    const issues = validateSubscriptions(
+      [spec("s", { insight: undefined })],
+      state,
+    );
+    expect(issues.some((m) => m.includes("exactly one of"))).toBeTruthy();
+  });
+
+  it("requires exactly one of insight/dashboard (both)", () => {
+    const issues = validateSubscriptions(
+      [spec("s", { dashboard: { key: "growth" } as Subscription["dashboard"] })],
+      state,
+    );
+    expect(issues.some((m) => m.includes("exactly one of"))).toBeTruthy();
+  });
+
+  it("rejects a reference not declared in the same run", () => {
+    const issues = validateSubscriptions(
+      [spec("s", { insight: { key: "nope" } as Insight })],
+      state,
+    );
+    expect(issues.some((m) => m.includes("unknown insight"))).toBeTruthy();
+  });
+
+  it("rejects a title that, with the identity marker, exceeds the 100-char cap", () => {
+    const longTitle = "A".repeat(60); // 60 + key + ~55 marker overhead > 100
+    const issues = validateSubscriptions([spec("s", { title: longTitle })], state);
+    expect(issues.some((m) => m.includes("title is too long"))).toBeTruthy();
+  });
+
+  it("accepts a valid insight-scoped subscription", () => {
+    expect(validateSubscriptions([spec("ok")], state)).toEqual([]);
+  });
+});

--- a/src/resources/subscription/pipeline.ts
+++ b/src/resources/subscription/pipeline.ts
@@ -1,0 +1,284 @@
+import type { ClientConfig } from "../../client/config.js";
+import { ApiError } from "../../client/typed.js";
+import { specHash } from "../../apply/hash.js";
+import { obj, scalar, type DisplayValue } from "../../apply/display.js";
+import { SafetyViolationError } from "../../apply/errors.js";
+import { getResourceKind, type ApplyContext, type DesiredState, type ResourceOp } from "../types.js";
+import type { Insight } from "../insight/sdk.js";
+import type { Dashboard } from "../dashboard/sdk.js";
+import type { Subscription } from "./sdk.js";
+import {
+  createSubscription,
+  deleteSubscription,
+  getSubscription,
+  type ServerSubscription,
+  type SubscriptionCreate,
+  updateSubscription,
+} from "./client.js";
+
+export const SUBSCRIPTION_IDENTITY_PREFIX = "iac:subscriptions:";
+
+const MARKER_REGEX = /\n*<!--\s*iac:subscriptions:(\S+)\s+iac:hash:(\S+)\s*-->\s*$/;
+const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+type ParsedMarker = { userTitle: string; key: string; hash: string };
+
+function parseMarker(title: string | null | undefined): ParsedMarker | undefined {
+  if (!title) return undefined;
+  const match = title.match(MARKER_REGEX);
+  if (!match || match.index === undefined) return undefined;
+  return {
+    userTitle: title.slice(0, match.index).replace(/\s+$/, ""),
+    key: match[1]!,
+    hash: match[2]!,
+  };
+}
+
+function withMarker(userTitle: string, key: string, hash: string): string {
+  const trailer = `<!-- iac:subscriptions:${key} iac:hash:${hash} -->`;
+  const trimmed = userTitle.replace(/\s+$/, "");
+  return trimmed ? `${trimmed}\n\n${trailer}` : trailer;
+}
+
+export function stripMarker(title: string | null | undefined): string | null {
+  if (!title) return null;
+  const parsed = parseMarker(title);
+  return parsed ? parsed.userTitle || null : title;
+}
+
+export function subscriptionKeyFromServer(server: ServerSubscription): string | undefined {
+  return parseMarker(server.title)?.key;
+}
+
+export function subscriptionHashFromServer(server: ServerSubscription): string | undefined {
+  return parseMarker(server.title)?.hash;
+}
+
+function specForHash(spec: Subscription): unknown {
+  return {
+    key: spec.key,
+    title: spec.title,
+    insight_key: spec.insight?.key ?? null,
+    dashboard_key: spec.dashboard?.key ?? null,
+    target_type: spec.targetType,
+    target_value: spec.target,
+    frequency: spec.frequency,
+    interval: spec.interval ?? 1,
+    start_date: spec.startDate,
+    byweekday: spec.byweekday ?? null,
+    bysetpos: spec.bysetpos ?? null,
+    count: spec.count ?? null,
+    until_date: spec.untilDate ?? null,
+    enabled: spec.enabled ?? true,
+    integration_id: spec.integrationId ?? null,
+    summary_enabled: spec.summaryEnabled ?? null,
+    summary_prompt_guide: spec.summaryPromptGuide ?? null,
+    prompt: spec.prompt ?? null,
+  };
+}
+
+export function subscriptionHash(spec: Subscription): string {
+  return specHash(specForHash(spec));
+}
+
+function buildPayload(spec: Subscription, hash: string, ctx: ApplyContext): SubscriptionCreate {
+  const payload: SubscriptionCreate = {
+    title: withMarker(spec.title, spec.key, hash),
+    target_type: spec.targetType,
+    target_value: spec.target,
+    frequency: spec.frequency,
+    start_date: spec.startDate,
+    interval: spec.interval ?? 1,
+    enabled: spec.enabled ?? true,
+    // Never deliver as a side effect of apply (defaults to true otherwise).
+    send_test_now: false,
+  };
+  if (spec.insight) {
+    const id = ctx.insightIdByKey.get(spec.insight.key);
+    if (id === undefined) {
+      throw new Error(
+        `subscription "${spec.key}" references insight "${spec.insight.key}" but no server id is known. Insights must run before subscriptions.`,
+      );
+    }
+    payload.insight = id;
+  }
+  if (spec.dashboard) {
+    const id = ctx.dashboardIdByKey.get(spec.dashboard.key);
+    if (id === undefined) {
+      throw new Error(
+        `subscription "${spec.key}" references dashboard "${spec.dashboard.key}" but no server id is known. Dashboards must run before subscriptions.`,
+      );
+    }
+    payload.dashboard = id;
+  }
+  if (spec.byweekday !== undefined) payload.byweekday = spec.byweekday;
+  if (spec.bysetpos !== undefined) payload.bysetpos = spec.bysetpos;
+  if (spec.count !== undefined) payload.count = spec.count;
+  if (spec.untilDate !== undefined) payload.until_date = spec.untilDate;
+  if (spec.integrationId !== undefined) payload.integration_id = spec.integrationId;
+  if (spec.summaryEnabled !== undefined) payload.summary_enabled = spec.summaryEnabled;
+  if (spec.summaryPromptGuide !== undefined) payload.summary_prompt_guide = spec.summaryPromptGuide;
+  if (spec.prompt !== undefined) payload.prompt = spec.prompt;
+  return payload;
+}
+
+export function looksLikeSubscription(value: unknown): value is Subscription {
+  return getResourceKind(value) === "subscription";
+}
+
+export function validateSubscriptions(specs: Subscription[], state: DesiredState): string[] {
+  const issues: string[] = [];
+  const seenKeys = new Set<string>();
+
+  const knownInsightKeys = new Set<string>();
+  for (const loaded of state.get("insights") ?? []) {
+    const insight = loaded.spec as Insight;
+    if (insight?.key) knownInsightKeys.add(insight.key);
+  }
+  const knownDashboardKeys = new Set<string>();
+  for (const loaded of state.get("dashboards") ?? []) {
+    const dashboard = loaded.spec as Dashboard;
+    if (dashboard?.key) knownDashboardKeys.add(dashboard.key);
+  }
+
+  for (const spec of specs) {
+    if (!spec.key) {
+      issues.push("subscription.key is required");
+      continue;
+    }
+    if (!KEY_PATTERN.test(spec.key)) {
+      issues.push(`subscription "${spec.key}" key must match ${KEY_PATTERN.source}`);
+    }
+    if (seenKeys.has(spec.key)) issues.push(`Duplicate subscription key "${spec.key}"`);
+    seenKeys.add(spec.key);
+
+    if (!spec.title || spec.title.trim() === "") {
+      issues.push(`subscription "${spec.key}" title is required (it carries the identity marker)`);
+    } else {
+      // The server caps `title` at 100 chars, and the title also carries the
+      // identity+hash marker. Fail here with an actionable message rather than
+      // let apply hit a 400. Effective budget: title + key length <= ~45.
+      const withMarkerLen = withMarker(spec.title, spec.key, subscriptionHash(spec)).length;
+      if (withMarkerLen > 100) {
+        issues.push(
+          `subscription "${spec.key}" title is too long: title + identity marker is ${withMarkerLen} chars but the server caps \`title\` at 100. Shorten the title (or key) — the budget is roughly 45 minus the key length.`,
+        );
+      }
+    }
+    if (!spec.target || spec.target.trim() === "") {
+      issues.push(`subscription "${spec.key}" target is required`);
+    }
+    if (!spec.startDate) issues.push(`subscription "${spec.key}" startDate is required`);
+
+    const hasInsight = Boolean(spec.insight);
+    const hasDashboard = Boolean(spec.dashboard);
+    if (hasInsight === hasDashboard) {
+      issues.push(
+        `subscription "${spec.key}" must reference exactly one of \`insight\` or \`dashboard\``,
+      );
+    }
+    if (hasInsight && !knownInsightKeys.has(spec.insight!.key)) {
+      issues.push(
+        `subscription "${spec.key}" references unknown insight "${spec.insight!.key}" — declare it in the same run`,
+      );
+    }
+    if (hasDashboard && !knownDashboardKeys.has(spec.dashboard!.key)) {
+      issues.push(
+        `subscription "${spec.key}" references unknown dashboard "${spec.dashboard!.key}" — declare it in the same run`,
+      );
+    }
+  }
+  return issues;
+}
+
+async function assertManaged(
+  config: ClientConfig,
+  id: number,
+  key: string,
+  options: { verbose?: boolean },
+): Promise<void> {
+  const current = await getSubscription(config, id, options);
+  if (subscriptionKeyFromServer(current) !== key) {
+    throw new SafetyViolationError("subscription", id, key);
+  }
+}
+
+export async function runSubscriptionOp(
+  config: ClientConfig,
+  op: ResourceOp<Subscription, ServerSubscription>,
+  ctx: ApplyContext,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+
+  const payload = buildPayload(op.spec, subscriptionHash(op.spec), ctx);
+
+  if (op.kind === "create") {
+    await createSubscription(config, payload, options);
+    return;
+  }
+
+  await assertManaged(config, op.server.id, op.spec.key, options);
+  await updateSubscription(config, op.server.id, payload, options);
+}
+
+export async function pruneSubscription(
+  config: ClientConfig,
+  orphan: ServerSubscription,
+  options: { verbose?: boolean } = {},
+): Promise<boolean> {
+  const key = subscriptionKeyFromServer(orphan) ?? `id:${orphan.id}`;
+  try {
+    await assertManaged(config, orphan.id, key, options);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return false;
+    throw err;
+  }
+  await deleteSubscription(config, orphan.id, options);
+  return true;
+}
+
+export function displaySubscription(spec: Subscription): DisplayValue {
+  return obj([
+    ["key", scalar(spec.key)],
+    ["title", scalar(spec.title)],
+    ["insight", scalar(spec.insight?.key ?? null)],
+    ["dashboard", scalar(spec.dashboard?.key ?? null)],
+    ["target_type", scalar(spec.targetType)],
+    ["target", scalar(spec.target)],
+    ["frequency", scalar(spec.frequency)],
+    ["interval", scalar(spec.interval ?? 1)],
+    ["start_date", scalar(spec.startDate)],
+    ["enabled", scalar(spec.enabled ?? true)],
+    ["integration_id", scalar(spec.integrationId ?? null)],
+    ["summary_enabled", scalar(spec.summaryEnabled ?? null)],
+  ]);
+}
+
+export function displaySubscriptionFromServer(
+  server: ServerSubscription,
+  ctx: ApplyContext,
+): DisplayValue {
+  const insightKey =
+    server.insight != null
+      ? (ctx.insightKeyByServerId.get(server.insight) ?? `id:${server.insight}`)
+      : null;
+  const dashboardKey =
+    server.dashboard != null
+      ? (ctx.dashboardKeyByServerId.get(server.dashboard) ?? `id:${server.dashboard}`)
+      : null;
+  return obj([
+    ["key", scalar(subscriptionKeyFromServer(server) ?? null)],
+    ["title", scalar(stripMarker(server.title))],
+    ["insight", scalar(insightKey)],
+    ["dashboard", scalar(dashboardKey)],
+    ["target_type", scalar(server.target_type ?? null)],
+    ["target", scalar(server.target_value ?? null)],
+    ["frequency", scalar(server.frequency ?? null)],
+    ["interval", scalar(server.interval ?? 1)],
+    ["start_date", scalar(server.start_date ?? null)],
+    ["enabled", scalar(server.enabled ?? true)],
+    ["integration_id", scalar(server.integration_id ?? null)],
+    ["summary_enabled", scalar(server.summary_enabled ?? null)],
+  ]);
+}

--- a/src/resources/subscription/sdk.ts
+++ b/src/resources/subscription/sdk.ts
@@ -1,0 +1,58 @@
+import { markResourceKind } from "../types.js";
+import type { Insight } from "../insight/sdk.js";
+import type { Dashboard } from "../dashboard/sdk.js";
+
+export type SubscriptionTargetType = "email" | "slack";
+export type SubscriptionFrequency = "daily" | "weekly" | "monthly" | "yearly";
+
+export type Subscription = {
+  key: string;
+  /**
+   * Human-readable subscription title. Also carries the identity marker (a
+   * trailing HTML comment), the way endpoints/surveys carry identity in a
+   * free-text field.
+   */
+  title: string;
+  /** The insight this subscription delivers. Declare exactly one of `insight` / `dashboard`. */
+  insight?: Insight;
+  /** The dashboard this subscription delivers. Declare exactly one of `insight` / `dashboard`. */
+  dashboard?: Dashboard;
+  /** Delivery channel. */
+  targetType: SubscriptionTargetType;
+  /**
+   * Recipient(s): comma-separated email addresses for `email`, or a Slack
+   * channel name/ID for `slack`.
+   *
+   * Side effect: applying an email subscription **invites the recipients**
+   * (PostHog emails them). Use real addresses only when you intend that.
+   */
+  target: string;
+  frequency: SubscriptionFrequency;
+  /** Every `interval` periods (e.g. every 2 weeks). Defaults to 1. */
+  interval?: number;
+  /** ISO 8601 datetime the schedule anchors to. */
+  startDate: string;
+  /** Recurrence: weekday indices for weekly/monthly schedules. */
+  byweekday?: string[];
+  bysetpos?: number;
+  count?: number;
+  untilDate?: string;
+  enabled?: boolean;
+  /**
+   * Slack integration id for `slack` targets. **Environment-specific** — the
+   * id is per-project and does not port across projects. It round-trips and is
+   * part of the hash; note the non-portability when copying definitions between
+   * projects.
+   */
+  integrationId?: number;
+  /** Attach an AI-generated summary to each delivery. */
+  summaryEnabled?: boolean;
+  /** Free-text guidance for the AI summary. */
+  summaryPromptGuide?: string;
+  /** Free-text prompt for an AI-only subscription. */
+  prompt?: string;
+};
+
+export function subscription(spec: Subscription): Subscription {
+  return markResourceKind(spec, "subscription");
+}

--- a/src/resources/types.ts
+++ b/src/resources/types.ts
@@ -69,6 +69,10 @@ export type ApplyContext = {
   insightIdByKey: Map<string, number>;
   /** Inverse of insightIdByKey; populated when displaying server-side dashboard tiles so we can show keys rather than ids. */
   insightKeyByServerId: Map<number, string>;
+  /** Dashboard server id by spec key. Populated by the dashboard module's executor; read by resources that reference a dashboard by key (annotations, subscriptions). */
+  dashboardIdByKey: Map<string, number>;
+  /** Inverse of dashboardIdByKey; populated for display so dashboard references render as keys rather than opaque ids. */
+  dashboardKeyByServerId: Map<number, string>;
   /** Property-group server id by spec key. Populated by the property-group module's executor; read by the event-definition module to reconcile EventSchema links. */
   propertyGroupIdByKey: Map<string, string>;
   /** Experiment-holdout server id by spec key. Populated by the experiment-holdout module's executor; read by the experiment module's resolver. */
@@ -81,6 +85,8 @@ export function newApplyContext(): ApplyContext {
   return {
     insightIdByKey: new Map(),
     insightKeyByServerId: new Map(),
+    dashboardIdByKey: new Map(),
+    dashboardKeyByServerId: new Map(),
     propertyGroupIdByKey: new Map(),
     experimentHoldoutIdByKey: new Map(),
     experimentSavedMetricIdByKey: new Map(),


### PR DESCRIPTION
Adds **subscriptions** (scheduled insight/dashboard delivery) — second of the two Wave 2 greenlit resources.

## Identity
Title-marker pattern (`iac:subscriptions:<key>` in `title`) as designed. A subscription references **exactly one** insight or dashboard by key (resolved to an id at execute time; validation enforces exactly-one + same-run declaration). Email/Slack targets, recurrence, and AI-summary fields round-trip as plain fields.

## Delivery safety (your warning — handled + verified)
`send_test_now` **defaults to `true`** on the API and delivers immediately on save. The client **forces it `false`** on every create, update, and the pull tag-back — apply never delivers as a side effect. **Live-verified the deliveries list stayed empty (count 0)** across create and update. Note: applying an *email* subscription still **invites its recipients** (inherent product behavior) — verification used `example.com` throwaways; documented in the SDK.

## ⚠️ Surprise / constraint — please sanity-check
The server caps `title` at **100 chars**, and `title` also carries the identity+hash marker (~53 + key length). **Effective budget: `title` + `key` ≲ 45.** Other free-text fields aren't viable carriers (`prompt` is mutually exclusive with insight/dashboard; `invite_message` is email-only and user-facing; `summary_prompt_guide` is AI-only). I didn't catch this in the identity investigation (used short values). It's **not silent loss** — validation now fails fast with an actionable message when title+marker would exceed 100 (pre-empting the API 400) — but it's a real usability limit on title length. Flagging in case you'd rather revisit the carrier; the resource is fully functional for normal-length titles.

Because a STAMP-length smoke key can't round-trip through pull within that budget, **subscriptions are excluded from the smoke seed** (like singletons, with a header note) and verified in isolation.

## Shared infra (dedupe with #94)
This branch reintroduces two commits identical to the annotations PR (#94): `feat(apply): expose dashboard ids by key in ApplyContext` (needed for dashboard refs) and `fix(pull): tolerate dependency kinds absent from a --kind subset`. If both merge, they dedupe trivially.

## Live verification (project 806)
create → no-op re-apply (hash projection correct) → edit → single update → cross-resource ref (insight resolved to id) → orphan left alone → hand-built subscription (no marker) untouched → kind-scoped prune deletes managed only. Delete is soft-delete via PATCH `{deleted:true}` (DELETE → 405).

Scope: `subscription:read` / `subscription:write` (+ `insight:*` / `dashboard:*`). Gates green (typecheck / typecheck:examples / test 307 / lint).

---

Stacks on #81 (base `pl/spec-migration`). Retarget to `main` when #81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)