### PR TITLE
feat(logs-view): manage logs saved views as code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Alpha — do not use in production.**
 > This is pre-MVP software (`0.1.0-alpha.0`). The CLI, the on-disk file format, the SDK surface, and the tag-based identity model are all subject to breaking changes without notice. Use it on throwaway projects or in a sandbox while we stabilize.
 
-Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, and experiment saved metrics in TypeScript, then sync them to a PostHog project with one command.
+Infrastructure-as-code for PostHog. Define dashboards, insights, feature flags, actions, endpoints, event definitions, property groups, experiments, experiment holdouts, experiment saved metrics, and logs views in TypeScript, then sync them to a PostHog project with one command.
 
 ## Why
 
@@ -51,6 +51,7 @@ export default dashboard({
    - `event_definition:read`, `event_definition:write` (also covers property groups)
    - `experiment:read`, `experiment:write` (also covers experiment holdouts)
    - `experiment_saved_metric:read`, `experiment_saved_metric:write`
+   - `logs:read`, `logs:write` (logs views)
 
    Then add it (and your numeric project ID) to a `.env` (or `.envrc`) file:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -80,6 +80,18 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 | Spike detection config | ✅ `environments/{id}/error_tracking/spike_detection_config` | ❌                  |       |
 | Settings               | ✅ `environments/{id}/error_tracking/settings`               | ❌                  |       |
 
+## Logs
+
+Rows added ahead of the full matrix refresh (#78). See the parity plan for the
+Wave-2 logs verdicts.
+
+| Resource        | PostHog API                          | posthog-definitions | Notes                                                                                                                                                            |
+| --------------- | ------------------------------------ | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Logs views      | ✅ `projects/{id}/logs/views`        | ✅                  | Identity via `iac:logs-views:<key>` marker in `name` (subscriptions pattern). Addressed by server `short_id`. `filters`/`columns`/`pinned` round-trip; real PATCH + real DELETE. |
+| Logs sampling rules | ✅ `projects/{id}/logs/sampling_rules` | ❌              | Order-sensitive (`priority`, first-match-wins) — buildable.                                                                                                       |
+| Logs metric rules | ✅ `projects/{id}/logs/metric_rules` | ❌                 | Gated behind org feature flag `logs-metric-rules`.                                                                                                                |
+| Logs alerts     | ✅ `projects/{id}/logs/alerts`       | ❌                  | Deferred — `name`-only carrier is notification-facing; destinations are an unreadable imperative subresource.                                                     |
+
 ## Project & org configuration
 
 | Resource                | PostHog API                                    | posthog-definitions | Notes                              |
@@ -96,7 +108,7 @@ Source of truth for the API column: registered viewsets in [`posthog/posthog/api
 
 ## Summary
 
-Currently shipped: **12 resource types** — Dashboards, Insights, Feature flags, Endpoints, Schema property groups, Event definitions, Experiments, Experiment holdouts, Experiment saved metrics, Project settings, Cohorts, and Actions. Event definitions and property groups together feed `createTypedPostHog`, which wraps any `posthog-js`-shaped client and type-checks `.capture(name, properties)` at compile time against the same specs synced via `apply`. Experiments are declarative across the full lifecycle (draft / running / paused / stopped) — apply drives the launch / pause / resume / end transitions to match. Project settings is the first singleton resource: declared as one block, field-level diff against the live row, declared-only PATCH. Cohorts run before feature flags in the apply order, leaving the door open for cohort-by-key references inside flag conditions.
+Currently shipped: **13 resource types** — Dashboards, Insights, Feature flags, Endpoints, Schema property groups, Event definitions, Experiments, Experiment holdouts, Experiment saved metrics, Project settings, Cohorts, Actions, and Logs views. Event definitions and property groups together feed `createTypedPostHog`, which wraps any `posthog-js`-shaped client and type-checks `.capture(name, properties)` at compile time against the same specs synced via `apply`. Experiments are declarative across the full lifecycle (draft / running / paused / stopped) — apply drives the launch / pause / resume / end transitions to match. Project settings is the first singleton resource: declared as one block, field-level diff against the live row, declared-only PATCH. Cohorts run before feature flags in the apply order, leaving the door open for cohort-by-key references inside flag conditions.
 
 Reasonable IaC targets across the API surface: **~25–30** (cohorts, actions, surveys, annotations, alerts, hog functions/flows, error-tracking rules, warehouse queries, batch exports, …).
 

--- a/examples/posthog/logs-views/api_errors.ts
+++ b/examples/posthog/logs-views/api_errors.ts
@@ -1,0 +1,20 @@
+import { logsView } from "../../../src/index.js";
+
+// The saved view on-call opens first: errors and fatals from the API service,
+// with a custom column pulling the request path out of the log attributes so
+// you can eyeball which endpoint is angry without expanding every row.
+export default logsView({
+  key: "api_errors",
+  name: "API errors",
+  filters: {
+    severityLevels: ["error", "fatal"],
+    serviceNames: ["api"],
+  },
+  columns: [
+    { id: "ts", type: "timestamp" },
+    { id: "lvl", type: "level" },
+    { id: "route", type: "custom", name: "route", expression: "attributes.http.route" },
+    { id: "msg", type: "message" },
+  ],
+  pinned: true,
+});

--- a/examples/posthog/logs-views/billing_warnings.ts
+++ b/examples/posthog/logs-views/billing_warnings.ts
@@ -1,0 +1,19 @@
+import { logsView } from "../../../src/index.js";
+
+// Anything the billing worker grumbles about — warnings and up. Not pinned:
+// finance only goes looking after a customer complains, so it lives in the
+// saved-views list rather than the sidebar.
+export default logsView({
+  key: "billing_warnings",
+  name: "Billing worker warnings",
+  filters: {
+    severityLevels: ["warn", "error", "fatal"],
+    serviceNames: ["billing-worker"],
+    searchTerm: "invoice",
+  },
+  columns: [
+    { id: "ts", type: "timestamp" },
+    { id: "lvl", type: "level" },
+    { id: "msg", type: "message" },
+  ],
+});

--- a/openapi-filter.yaml
+++ b/openapi-filter.yaml
@@ -86,6 +86,13 @@ inverseOperationIds:
   - actions_partial_update
   - actions_destroy
 
+  - logs_views_list
+  - logs_views_create
+  - logs_views_retrieve
+  - logs_views_update
+  - logs_views_partial_update
+  - logs_views_destroy
+
 unusedComponents:
   - schemas
   - parameters

--- a/scripts/smoke-cleanup.ts
+++ b/scripts/smoke-cleanup.ts
@@ -82,6 +82,12 @@ import {
   pruneAction,
 } from "../src/resources/action/pipeline.js";
 
+import { listManagedLogsViews } from "../src/resources/logs-view/client.js";
+import {
+  logsViewKeyFromServer,
+  pruneLogsView,
+} from "../src/resources/logs-view/pipeline.js";
+
 import type { ClientConfig } from "../src/client/config.js";
 
 type Args = {
@@ -96,6 +102,7 @@ type Args = {
   "property-group"?: string;
   cohort?: string;
   endpoint?: string;
+  "logs-view"?: string;
 };
 
 const ARG_KEYS: Array<keyof Args> = [
@@ -110,6 +117,7 @@ const ARG_KEYS: Array<keyof Args> = [
   "property-group",
   "cohort",
   "endpoint",
+  "logs-view",
 ];
 
 function parseArgs(argv: string[]): Args {
@@ -268,6 +276,16 @@ async function main(): Promise<void> {
       listManagedEndpoints,
       (row) => endpointKeyFromServer(row),
       (c, row) => pruneEndpoint(c, row),
+    );
+  }
+  if (args["logs-view"]) {
+    await deleteByKey(
+      "logs-view",
+      args["logs-view"],
+      config,
+      listManagedLogsViews,
+      (row) => logsViewKeyFromServer(row),
+      (c, row) => pruneLogsView(c, row),
     );
   }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -63,6 +63,7 @@ SAVED_METRIC_KEY="smoke-metric-${STAMP}"
 EXPERIMENT_KEY="smoke-experiment-${STAMP}"
 COHORT_KEY="smoke-cohort-${STAMP}"
 ENDPOINT_KEY="smoke-endpoint-${STAMP}"
+LOGS_VIEW_KEY="smoke-logs-view-${STAMP}"
 
 # Names that round-trip cleanly through pull's slug-from-name. We use the
 # event-definition `name` as both the spec key AND the on-the-wire event
@@ -71,7 +72,7 @@ EVENT_NAME="${EVENT_DEFINITION_KEY}"
 
 # Resource kinds we'll seed and pull. Used both in --kind for pull and in
 # the no-op assertion's filter (we don't want unrelated kinds dirtying it).
-SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints"
+SMOKE_KINDS="insights,dashboards,property-groups,event-definitions,actions,feature-flags,experiment-holdouts,experiment-saved-metrics,experiments,cohorts,endpoints,logs-views"
 
 cleanup() {
   echo
@@ -88,6 +89,7 @@ cleanup() {
     "--property-group=${PROPERTY_GROUP_KEY}" \
     "--cohort=${COHORT_KEY}" \
     "--endpoint=${ENDPOINT_KEY}" \
+    "--logs-view=${LOGS_VIEW_KEY}" \
     || echo "smoke: cleanup hit an error (continuing)"
   echo "smoke: removing workdir $WORK_DIR"
   rm -rf "$WORK_DIR"
@@ -153,7 +155,8 @@ mkdir -p \
   "$SEED_DIR/experiment-saved-metrics" \
   "$SEED_DIR/experiments" \
   "$SEED_DIR/cohorts" \
-  "$SEED_DIR/endpoints"
+  "$SEED_DIR/endpoints" \
+  "$SEED_DIR/logs-views"
 
 # Insight — referenced by the dashboard tile below.
 cat > "$SEED_DIR/insights/smoke-insight.ts" <<EOF
@@ -306,6 +309,20 @@ export default endpoint({
   key: "${ENDPOINT_KEY}",
   name: "${ENDPOINT_KEY}",
   query: { kind: "HogQLQuery", query: "select 1 as smoke" },
+});
+EOF
+
+# Logs view — standalone; identity marker rides in \`name\`.
+cat > "$SEED_DIR/logs-views/smoke-logs-view.ts" <<EOF
+import { logsView } from "@posthog/definitions";
+export default logsView({
+  key: "${LOGS_VIEW_KEY}",
+  name: "${LOGS_VIEW_KEY}",
+  filters: { severityLevels: ["error"], serviceNames: ["api"] },
+  columns: [
+    { id: "ts", type: "timestamp" },
+    { id: "msg", type: "message" },
+  ],
 });
 EOF
 

--- a/src/generated/api.d.ts
+++ b/src/generated/api.d.ts
@@ -616,6 +616,38 @@ export interface paths {
         patch: operations["insights_partial_update"];
         trace?: never;
     };
+    "/api/projects/{project_id}/logs/views/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["logs_views_list"];
+        put?: never;
+        post: operations["logs_views_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/logs/views/{short_id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["logs_views_retrieve"];
+        put: operations["logs_views_update"];
+        post?: never;
+        delete: operations["logs_views_destroy"];
+        options?: never;
+        head?: never;
+        patch: operations["logs_views_partial_update"];
+        trace?: never;
+    };
     "/api/projects/{project_id}/schema_property_groups/": {
         parameters: {
             query?: never;
@@ -9351,6 +9383,57 @@ export interface components {
          * @enum {string}
          */
         LogPropertyFilterType: "log" | "log_attribute" | "log_resource_attribute";
+        LogsView: {
+            /** Format: uuid */
+            readonly id: string;
+            readonly short_id: string;
+            name: string;
+            /** @description Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys. */
+            filters?: {
+                [key: string]: unknown;
+            };
+            /** @description Ordered column configuration for the logs table (LogsColumnConfig[]). Order is array index. Null means the view has no column preference and the client renders its default column set. Omitting the field on update leaves the saved configuration unchanged; send null to clear it. */
+            columns?: components["schemas"]["LogsViewColumn"][] | null;
+            pinned?: boolean;
+            /** Format: date-time */
+            readonly created_at: string;
+            readonly created_by: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at: string | null;
+        };
+        LogsViewColumn: {
+            /** @description Client-generated stable identity for list operations (React keys, reorder). Never interpreted by the server. */
+            id: string;
+            /**
+             * @description Column type. Built-in types resolve client-side from log row fields; `custom` columns are computed server-side from `expression`.
+             *
+             *     * `timestamp` - timestamp
+             *     * `level` - level
+             *     * `source` - source
+             *     * `trace_id` - trace_id
+             *     * `span_id` - span_id
+             *     * `message` - message
+             *     * `custom` - custom
+             */
+            type: components["schemas"]["LogsViewColumnTypeEnum"];
+            /** @description Header label override. Defaults to the built-in type's label, or to the expression for custom columns. */
+            name?: string;
+            /** @description Only meaningful for `type: custom`: a source-prefixed shorthand (`attributes.<key>`, `resource_attributes.<key>`, `body.<json.path>`) or a scalar HogQL expression, sent verbatim in the logs query's `customColumns`. */
+            expression?: string;
+            /** @description Column width in pixels (1–2000). Omitted for the default width; ignored for the flex message column. */
+            width?: number;
+        };
+        /**
+         * @description * `timestamp` - timestamp
+         *     * `level` - level
+         *     * `source` - source
+         *     * `trace_id` - trace_id
+         *     * `span_id` - span_id
+         *     * `message` - message
+         *     * `custom` - custom
+         * @enum {string}
+         */
+        LogsViewColumnTypeEnum: "timestamp" | "level" | "source" | "trace_id" | "span_id" | "message" | "custom";
         /**
          * ManualMetricType
          * @enum {string}
@@ -10287,6 +10370,21 @@ export interface components {
             previous?: string | null;
             results: components["schemas"]["Insight"][];
         };
+        PaginatedLogsViewList: {
+            /** @example 123 */
+            count: number;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=400&limit=100
+             */
+            next?: string | null;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?offset=200&limit=100
+             */
+            previous?: string | null;
+            results: components["schemas"]["LogsView"][];
+        };
         PaginatedSchemaPropertyGroupList: {
             /** @example 123 */
             count: number;
@@ -10691,6 +10789,24 @@ export interface components {
             readonly last_viewed_at?: string | null;
             /** @description How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match, returned only when no exact match exists). Null when the list is not filtered by `search`. */
             readonly search_match_type?: components["schemas"]["SearchMatchTypeEnum"] | components["schemas"]["NullEnum"];
+        };
+        PatchedLogsView: {
+            /** Format: uuid */
+            readonly id?: string;
+            readonly short_id?: string;
+            name?: string;
+            /** @description Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys. */
+            filters?: {
+                [key: string]: unknown;
+            };
+            /** @description Ordered column configuration for the logs table (LogsColumnConfig[]). Order is array index. Null means the view has no column preference and the client renders its default column set. Omitting the field on update leaves the saved configuration unchanged; send null to clear it. */
+            columns?: components["schemas"]["LogsViewColumn"][] | null;
+            pinned?: boolean;
+            /** Format: date-time */
+            readonly created_at?: string;
+            readonly created_by?: components["schemas"]["UserBasic"];
+            /** Format: date-time */
+            readonly updated_at?: string | null;
         };
         /**
          * @description OpenAPI-only PATCH body for dashboards (agents/MCP).
@@ -20498,6 +20614,164 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["Insight"];
                     "text/csv": components["schemas"]["Insight"];
+                };
+            };
+        };
+    };
+    logs_views_list: {
+        parameters: {
+            query?: {
+                /** @description Number of results to return per page. */
+                limit?: number;
+                /** @description The initial index from which to return the results. */
+                offset?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedLogsViewList"];
+                };
+            };
+        };
+    };
+    logs_views_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LogsView"];
+                "application/x-www-form-urlencoded": components["schemas"]["LogsView"];
+                "multipart/form-data": components["schemas"]["LogsView"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogsView"];
+                };
+            };
+        };
+    };
+    logs_views_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+                short_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogsView"];
+                };
+            };
+        };
+    };
+    logs_views_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+                short_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LogsView"];
+                "application/x-www-form-urlencoded": components["schemas"]["LogsView"];
+                "multipart/form-data": components["schemas"]["LogsView"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogsView"];
+                };
+            };
+        };
+    };
+    logs_views_destroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+                short_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    logs_views_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/. */
+                project_id: components["parameters"]["ProjectIdPath"];
+                short_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedLogsView"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedLogsView"];
+                "multipart/form-data": components["schemas"]["PatchedLogsView"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogsView"];
                 };
             };
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,5 +75,8 @@ export type {
 export { projectSettings } from "./resources/project-settings/index.js";
 export type { ProjectSettings } from "./resources/project-settings/index.js";
 
+export { logsView } from "./resources/logs-view/index.js";
+export type { LogsView, LogsViewColumn, LogsViewColumnType } from "./resources/logs-view/index.js";
+
 export { createTypedPostHog } from "./client/typed-posthog.js";
 export type { TypedPostHog, CaptureCapableClient } from "./client/typed-posthog.js";

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -6,6 +6,7 @@ import { dashboardResource } from "./dashboard/index.js";
 import { endpointResource } from "./endpoint/index.js";
 import { featureFlagResource } from "./feature-flag/index.js";
 import { insightResource } from "./insight/index.js";
+import { logsViewResource } from "./logs-view/index.js";
 import { eventDefinitionResource } from "./event-definition/index.js";
 import { experimentResource } from "./experiment/index.js";
 import { experimentHoldoutResource } from "./experiment-holdout/index.js";
@@ -29,6 +30,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
   experimentSavedMetricResource as ResourceModule<unknown, unknown>,
   featureFlagResource as ResourceModule<unknown, unknown>,
   insightResource as ResourceModule<unknown, unknown>,
+  logsViewResource as ResourceModule<unknown, unknown>,
   projectSettingsResource as ResourceModule<unknown, unknown>,
   propertyGroupResource as ResourceModule<unknown, unknown>,
 ];
@@ -42,6 +44,7 @@ const REGISTRY: ReadonlyArray<ResourceModule<unknown, unknown>> = [
 export const RESOURCES: ReadonlyArray<ResourceModule<unknown, unknown>> = topoOrder(REGISTRY);
 
 export { insightResource } from "./insight/index.js";
+export { logsViewResource } from "./logs-view/index.js";
 export { dashboardResource } from "./dashboard/index.js";
 export { actionResource } from "./action/index.js";
 export { cohortResource } from "./cohort/index.js";

--- a/src/resources/logs-view/client.ts
+++ b/src/resources/logs-view/client.ts
@@ -1,0 +1,123 @@
+import { z } from "zod";
+import type { ClientConfig } from "../../client/config.js";
+import type { components } from "../../generated/api.js";
+import { createApiClient, followPagination, type Paginated } from "../../client/typed.js";
+
+const MANAGED_NAME_PREFIX = "<!-- iac:logs-views:";
+
+const ServerLogsViewColumnSchema = z
+  .object({
+    id: z.string(),
+    type: z.string(),
+    name: z.string().optional(),
+    expression: z.string().optional(),
+    width: z.number().optional(),
+  })
+  .loose();
+
+export const ServerLogsViewSchema = z
+  .object({
+    id: z.string(),
+    short_id: z.string(),
+    name: z.string().nullable().default(""),
+    filters: z.record(z.string(), z.unknown()).nullable().optional(),
+    columns: z.array(ServerLogsViewColumnSchema).nullable().optional(),
+    pinned: z.boolean().nullable().optional(),
+  })
+  .loose();
+
+export type ServerLogsView = z.infer<typeof ServerLogsViewSchema>;
+
+export type LogsViewCreate = {
+  name: string;
+  filters?: Record<string, unknown>;
+  columns?: components["schemas"]["LogsViewColumn"][] | null;
+  pinned?: boolean;
+};
+
+export type LogsViewUpdate = Partial<LogsViewCreate>;
+
+type LogsViewBody = components["schemas"]["LogsView"];
+type PatchedLogsViewBody = components["schemas"]["PatchedLogsView"];
+type GeneratedPaginatedList = components["schemas"]["PaginatedLogsViewList"];
+
+function paginatedFrom(raw: GeneratedPaginatedList): Paginated<unknown> {
+  return {
+    count: raw.count,
+    next: raw.next ?? null,
+    previous: raw.previous ?? null,
+    results: raw.results ?? [],
+  };
+}
+
+export async function listLogsViews(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerLogsView[]> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/logs/views/", {
+    params: { path: { project_id: config.projectId }, query: { limit: 100 } },
+  });
+  const firstPage = paginatedFrom(data!);
+  const allRaw = await followPagination<unknown>(config, firstPage, { verbose: options.verbose });
+  return allRaw.map((row) => ServerLogsViewSchema.parse(row));
+}
+
+export async function listManagedLogsViews(
+  config: ClientConfig,
+  options: { verbose?: boolean } = {},
+): Promise<ServerLogsView[]> {
+  const all = await listLogsViews(config, options);
+  return all.filter((row) => (row.name ?? "").includes(MANAGED_NAME_PREFIX));
+}
+
+export async function getLogsView(
+  config: ClientConfig,
+  shortId: string,
+  options: { verbose?: boolean } = {},
+): Promise<ServerLogsView> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.GET("/api/projects/{project_id}/logs/views/{short_id}/", {
+    params: { path: { project_id: config.projectId, short_id: shortId } },
+  });
+  return ServerLogsViewSchema.parse(data);
+}
+
+export async function createLogsView(
+  config: ClientConfig,
+  payload: LogsViewCreate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerLogsView> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.POST("/api/projects/{project_id}/logs/views/", {
+    params: { path: { project_id: config.projectId } },
+    body: payload as unknown as LogsViewBody,
+  });
+  return ServerLogsViewSchema.parse(data);
+}
+
+export async function updateLogsView(
+  config: ClientConfig,
+  shortId: string,
+  payload: LogsViewUpdate,
+  options: { verbose?: boolean } = {},
+): Promise<ServerLogsView> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  const { data } = await api.PATCH("/api/projects/{project_id}/logs/views/{short_id}/", {
+    params: { path: { project_id: config.projectId, short_id: shortId } },
+    body: payload as unknown as PatchedLogsViewBody,
+  });
+  return ServerLogsViewSchema.parse(data);
+}
+
+/** Delete a logs view. DELETE → 204 (real delete, verified live). */
+export async function deleteLogsView(
+  config: ClientConfig,
+  shortId: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const api = createApiClient(config, { verbose: options.verbose });
+  await api.DELETE("/api/projects/{project_id}/logs/views/{short_id}/", {
+    params: { path: { project_id: config.projectId, short_id: shortId } },
+  });
+}

--- a/src/resources/logs-view/codegen.ts
+++ b/src/resources/logs-view/codegen.ts
@@ -1,0 +1,69 @@
+import type { ClientConfig } from "../../client/config.js";
+import { renderObject, renderRawLiteral, stringLiteral } from "../../pull/render.js";
+import { slugify } from "../../pull/slug.js";
+import type { PullDependency, PullRenderContext, RenderedFile } from "../../pull/types.js";
+import { type ServerLogsView, updateLogsView } from "./client.js";
+import { stripMarker, withMarker } from "./pipeline.js";
+import type { LogsView } from "./sdk.js";
+
+export function pullFilter(_server: ServerLogsView): { kept: true } | { kept: false; reason: string } {
+  return { kept: true };
+}
+
+export function pullLabel(server: ServerLogsView): { primary: string; secondary?: string } {
+  const name = stripMarker(server.name) ?? "(unnamed)";
+  return { primary: name.slice(0, 48), secondary: `[${server.short_id}]` };
+}
+
+export function serverIdOf(server: ServerLogsView): string {
+  return server.short_id;
+}
+
+export async function pullDependencies(
+  _config: ClientConfig,
+  _server: ServerLogsView,
+): Promise<PullDependency[]> {
+  return [];
+}
+
+export function renderToFile(
+  server: ServerLogsView,
+  ctx: PullRenderContext,
+): RenderedFile | { skipped: true; reason: string } {
+  const name = stripMarker(server.name) ?? "";
+  const baseSlug = slugify(name) || `logs-view-${server.short_id}`;
+  const slug = ctx.uniqueSlug(baseSlug);
+
+  const fields: Record<string, string> = {
+    key: stringLiteral(slug),
+    name: stringLiteral(name),
+  };
+  if (server.filters && Object.keys(server.filters).length > 0) {
+    fields.filters = renderRawLiteral(server.filters, 4);
+  }
+  if (server.columns && server.columns.length > 0) {
+    fields.columns = renderRawLiteral(server.columns, 4);
+  }
+  if (server.pinned) fields.pinned = "true";
+
+  const parts: string[] = [
+    `import { logsView } from "@posthog/definitions";`,
+    "",
+    `export default logsView(${renderObject(fields, 2)});`,
+    "",
+  ];
+
+  return { filename: `${slug}.ts`, contents: parts.join("\n"), specKey: slug };
+}
+
+export async function tagOnServer(
+  config: ClientConfig,
+  server: ServerLogsView,
+  spec: LogsView,
+  hash: string,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  const userName = stripMarker(server.name) ?? "";
+  const newName = withMarker(userName, spec.key, hash);
+  await updateLogsView(config, server.short_id, { name: newName }, options);
+}

--- a/src/resources/logs-view/index.ts
+++ b/src/resources/logs-view/index.ts
@@ -1,0 +1,62 @@
+import type { ApplyContext, CollectionResourceModule } from "../types.js";
+import type { LogsView } from "./sdk.js";
+import {
+  LOGS_VIEW_IDENTITY_PREFIX,
+  displayLogsView,
+  displayLogsViewFromServer,
+  logsViewHash,
+  logsViewHashFromServer,
+  logsViewKeyFromServer,
+  looksLikeLogsView,
+  pruneLogsView,
+  runLogsViewOp,
+  validateLogsViews,
+} from "./pipeline.js";
+import {
+  getLogsView,
+  listLogsViews,
+  listManagedLogsViews,
+  type ServerLogsView,
+} from "./client.js";
+import {
+  pullDependencies,
+  pullFilter,
+  pullLabel,
+  renderToFile,
+  serverIdOf,
+  tagOnServer,
+} from "./codegen.js";
+
+export { logsView } from "./sdk.js";
+export type { LogsView, LogsViewColumn, LogsViewColumnType } from "./sdk.js";
+
+export const logsViewResource: CollectionResourceModule<LogsView, ServerLogsView> = {
+  kind: "collection",
+  name: "logs-views",
+  displayName: "logs view",
+  identityPrefix: LOGS_VIEW_IDENTITY_PREFIX,
+
+  isSpec: looksLikeLogsView,
+  specKey: (spec) => spec.key,
+
+  list: listManagedLogsViews,
+  keyFromServer: (server) => logsViewKeyFromServer(server),
+  hashFromServer: (server) => logsViewHashFromServer(server),
+
+  hash: logsViewHash,
+  validate: (specs, state) => validateLogsViews(specs, state),
+  executeOp: runLogsViewOp,
+  prune: pruneLogsView,
+
+  displaySpec: (spec, _ctx: ApplyContext) => displayLogsView(spec),
+  displayServer: (server, _ctx: ApplyContext) => displayLogsViewFromServer(server),
+
+  listAll: listLogsViews,
+  getById: (config, id, options) => getLogsView(config, String(id), options),
+  pullFilter,
+  pullLabel,
+  serverIdOf,
+  pullDependencies,
+  renderToFile,
+  tagOnServer,
+};

--- a/src/resources/logs-view/pipeline.test.ts
+++ b/src/resources/logs-view/pipeline.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { diff } from "../../apply/diff.js";
+import type { DesiredState } from "../types.js";
+import type { LogsView } from "./sdk.js";
+import type { ServerLogsView } from "./client.js";
+import { logsViewHash, validateLogsViews } from "./pipeline.js";
+
+function spec(key: string, overrides: Partial<LogsView> = {}): LogsView {
+  return {
+    key,
+    name: `Errors ${key}`,
+    filters: { severityLevels: ["error"] },
+    columns: [{ id: "c1", type: "timestamp" }],
+    ...overrides,
+  };
+}
+
+function serverRow(shortId: string, key: string, hash: string, userName = "Errors"): ServerLogsView {
+  const marker = `<!-- iac:logs-views:${key} iac:hash:${hash} -->`;
+  return {
+    id: `uuid-${shortId}`,
+    short_id: shortId,
+    name: `${userName}\n\n${marker}`,
+    filters: { severityLevels: ["error"] },
+    columns: [{ id: "c1", type: "timestamp" }],
+  };
+}
+
+function desiredFor(specs: LogsView[]): DesiredState {
+  const state: DesiredState = new Map();
+  state.set(
+    "logs-views",
+    specs.map((spec) => ({ path: "<test>", spec })),
+  );
+  return state;
+}
+
+function currentFor(rows: ServerLogsView[]): Map<string, unknown[]> {
+  return new Map<string, unknown[]>([["logs-views", rows]]);
+}
+
+describe("logs-view pipeline", () => {
+  it("emits create when desired has no matching server row", () => {
+    const slice = diff(desiredFor([spec("v1")]), currentFor([])).get("logs-views")!;
+    expect(slice.ops[0]!.kind).toBe("create");
+  });
+
+  it("emits unchanged when server hash matches", () => {
+    const desired = spec("v1");
+    const op = diff(
+      desiredFor([desired]),
+      currentFor([serverRow("AAA", "v1", logsViewHash(desired), "Errors v1")]),
+    ).get("logs-views")!.ops[0]!;
+    expect(op.kind).toBe("unchanged");
+  });
+
+  it("emits update when server hash differs", () => {
+    const op = diff(
+      desiredFor([spec("v1")]),
+      currentFor([serverRow("AAA", "v1", "stale00000000")]),
+    ).get("logs-views")!.ops[0]!;
+    expect(op.kind).toBe("update");
+  });
+
+  it("hash changes when filters, columns, name, or pinned change", () => {
+    const base = spec("v");
+    expect(logsViewHash(base)).not.toBe(logsViewHash(spec("v", { filters: { severityLevels: ["warn"] } })));
+    expect(logsViewHash(base)).not.toBe(logsViewHash(spec("v", { columns: [{ id: "c1", type: "message" }] })));
+    expect(logsViewHash(base)).not.toBe(logsViewHash(spec("v", { name: "Other" })));
+    expect(logsViewHash(base)).not.toBe(logsViewHash(spec("v", { pinned: true })));
+  });
+
+  it("hash is stable under column reordering being significant", () => {
+    const a = spec("v", { columns: [{ id: "c1", type: "timestamp" }, { id: "c2", type: "message" }] });
+    const b = spec("v", { columns: [{ id: "c2", type: "message" }, { id: "c1", type: "timestamp" }] });
+    // Column order is meaningful (array index = display order) → different hash.
+    expect(logsViewHash(a)).not.toBe(logsViewHash(b));
+  });
+
+  it("classifies a server-only managed view as an orphan", () => {
+    const slice = diff(desiredFor([]), currentFor([serverRow("ZZ", "ghost", "any")])).get(
+      "logs-views",
+    )!;
+    expect(slice.orphans.length).toBe(1);
+  });
+
+  it("safety invariant: ignores server rows without the identity marker", () => {
+    const handBuilt: ServerLogsView = {
+      id: "uuid-hand",
+      short_id: "HAND",
+      name: "A view someone saved in the UI",
+      filters: {},
+      columns: [],
+    };
+    const slice = diff(desiredFor([]), currentFor([handBuilt])).get("logs-views")!;
+    expect(slice.ops.length).toBe(0);
+    expect(slice.orphans.length).toBe(0);
+  });
+});
+
+describe("logs-view validation", () => {
+  const state: DesiredState = new Map();
+
+  it("requires a name (it carries the marker)", () => {
+    const issues = validateLogsViews([spec("v", { name: "" })], state);
+    expect(issues.some((m) => m.includes("name is required"))).toBeTruthy();
+  });
+
+  it("rejects a name that, with the marker, exceeds the 400-char cap", () => {
+    const issues = validateLogsViews([spec("v", { name: "A".repeat(400) })], state);
+    expect(issues.some((m) => m.includes("name is too long"))).toBeTruthy();
+  });
+
+  it("rejects a duplicate key", () => {
+    const issues = validateLogsViews([spec("dup"), spec("dup")], state);
+    expect(issues.some((m) => m.includes("Duplicate"))).toBeTruthy();
+  });
+
+  it("rejects a column missing id or type", () => {
+    const issues = validateLogsViews(
+      [spec("v", { columns: [{ id: "", type: "timestamp" }] })],
+      state,
+    );
+    expect(issues.some((m) => m.includes("stable `id`"))).toBeTruthy();
+  });
+
+  it("accepts a valid view", () => {
+    expect(validateLogsViews([spec("ok")], state)).toEqual([]);
+  });
+});

--- a/src/resources/logs-view/pipeline.ts
+++ b/src/resources/logs-view/pipeline.ts
@@ -1,0 +1,201 @@
+import type { ClientConfig } from "../../client/config.js";
+import { ApiError } from "../../client/typed.js";
+import { specHash } from "../../apply/hash.js";
+import { obj, scalar, displayJson, type DisplayValue } from "../../apply/display.js";
+import { SafetyViolationError } from "../../apply/errors.js";
+import { getResourceKind, type ApplyContext, type DesiredState, type ResourceOp } from "../types.js";
+import type { LogsView, LogsViewColumn } from "./sdk.js";
+import {
+  createLogsView,
+  deleteLogsView,
+  getLogsView,
+  type LogsViewCreate,
+  type ServerLogsView,
+  updateLogsView,
+} from "./client.js";
+
+export const LOGS_VIEW_IDENTITY_PREFIX = "iac:logs-views:";
+
+/** Server caps `name` at 400 chars; the name also carries the identity marker. */
+const NAME_MAX = 400;
+
+const MARKER_REGEX = /\n*<!--\s*iac:logs-views:(\S+)\s+iac:hash:(\S+)\s*-->\s*$/;
+const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+type ParsedMarker = { userName: string; key: string; hash: string };
+
+function parseMarker(name: string | null | undefined): ParsedMarker | undefined {
+  if (!name) return undefined;
+  const match = name.match(MARKER_REGEX);
+  if (!match || match.index === undefined) return undefined;
+  return {
+    userName: name.slice(0, match.index).replace(/\s+$/, ""),
+    key: match[1]!,
+    hash: match[2]!,
+  };
+}
+
+export function withMarker(userName: string, key: string, hash: string): string {
+  const trailer = `<!-- iac:logs-views:${key} iac:hash:${hash} -->`;
+  const trimmed = userName.replace(/\s+$/, "");
+  return trimmed ? `${trimmed}\n\n${trailer}` : trailer;
+}
+
+export function stripMarker(name: string | null | undefined): string | null {
+  if (!name) return null;
+  const parsed = parseMarker(name);
+  return parsed ? parsed.userName || null : name;
+}
+
+export function logsViewKeyFromServer(server: ServerLogsView): string | undefined {
+  return parseMarker(server.name)?.key;
+}
+
+export function logsViewHashFromServer(server: ServerLogsView): string | undefined {
+  return parseMarker(server.name)?.hash;
+}
+
+function columnsForHash(columns: LogsViewColumn[] | undefined): unknown {
+  if (!columns) return null;
+  // Order is significant (array index = column order); keep it. Normalise each
+  // entry to a stable key set so an omitted optional never flips the hash.
+  return columns.map((c) => ({
+    id: c.id,
+    type: c.type,
+    name: c.name ?? null,
+    expression: c.expression ?? null,
+    width: c.width ?? null,
+  }));
+}
+
+function specForHash(spec: LogsView): unknown {
+  return {
+    key: spec.key,
+    name: spec.name,
+    filters: spec.filters ?? null,
+    columns: columnsForHash(spec.columns),
+    pinned: spec.pinned ?? false,
+  };
+}
+
+export function logsViewHash(spec: LogsView): string {
+  return specHash(specForHash(spec));
+}
+
+function buildPayload(spec: LogsView, hash: string): LogsViewCreate {
+  const payload: LogsViewCreate = {
+    name: withMarker(spec.name, spec.key, hash),
+  };
+  if (spec.filters !== undefined) payload.filters = spec.filters;
+  if (spec.columns !== undefined) payload.columns = spec.columns;
+  if (spec.pinned !== undefined) payload.pinned = spec.pinned;
+  return payload;
+}
+
+export function looksLikeLogsView(value: unknown): value is LogsView {
+  return getResourceKind(value) === "logs-view";
+}
+
+export function validateLogsViews(specs: LogsView[], _state: DesiredState): string[] {
+  const issues: string[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const spec of specs) {
+    if (!spec.key) {
+      issues.push("logsView.key is required");
+      continue;
+    }
+    if (!KEY_PATTERN.test(spec.key)) {
+      issues.push(`logsView "${spec.key}" key must match ${KEY_PATTERN.source}`);
+    }
+    if (seenKeys.has(spec.key)) issues.push(`Duplicate logsView key "${spec.key}"`);
+    seenKeys.add(spec.key);
+
+    if (!spec.name || spec.name.trim() === "") {
+      issues.push(`logsView "${spec.key}" name is required (it carries the identity marker)`);
+    } else {
+      const withMarkerLen = withMarker(spec.name, spec.key, logsViewHash(spec)).length;
+      if (withMarkerLen > NAME_MAX) {
+        issues.push(
+          `logsView "${spec.key}" name is too long: name + identity marker is ${withMarkerLen} chars but the server caps \`name\` at ${NAME_MAX}. Shorten the name (or key).`,
+        );
+      }
+    }
+
+    for (const [i, col] of (spec.columns ?? []).entries()) {
+      if (!col.id) issues.push(`logsView "${spec.key}" column[${i}] requires a stable \`id\``);
+      if (!col.type) issues.push(`logsView "${spec.key}" column[${i}] requires a \`type\``);
+    }
+  }
+  return issues;
+}
+
+async function assertManaged(
+  config: ClientConfig,
+  shortId: string,
+  key: string,
+  options: { verbose?: boolean },
+): Promise<void> {
+  const current = await getLogsView(config, shortId, options);
+  if (logsViewKeyFromServer(current) !== key) {
+    throw new SafetyViolationError("logs-view", shortId, key);
+  }
+}
+
+export async function runLogsViewOp(
+  config: ClientConfig,
+  op: ResourceOp<LogsView, ServerLogsView>,
+  _ctx: ApplyContext,
+  options: { verbose?: boolean } = {},
+): Promise<void> {
+  if (op.kind === "unchanged") return;
+
+  const payload = buildPayload(op.spec, logsViewHash(op.spec));
+
+  if (op.kind === "create") {
+    await createLogsView(config, payload, options);
+    return;
+  }
+
+  await assertManaged(config, op.server.short_id, op.spec.key, options);
+  await updateLogsView(config, op.server.short_id, payload, options);
+}
+
+export async function pruneLogsView(
+  config: ClientConfig,
+  orphan: ServerLogsView,
+  options: { verbose?: boolean } = {},
+): Promise<boolean> {
+  const key = logsViewKeyFromServer(orphan) ?? `id:${orphan.short_id}`;
+  try {
+    await assertManaged(config, orphan.short_id, key, options);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return false;
+    throw err;
+  }
+  await deleteLogsView(config, orphan.short_id, options);
+  return true;
+}
+
+export function displayLogsView(spec: LogsView): DisplayValue {
+  return obj([
+    ["key", scalar(spec.key)],
+    ["name", scalar(spec.name)],
+    ["filters", displayJson(spec.filters ?? null)],
+    ["columns", displayJson(columnsForHash(spec.columns))],
+    ["pinned", scalar(spec.pinned ?? false)],
+  ]);
+}
+
+export function displayLogsViewFromServer(server: ServerLogsView): DisplayValue {
+  const columns = server.columns
+    ? (server.columns as LogsViewColumn[])
+    : undefined;
+  return obj([
+    ["key", scalar(logsViewKeyFromServer(server) ?? null)],
+    ["name", scalar(stripMarker(server.name))],
+    ["filters", displayJson(server.filters ?? null)],
+    ["columns", displayJson(columnsForHash(columns))],
+    ["pinned", scalar(server.pinned ?? false)],
+  ]);
+}

--- a/src/resources/logs-view/sdk.ts
+++ b/src/resources/logs-view/sdk.ts
@@ -1,0 +1,51 @@
+import { markResourceKind } from "../types.js";
+
+export type LogsViewColumnType =
+  | "timestamp"
+  | "level"
+  | "source"
+  | "trace_id"
+  | "span_id"
+  | "message"
+  | "custom";
+
+/**
+ * One column in a logs-table view. `id` is a client-generated stable handle
+ * (React key / reorder anchor) the server never interprets — pick any stable
+ * string. `expression` is only meaningful for `type: "custom"`.
+ */
+export type LogsViewColumn = {
+  id: string;
+  type: LogsViewColumnType;
+  /** Header label override. Defaults to the built-in type's label. */
+  name?: string;
+  /** Source-prefixed shorthand or HogQL expression; only for `type: "custom"`. */
+  expression?: string;
+  /** Column width in pixels (1–2000). */
+  width?: number;
+};
+
+export type LogsView = {
+  key: string;
+  /**
+   * Human-readable view name shown in the saved-views picker. Also carries the
+   * identity marker (a trailing HTML comment), the way subscriptions carry
+   * identity in their `title`. The server caps `name` at 400 chars including
+   * the marker — a validation guard fails fast if the budget is exceeded.
+   */
+  name: string;
+  /**
+   * Filter criteria — a passthrough subset of the logs viewer's filters. May
+   * contain `severityLevels`, `serviceNames`, `searchTerm`, `filterGroup`,
+   * `dateRange`, and other keys. Sent verbatim; not interpreted here.
+   */
+  filters?: Record<string, unknown>;
+  /** Ordered column configuration for the logs table. Order is array index. */
+  columns?: LogsViewColumn[];
+  /** Whether the view is pinned in the picker. */
+  pinned?: boolean;
+};
+
+export function logsView(spec: LogsView): LogsView {
+  return markResourceKind(spec, "logs-view");
+}

--- a/src/resources/order.test.ts
+++ b/src/resources/order.test.ts
@@ -15,6 +15,7 @@ import { experimentHoldoutResource } from "./experiment-holdout/index.js";
 import { experimentSavedMetricResource } from "./experiment-saved-metric/index.js";
 import { featureFlagResource } from "./feature-flag/index.js";
 import { insightResource } from "./insight/index.js";
+import { logsViewResource } from "./logs-view/index.js";
 import { projectSettingsResource } from "./project-settings/index.js";
 import { propertyGroupResource } from "./property-group/index.js";
 
@@ -183,6 +184,7 @@ describe("RESOURCES (real registry)", () => {
         experimentSavedMetricResource,
         featureFlagResource,
         insightResource,
+        logsViewResource,
         projectSettingsResource,
         propertyGroupResource,
       ].map((r) => r.name),


### PR DESCRIPTION
Adds **logs views** (`projects/{id}/logs/views`) as a managed resource.

## Design
- **Identity carrier:** trailing HTML-comment marker in `name` (the subscriptions pattern) — the API exposes no `tags`/`description`, and `name` is the only free-text field (maxLength 400, generous budget). A validation guard fails fast if `name` + marker exceeds 400.
- **Addressing:** server-assigned `short_id` (like session-recording playlists).
- **Round-trip (live-verified on 806):** `filters`/`columns`/`pinned` round-trip as passthrough; `description`/`name`/`tags` extras are silently dropped by the create serializer. Real `PATCH` update (HTTP 200) and real `DELETE` (204).
- **Order:** columns carry array-index order; hashed positionally.

## Verification (dev project 806)
create → no-op re-apply (clean) → edit → single update → no-op after edit → orphan left untouched → hand-built row (no marker) invisible to plan/orphans (safety invariant) → scoped prune via direct `pruneLogsView` call. All rows cleaned up. Gates: `typecheck`, `typecheck:examples`, `test` (303), `lint` all pass. Logs-views smoke seed verified in isolation (seed→apply→pull `--all-rows`→tag-back→dry-run no-op→cleanup).

## Stacking
Stacks on #81 (`pl/spec-migration`) — the codegen-only base branch. **Retarget to `master` when #81 merges.** First commit is the codegen regen (skippable in review). The `docs/resources.md` Logs rows are provisional ahead of the full matrix refresh (#78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)