### PR TITLE
ci: harden release workflow against script injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ permissions:
 
 jobs:
   publish:
+    # Never publish from a fork
+    if: github.repository == 'PostHog/posthog-definitions'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -34,9 +36,11 @@ jobs:
 
       - name: Resolve dist-tag
         id: tag
+        env:
+          DIST_TAG: ${{ inputs.dist-tag }}
         run: |
-          if [ -n "${{ inputs.dist-tag }}" ]; then
-            echo "tag=${{ inputs.dist-tag }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$DIST_TAG" ]; then
+            echo "tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_REF_NAME}" == *-alpha* ]]; then
             echo "tag=alpha" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_REF_NAME}" == *-beta* ]]; then
@@ -47,4 +51,6 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      - run: npx -y npm@11 publish --provenance --access public --tag ${{ steps.tag.outputs.tag }}
+      - env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: npx -y npm@11 publish --provenance --access public --tag "$TAG"


### PR DESCRIPTION
Addresses the Wiz finding "Workflow job 'publish' should not use workflow_dispatch input 'inputs.dist-tag' directly in run commands."

## Changes

- **Pass `inputs.dist-tag` through `env` instead of interpolating it into the `run` script.** `${{ }}` expressions are expanded before the shell runs, so a crafted input could inject arbitrary commands into a job holding npm publish credentials and `id-token: write`. Reading it from an environment variable makes the shell treat it as data, not code.
- **Same treatment for `steps.tag.outputs.tag`** in the `npm publish` step, since it is derived from the input.
- **Guard the `publish` job with `if: github.repository == 'PostHog/posthog-definitions'`** so it never runs from a fork. The Wiz-suggested `github.event.pull_request.base.repo.full_name` check is not applicable verbatim here — this workflow has no pull-request trigger, so that field is always empty and the condition would prevent the job from ever running; `github.repository` enforces the same intent for `push`/`workflow_dispatch` events.

No behavior change for legitimate releases: tag-push resolution (`alpha`/`beta`/`rc`/`latest`) and manual dispatch work exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj1CSPjsnDMzLgJh4m4JM4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dj1CSPjsnDMzLgJh4m4JM4)_